### PR TITLE
fixes non buffers in data event issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -310,6 +310,7 @@ Request.prototype.request = function () {
           var buffer = []
           var bodyLen = 0
           options.on("data", function (chunk) { 
+            chunk = Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk)
             buffer.push(chunk)
             bodyLen += chunk.length
           })

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -25,6 +25,11 @@ var tests =
       ])
     , expectBody: "Ω☃"
     }
+  , testChunkNotABuffer :
+    { resp : server.createChunkResponse(['BM:\u0000\u0000\u0000'])
+    , encoding : 'binary'
+    , expectBody : 'BM:\u0000\u0000\u0000'
+    }
   , testGetJSON : 
     { resp : server.createGetResponse('{"test":true}', 'application/json')
     , json : true


### PR DESCRIPTION
[main,test-body] fixes non buffers in data event issue when setting encoding manually
- added unit test to test/test-body.js
- fixed bug by checking if chunk is buffer in main.js
- fixes #74
