### PR TITLE
Avoid buffer.toString() utf-8 encoding problems...

### DIFF
--- a/main.js
+++ b/main.js
@@ -425,7 +425,7 @@ Request.prototype.request = function () {
                 chunk.copy(body, i, 0, chunk.length)
                 i += chunk.length
               })
-              response.body = body.toString()
+              response.body = body;
             } else if (buffer.length) {
               response.body = buffer.join('')
             }


### PR DESCRIPTION
If the request get a buffer, it should send a buffer.
Converting a buffer into a string could generate the following problem:
you cannot regain the buffer from its string representation

b = new Buffer(...), s = b.toString(), b != new Buffer(s)

for example:

&gt; var buffer = new Buffer(1);
&gt; buffer[0] = 0x89;
 137
&gt; buffer
 &lt;Buffer 89&gt;
&gt; var string = buffer.toString();
&gt; string
 '�'
&gt; new Buffer('�') // problem!
&lt;Buffer ef bf bd&gt;
