### PR TITLE
Modified the post, put, head and del shortcuts to support uri optional param

### DIFF
--- a/main.js
+++ b/main.js
@@ -657,6 +657,20 @@ Request.prototype.destroy = function () {
   if (!this._ended) this.end()
 }
 
+// organize params for post, put, head, del
+function initParams(uri, options, callback) {
+  if ((typeof options === 'function') && !callback) callback = options;
+  if (typeof options === 'object') {
+    options.uri = uri;
+  } else if (typeof uri === 'string') {
+    options = {uri:uri};
+  } else {
+    options = uri;
+    uri = options.uri;
+  }
+  return { uri: uri, options: options, callback: callback };
+}
+
 function request (uri, options, callback) {
   if ((typeof options === 'function') && !callback) callback = options;
   if (typeof options === 'object') {
@@ -708,28 +722,28 @@ request.forever = function (agentOptions, optionsArg) {
 }
 
 request.get = request
-request.post = function (options, callback) {
-  if (typeof options === 'string') options = {uri:options}
-  options.method = 'POST'
-  return request(options, callback)
+request.post = function (uri, options, callback) {
+  var params = initParams(uri, options, callback);
+  params.options.method = 'POST';
+  return request(params.uri, params.options, params.callback)
 }
-request.put = function (options, callback) {
-  if (typeof options === 'string') options = {uri:options}
-  options.method = 'PUT'
-  return request(options, callback)
+request.put = function (uri, options, callback) {
+  var params = initParams(uri, options, callback);
+  params.options.method = 'PUT'
+  return request(params.uri, params.options, params.callback)
 }
-request.head = function (options, callback) {
-  if (typeof options === 'string') options = {uri:options}
-  options.method = 'HEAD'
+request.head = function (uri, options, callback) {
+  var params = initParams(uri, options, callback);
+  params.options.method = 'HEAD'
   if (options.body || options.requestBodyStream || options.json || options.multipart) {
     throw new Error("HTTP HEAD requests MUST NOT include a request body.")
   }
-  return request(options, callback)
+  return request(params.uri, params.options, params.callback)
 }
-request.del = function (options, callback) {
-  if (typeof options === 'string') options = {uri:options}
-  options.method = 'DELETE'
-  return request(options, callback)
+request.del = function (uri, options, callback) {
+  var params = initParams(uri, options, callback);
+  params.options.method = 'DELETE'
+  return request(params.uri, params.options, params.callback)
 }
 request.jar = function () {
   return new CookieJar

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -78,7 +78,7 @@ s.listen(s.port, function () {
   })
 
   // Should not follow post redirects by default
-  request.post({uri:server+'/temp', jar: jar, headers: {cookie: 'foo=bar'}}, function (er, res, body) {
+  request.post(server+'/temp', { jar: jar, headers: {cookie: 'foo=bar'}}, function (er, res, body) {
     try {
       assert.ok(hits.temp, 'Original request is to /temp')
       assert.ok(!hits.temp_landing, 'No chasing the redirect when post')


### PR DESCRIPTION
Now you should be able to do the following:

``` javascript
request.post("http://example.com/widgets", function(e,r,b) { console.log(b) });
//or
request.post("http://example.com/widgets", { body: 'foo=bar'}, function(e,r,b) { console.log(b) });
//and still do
request.post({ uri: "http://example.com/widgets", body: 'foo=bar'}, function(e,r,b) { console.log(b) });
```

created a new function called initParams to reduce duplication:

``` javascript
function initParams(uri, options, callback) {
  if ((typeof options === 'function') && !callback) callback = options;
  if (typeof options === 'object') {
    options.uri = uri;
  } else if (typeof uri === 'string') {
    options = {uri:uri};
  } else {
    options = uri;
    uri = options.uri;
  }
  return { uri: uri, options: options, callback: callback };
}
```

and each shortcut method calls this method to organize the method params

``` javascript
request.post = function (uri, options, callback) {
  var params = initParams(uri, options, callback);
  params.options.method = 'POST';
  return request(params.uri, params.options, params.callback)
}
```
