### PR TITLE
Untitled

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@
 var http = require('http')
   , url = require('url')
   , sys = require('sys')
+  , qs = require('querystring')
   ;
 
 var toBase64 = function(str) {


### PR DESCRIPTION
Failure case is for something like user:p@ssword: node's url.parse expects the credentials to be escaped in the URL string – user:p%40ssword – but they must be unescaped before base64 encoding for basic auth.

(PS: sorry about the muffed request just now)
