### PR TITLE
Fix for basic auth vs. url-escaped passwords.

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,10 +89,10 @@ function request (options, callback) {
   options.client.addListener('error', clientErrorHandler);
 
   if (options.uri.auth && !options.headers.authorization) {
-    options.headers.authorization = "Basic " + toBase64(options.uri.auth);
+    options.headers.authorization = "Basic " + toBase64(options.uri.auth.split(':').map(qs.unescape).join(':'));
   }
   if (options.proxy && options.proxy.auth && !options.headers['proxy-authorization']) {
-    options.headers['proxy-authorization'] = "Basic " + toBase64(options.proxy.auth);
+    options.headers['proxy-authorization'] = "Basic " + toBase64(options.proxy.auth.split(':').map(qs.unescape).join(':'));
   }
 
   options.fullpath = options.uri.href.replace(options.uri.protocol + '//' + options.uri.host, '');


### PR DESCRIPTION
Failure case is something like user:p@ssword: node's url.parse expects this to be escaped in the URL string – user:p%40ssword – but they must be unescaped before base64 encoding for basic auth.

testing @mikeal
