### PR TITLE
Certain servers requires a content-length for DELETE and PUT requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -188,8 +188,8 @@ Request.prototype.request = function () {
     }
   }
   
-  // Nginx for instance, doesn't like DELETE or PUT without a content-length
-  if((options.method === 'DELETE' || options.method === 'PUT') && typeof(options.headers['content-length']) === 'undefined') {
+  // Certain servers will 411 if requset lacks a content-length regardless if they include a body or not
+  if(~['DELETE', 'PUT', 'POST'].indexOf(options.method) && typeof(options.headers['content-length']) === 'undefined') {
     options.headers['content-length'] = 0;
   }
   


### PR DESCRIPTION
Hello,

I'm attaching some commits that helps me use this library with nginx which won't accept DELETE or PUT's without explicitly defining a Content-Length header in the request. Particularly an issue with DELETE which usually does not contain a body.

See also https://github.com/cloudhead/cradle/pull/62 which was for a similar issue in an unrelated library.
