### PR TITLE
Make redirects with status code 303 change the method to 'GET'

### DIFF
--- a/main.js
+++ b/main.js
@@ -373,6 +373,10 @@ Request.prototype.request = function () {
         self.uri = response.headers.location
         self.redirects.push( { statusCode : response.statusCode,
                                redirectUri: response.headers.location })
+        //following RFC 2616 
+        if (response.statusCode===303) {
+          self.method='GET';
+        }
         delete self.req
         delete self.agent
         delete self._started


### PR DESCRIPTION
This behavior is as described by RFC 2616. This change is in addition to issue #55 and issue #90 (pull request)
