### PR TITLE
fix request.defaults and 'close' event in response

### DIFF
--- a/main.js
+++ b/main.js
@@ -230,7 +230,8 @@ Request.prototype.request = function () {
       options._redirectsFollowed = 0;
       // Be a good stream and emit end when the response is finished.
       // Hack to emit end on close becuase of a core bug that never fires end
-      response.on('close', function () {options.emit('end')})
+      response.on('close', function () { options.emit('end');
+                                         response.emit('end')})
       
       if (options.encoding) {
         if (options.dests.length !== 0) {


### PR DESCRIPTION
1. in `request.defaults` a typo and a misplaced return statement
2. in `request.defaults`, override the options with default only if it is not set (`===undefined`)
3. when receiving a `close` event on the response object, propagate also to the response as an `end` event.

Point 3. covers a case where the server hangs up on us in the middle of a response. Not sure it should be treated like an `end` event though. An specific error could make more sense.
