### PR TITLE
Issue with maxSockets and https

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ var Request = function (options) {
 util.inherits(Request, stream.Stream);
 Request.prototype.getAgent = function (host, port) {
   if (!this.pool[host+':'+port]) {
-    this.pool[host+':'+port] = new this.httpModule.Agent({host:host, port:port});
+    this.pool[host+':'+port] = new this.httpModule.getAgent({host:host, port:port});
   }
   return this.pool[host+':'+port];
 }


### PR DESCRIPTION
```
this.pool[host+':'+port] = new this.httpModule.Agent({host:host, port:port
                           ^
```

TypeError: undefined is not a function
    at CALL_NON_FUNCTION_AS_CONSTRUCTOR (native)

http exports Agent and getAgent, but https only exports getAgent, updated to call getAgent
