### PR TITLE
Error on piping a request to a destination

### DIFF
--- a/main.js
+++ b/main.js
@@ -301,12 +301,12 @@ Request.prototype.end = function () {
   this.req.end.apply(this.req, arguments);
 }
 Request.prototype.pause = function () {
-  if (!this.req) throw new Error("This request has been piped before http.request() was called.");
-  this.req.pause.apply(this.req, arguments);
+  if (!this.response) throw new Error("This request has been piped before http.request() was called.");
+  this.response.pause.apply(this.response, arguments);
 }
 Request.prototype.resume = function () {
-  if (!this.req) throw new Error("This request has been piped before http.request() was called.");
-  this.req.resume.apply(this.req, arguments);
+  if (!this.response) throw new Error("This request has been piped before http.request() was called.");
+  this.response.resume.apply(this.response, arguments);
 }
 
 function request (options, callback) {


### PR DESCRIPTION
i was getting a weird error using the master branch of request and sending it to a file:

```
TypeError: Cannot call method 'apply' of undefined
    at [object Object].resume (/Users/topper/Sites/snap/javascript-openstack-object/lib/request.js:310:19)
    at [object Object].ondrain (stream.js:43:33)
    at [object Object].emit (events.js:61:17)
    at [object Object].flush (fs.js:1010:32)
    at fs.js:1051:10
    at wrapper (fs.js:295:17)
```

I changed pause and resume to operate on response instead of request. However, I'm not sure if there will be any consequences to the change.
