### PR TITLE
Fix request.defaults to support (uri, options, callback) api

### DIFF
--- a/main.js
+++ b/main.js
@@ -690,12 +690,12 @@ module.exports = request
 
 request.defaults = function (options) {
   var def = function (method) {
-    var d = function (opts, callback) {
-      if (typeof opts === 'string') opts = {uri:opts}
+    var d = function (uri, opts, callback) {
+      var params = initParams(uri, opts, callback);
       for (var i in options) {
-        if (opts[i] === undefined) opts[i] = options[i]
+        if (params.options[i] === undefined) params.options[i] = options[i]
       }
-      return method(opts, callback)
+      return method(params.uri, params.options, params.callback)
     }
     return d
   }

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -1,0 +1,68 @@
+var server = require('./server')
+  , assert = require('assert')
+  , request = require('../main.js')
+  ;
+
+var s = server.createServer();
+
+s.listen(s.port, function () {
+  var counter = 0;
+  s.on('/get', function (req, resp) {
+    assert.equal(req.headers.foo, 'bar');
+    assert.equal(req.method, 'GET')
+    resp.writeHead(200, {'Content-Type': 'text/plain'});
+    resp.end('TESTING!');
+  });
+
+  // test get(string, function)
+  request.defaults({headers:{foo:"bar"}})(s.url + '/get', function (e, r, b){
+    if (e) throw e;
+    assert.deepEqual("TESTING!", b);
+    counter += 1;
+  });
+
+  s.on('/post', function (req, resp) {
+    assert.equal(req.headers.foo, 'bar');
+    assert.equal(req.headers['content-type'], 'application/json');
+    assert.equal(req.method, 'POST')
+    resp.writeHead(200, {'Content-Type': 'application/json'});
+    resp.end(JSON.stringify({foo:'bar'}));
+  });
+
+  // test post(string, object, function)
+  request.defaults({headers:{foo:"bar"}}).post(s.url + '/post', {json: true}, function (e, r, b){
+    if (e) throw e;
+    assert.deepEqual('bar', b.foo);
+    counter += 1;
+  });
+
+  s.on('/del', function (req, resp) {
+    assert.equal(req.headers.foo, 'bar');
+    assert.equal(req.method, 'DELETE')
+    resp.writeHead(200, {'Content-Type': 'application/json'});
+    resp.end(JSON.stringify({foo:'bar'}));
+  });
+
+  // test .del(string, function)
+  request.defaults({headers:{foo:"bar"}}).del(s.url + '/del', function (e, r, b){
+    if (e) throw e;
+    assert.deepEqual('bar', b.foo);
+    counter += 1;
+  });
+
+  s.on('/head', function (req, resp) {
+    assert.equal(req.headers.foo, 'bar');
+    assert.equal(req.method, 'HEAD')
+    resp.writeHead(200, {'Content-Type': 'text/plain'});
+    resp.end();
+  });
+
+  // test head.(object, function)
+  request.defaults({headers:{foo:"bar"}}).head({uri: s.url + '/head'}, function (e, r, b){
+    if (e) throw e;
+    counter += 1;
+    console.log(counter.toString() + " tests passed.")
+    s.close()
+  });
+
+})


### PR DESCRIPTION
Fixed request.defaults to support the (uri, options, callback) api, is should still support the (uri, callback) and (options, callback) api's as well.  See tests/test-defaults.js for details.  

Thx
