### PR TITLE
Automatic parsing of the url optional. 

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,6 +74,10 @@ function Request (options) {
     options = {uri:options}
   }
   
+  if (typeof options.parseUrl === 'undefined') {
+    options.parseUrl = true;
+  }
+  
   for (var i in options) {
     this[i] = options[i]
   }
@@ -98,7 +102,7 @@ Request.prototype.request = function () {
 
   if (!options.uri) {
     throw new Error("options.uri is a required argument")
-  } else {
+  } else if (options.parseUrl){
     if (typeof options.uri == "string") options.uri = url.parse(options.uri)
   }
   if (options.proxy) {


### PR DESCRIPTION
Use case:

This works
http://where.yahooapis.com/v1/places$and(.q('barc%2A'),.type(7));count=6?format=json&appid=

This doesn't
http://where.yahooapis.com/v1/places$and(.q(%27barc%2A%27),.type(7));count=6?format=json&appid=
