### PR TITLE
Read path for cookies

### DIFF
--- a/vendor/cookie/index.js
+++ b/vendor/cookie/index.js
@@ -40,9 +40,8 @@ var Cookie = exports = module.exports = function Cookie(str, req) {
     : Infinity;
 
   // Default or trim path
-  this.path = this.Path
-    ? this.Path.trim()
-    : url.parse(req.url).pathname;
+  var pathName = Object.keys(this).filter(function (k) { return !!k.match(/path/i); })[0];
+  this.path = (pathName) ? this[pathName] : "/";
 };
 
 /**


### PR DESCRIPTION
Changed path to Path (http://en.wikipedia.org/wiki/HTTP_cookie) in vendor/cookie/index.js:43-44
This patch fixes bug: TypeError: Cannot read property 'url' of undefined

Code to reproduce error:

``` javascript
request('https://bramka.play.pl/composer/public/mmsCompose.do', function (error, response, body) {
    if (!error && response.statusCode == 200) {
        console.log(body);
    }
});
```
