### PR TITLE
Fix issue #159

### DIFF
--- a/main.js
+++ b/main.js
@@ -361,7 +361,10 @@ Request.prototype.request = function () {
       }
 
       if (setHost) delete self.headers.host
-      if (self.timeout && self.timeoutTimer) clearTimeout(self.timeoutTimer)
+      if (self.timeout && self.timeoutTimer) {
+          clearTimeout(self.timeoutTimer);
+          self.timeoutTimer = null;
+      }  
       
       if (response.headers['set-cookie'] && (!self._disableCookies)) {
         response.headers['set-cookie'].forEach(function(cookie) {


### PR DESCRIPTION
1) Request freezes when remote server send headers and stops.
2) Timeout not sets after redirecting request.
https://github.com/mikeal/request/blob/master/main.js#L361 - on this line self.timeoutTimer stay assigned after redirect
https://github.com/mikeal/request/blob/master/main.js#L487 - this line failed after redirect because self.timeoutTimer has value

Please tell me if you have additional requirements for accept this patch. Docs update, additional test, etc.

Regards,
Dmitry
