### PR TITLE
Attempt to recover from non-uri-encoded location headers

### DIFF
--- a/main.js
+++ b/main.js
@@ -439,6 +439,9 @@ Request.prototype.start = function () {
       if (!isUrl.test(response.headers.location)) {
         response.headers.location = url.resolve(self.uri.href, response.headers.location)
       }
+      if ( ! /%25/.test(encodeURI(response.headers.location))) {
+        response.headers.location = encodeURI(response.headers.location)
+      }
       self.uri = response.headers.location
       self.redirects.push(
         { statusCode : response.statusCode


### PR DESCRIPTION
Hey Mikeal,

I came across a strange bug while trying to use request to download some files from github. From what I could tell, what was happening was that a redirect uri to cloud.github.com has a space in it, and that this space on the second request confused github's servers.

I was able to get a fix together for myself at least, so I'm sharing. I'm sure you can think of a better way to do this check, but at least this gives you an idea?

Anyway.
