### PR TITLE
GET request on lighttpd are now working

### DIFF
--- a/main.js
+++ b/main.js
@@ -236,6 +236,10 @@ function Request (options) {
     } else {
       throw new Error('Argument error, options.body.')
     }
+  } else {
+    if (self.method && self.method != 'GET') {
+      self.headers['content-length'] = 0
+    }
   }
 
   var protocol = self.proxy ? self.proxy.protocol : self.uri.protocol
@@ -299,7 +303,6 @@ function Request (options) {
       console.warn("options.requestBodyStream is deprecated, please pass the request object to stream.pipe.")
       self.requestBodyStream.pipe(self)
     } else if (!self.src) {
-      self.headers['content-length'] = 0
       self.end()
     }
     self.ntick = true


### PR DESCRIPTION
GET request should not have content-length: 0 in headers, this cause a Bad
Request response in lighttpd.

This code sample is now working :

```
var request = require('request');
var util = require('util');

request({ uri: 'http://piratebay.se' }, function (error, response, body) {
  if (!error && response.statusCode == 200) {
    util.puts(body);
  } else {
    if (error)
      console.log("error :", error);
    console.log("statusCode :", response.statusCode);
  }
});
```
