### PR TITLE
use Buffer for the body

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The first argument can be either a url or an options object. The only required o
 * `followRedirect` - follow HTTP 3xx responses as redirects. defaults to true.
 * `maxRedirects` - the maximum number of redirects to follow, defaults to 10.
 * `onResponse` - If true the callback will be fired on the "response" event instead of "end". If a function it will be called on "response" and not effect the regular semantics of the main callback on "end".
-* `encoding` - Encoding to be used on response.setEncoding when buffering the response data.
+* `encoding` - Encoding to be used on response.setEncoding when buffering the response data. If set to `null` then the callback `body` will be a `Buffer`.
 * `pool` - A hash object containing the agents for these requests. If omitted this request will use the global pool which is set to node's default maxSockets.
 * `pool.maxSockets` - Integer containing the maximum amount of sockets in the pool.
 * `timeout` - Integer containing the number of milliseconds to wait for a request to respond before aborting the request	


### PR DESCRIPTION
Here's my patch for gh-57, I used the \* 2 buffer size technique in the end as it was simpler, it's a good heuristic.

I made it so that the `body` in the callback is only set to be a `Buffer` if `encoding: null` is set, otherwise a `string` is returned so not to break existing code.
