### PR TITLE
Should content-type default to 'application/x-www-form-urlencoded' for POST requests?

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,7 +152,6 @@ Request.prototype.request = function () {
   }
   if (options.onResponse) options.on('error', function (e) {options.onResponse(e)}) 
   if (options.callback) options.on('error', function (e) {options.callback(e)})
-  
 
   if (options.uri.auth && !options.headers.authorization) {
     options.headers.authorization = "Basic " + toBase64(options.uri.auth.split(':').map(function(item){ return qs.unescape(item)}).join(':'))
@@ -165,7 +164,11 @@ Request.prototype.request = function () {
   if (options.path.length === 0) options.path = '/'
 
   if (options.proxy) options.path = (options.uri.protocol + '//' + options.uri.host + options.path)
-
+  
+  if ( options.method.toUpperCase() == 'POST' && !options.headers['content-type']) {
+    options.headers['content-type'] = 'application/x-www-form-urlencoded'
+  }
+  
   if (options.json) {
     options.headers['content-type'] = 'application/json'
     if (typeof options.json === 'boolean') {


### PR DESCRIPTION
Here's the backstory: I was trying to use request to make a POST request to a server running express. I kept on getting 500s, but it would work when I used curl. After four hours of trying to figure out wtf is wrong, I find out the server is using express.bodyParser and assuming req.body would exist, however the bodyParser middleware only populates body on POST and only if the application/x-www-form-urlencoded content-type is set (which curl sets automatically when you POST). 

So, this patch sets the content-type to be application/x-www-form-urlencoded if the user hasn't already set one. It's not perfect, because it detects if it's set only by the one particular capitalization scheme, but it is consist with the rest of the code in that way.
