### PR TITLE
Bug when a request fails and a timeout is set

### DIFF
--- a/main.js
+++ b/main.js
@@ -148,6 +148,7 @@ Request.prototype.request = function () {
 
   var clientErrorHandler = function (error) {
     if (setHost) delete self.headers.host
+    if (self.timeout && self.timeoutTimer) clearTimeout(self.timeoutTimer)
     self.emit('error', error)
   }
   if (self.onResponse) self.on('error', function (e) {self.onResponse(e)})


### PR DESCRIPTION
Hello,

When using a timeout and getting an error on the request, 2 errors are emitted because the timeout is never cleared, this commit fixes it.

Regards
