### PR TITLE
Wondering why redirects are disabled for POST requests?

### DIFF
--- a/main.js
+++ b/main.js
@@ -226,7 +226,6 @@ Request.prototype.request = function () {
           response.statusCode < 400  && 
           options.followRedirect     && 
           options.method !== 'PUT' && 
-          options.method !== 'POST' &&
           response.headers.location) {
         if (options._redirectsFollowed >= options.maxRedirects) {
           options.emit('error', new Error("Exceeded maxRedirects. Probably stuck in a redirect loop."))

--- a/tests/fixtures/page1.json
+++ b/tests/fixtures/page1.json
@@ -1,0 +1,7 @@
+{
+  "headers": {
+    "location": "http://localhost:6767/page2"
+  },
+
+  "body" : "<p>Document has been moved.</p>"
+}

--- a/tests/fixtures/page2.json
+++ b/tests/fixtures/page2.json
@@ -1,0 +1,4 @@
+{
+  "headers": {},
+  "body": "Page 2!"
+}

--- a/tests/redirect-server.js
+++ b/tests/redirect-server.js
@@ -1,0 +1,35 @@
+var http = require('http')
+  , fs   = require('fs')
+  , path = require('path')
+  , url  = require('url')
+
+exports.createServer = function(port) {
+  port = port || 6767;
+
+  server = http.createServer(function(req, resp) {
+    parsedUrl = url.parse(req.url, true)
+    redirectTo(req, resp, parsedUrl)
+  });
+
+  server.listen(port);
+  server.url = "http://localhost:" + port;
+  return server;
+}
+
+
+var redirectTo = function(req, resp, parsedUrl) {
+  location = parsedUrl.pathname;
+
+  documentJSON = fs.readFileSync( path.resolve( "fixtures/" + location + ".json" ) );
+  document = JSON.parse(documentJSON);
+
+  if (document.headers.hasOwnProperty('location')) {
+    resp.writeHead(302, document.headers);
+    resp.write(document.body);
+    resp.end()
+  } else {
+    resp.writeHead(200, document.headers);
+    resp.write(document.body);
+    resp.end()
+  }
+}

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -1,0 +1,40 @@
+var server  = require('./redirect-server')
+  , assert  = require('assert')
+  , request = require('../main.js')
+
+
+var s = server.createServer();
+var tests = [function() {
+  // test to make sure page 1 redirects to page 2 when getting a GET request
+  var url = s.url + '/' + 'page1';
+
+  request({ url: url }, function(err, resp, body) {
+    assert.ok(body.match(/Page 2!/));
+    
+    finishTest();
+  });
+}, function() {
+// test to make sure page 1 redirects to page 2 when getting a POST request
+  var url = s.url + '/' + 'page1';
+
+  request({ url: url, method: 'POST'}, function(err, resp, body) {
+    assert.ok(body.match(/Page 2!/));
+
+    finishTest();
+  });
+}];
+
+var totalTests = tests.length;
+
+tests.forEach(function(test) {
+  test();
+});
+
+function finishTest() {
+  totalTests--;
+
+  if (totalTests == 0) {
+    console.log("All tests passed");
+    s.close();
+  }
+}


### PR DESCRIPTION
I created a test showing a stubbed out scenario where I am having problems using Request. The http server responds with a 302 from a POST..

Changes:
- Created a redirect server which allows the testing of simple redirects.
- Created a couple fixtures to make sure that GET and POST get treated the
  same for redirects. All other tests still pass.
