### PR TITLE
add test script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,4 +11,5 @@
   { "web" : "http://github.com/mikeal/request/issues" }
 , "engines" : ["node >= 0.3.6"]
 , "main" : "./main"
+, "scripts": { "test": "bash tests/run.sh" }
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,6 @@
+FAILS=0
+for i in tests/test-*.js; do
+  echo $i
+  node $i || let FAILS++
+done
+exit $FAILS


### PR DESCRIPTION
It's very hard to retrain my fingers to _not_ type `npm test` to run all the tests.  Plus, this is good for CI hooks and such.

Also: looks like the timeout test is failing on node 0.4.11.
