### PR TITLE
Do not overwrite established content-type headers for read stream deliver

### DIFF
--- a/main.js
+++ b/main.js
@@ -327,7 +327,8 @@ Request.prototype.request = function () {
     if (options.ntick) throw new Error("You cannot pipe to this stream after the first nextTick() after creation of the request stream.")
     options.src = src
     if (isReadStream(src)) {
-      options.headers['content-type'] = mimetypes.lookup(src.path.slice(src.path.lastIndexOf('.')+1))
+      if (!options.headers['content-type'] && !options.headers['Content-Type'])
+        options.headers['content-type'] = mimetypes.lookup(src.path.slice(src.path.lastIndexOf('.')+1))
     } else {
       if (src.headers) {
         for (i in src.headers) {


### PR DESCRIPTION
Do not overwrite established content-type headers for read stream deliveries. Affects any and all upper libraries (e.g. cloudfiles)
