### PR TITLE
can't create a cookie in a wrapped request (defaults)

### DIFF
--- a/main.js
+++ b/main.js
@@ -681,6 +681,7 @@ request.jar = function () {
   return new CookieJar
 }
 request.cookie = function (str) {
+  if (str && str.uri) str = str.uri
   if (typeof str !== 'string') throw new Error("The cookie function only accepts STRING as param")
   return new Cookie(str)
 }


### PR DESCRIPTION
when the request object is a wrapped defaults, creating a cookie throws a expection

``` javascript
var cookie = request.cookie( 'your_cookie_here' )
Error: The cookie function only accepts STRING as param
```

the 'cookie' method only accepts a string, but the wrapped request transforms any params in { uri:opts }

``` javascript
if (typeof opts === 'string') opts = {uri:opts}
```
