### PR TITLE
host vs hostname

### DIFF
--- a/main.js
+++ b/main.js
@@ -167,10 +167,10 @@ Request.prototype.request = function () {
 
   if (self.proxy) {
     self.port = self.proxy.port
-    self.host = self.proxy.hostname
+    self.hostname = self.proxy.hostname
   } else {
     self.port = self.uri.port
-    self.host = self.uri.hostname
+    self.hostname = self.uri.hostname
   }
 
   if (self.onResponse === true) {
@@ -313,12 +313,12 @@ Request.prototype.request = function () {
   } else {
     if (self.maxSockets) {
       // Don't use our pooling if node has the refactored client
-      self.agent = self.httpModule.globalAgent || self.getAgent(self.host, self.port)
+      self.agent = self.httpModule.globalAgent || self.getAgent(self.hostname, self.port)
       self.agent.maxSockets = self.maxSockets
     }
     if (self.pool.maxSockets) {
       // Don't use our pooling if node has the refactored client
-      self.agent = self.httpModule.globalAgent || self.getAgent(self.host, self.port)
+      self.agent = self.httpModule.globalAgent || self.getAgent(self.hostname, self.port)
       self.agent.maxSockets = self.pool.maxSockets
     }
   }


### PR DESCRIPTION
When constructing the options hash to pass to `http.request`:

```
self.host = self.uri.hostname
```

Is there a reason to name it `host` instead of `hostname`?

I ran into problems using request with [nock](https://github.com/pgte/nock), which expects the `host` value to include the port number, like `url.parse`' would do.
