### PR TITLE
The "end" event isn't emitted for some responses

### DIFF
--- a/main.js
+++ b/main.js
@@ -236,8 +236,8 @@ Request.prototype.request = function () {
       } else {
         options._redirectsFollowed = 0;
         // Be a good stream and emit end when the response is finished.
-        // Hack to emit end on close becuase of a core bug that never fires end
-        response.on('close', function () {options.emit('end')})
+        // Hack to emit end on close because of a core bug that never fires end
+        response.on('close', function () {options.response.emit('end')})
 
         if (options.encoding) {
           if (options.dests.length !== 0) {


### PR DESCRIPTION
The "end" event that was supposed to be emitted to fix a core bug in NodeJS wasn't fired because it wasn't emitted on the response object.

I encountered this problem when trying to fetch https://profiles.google.com/VoxPelli through JSDom. I tracked it down to being that the response object in this file only emitted "data"-events and no "end"-events. The change here fixed that.

(I hope the bonus spelling correction of "because" is okay as well :) )
