### PR TITLE
Fix for Issue #127

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,6 +77,7 @@ var globalPool = {}
 
 function Request (options) {
   stream.Stream.call(this)
+  this.method = 'GET'
   this.readable = true
   this.writable = true
 


### PR DESCRIPTION
Updated fix for issue #127.

In Request constructor, set Request.method parameter to 'GET' by default to prevent issue of it being used before being set.
