### PR TITLE
need to use Authorization (titlecase) header with Tumblr OAuth

### DIFF
--- a/main.js
+++ b/main.js
@@ -694,9 +694,9 @@ Request.prototype.oauth = function (_oauth) {
       delete oa['oauth_'+i]
     }
   }
-  this.headers.authorization = 
+  this.headers.Authorization = 
     'OAuth '+Object.keys(oa).sort().map(function (i) {return i+'="'+oauth.rfc3986(oa[i])+'"'}).join(',')
-  this.headers.authorization += ',oauth_signature="'+oauth.rfc3986(signature)+'"'
+  this.headers.Authorization += ',oauth_signature="'+oauth.rfc3986(signature)+'"'
   return this
 }
 Request.prototype.jar = function (jar) {

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -6,7 +6,7 @@ var hmacsign = require('../oauth').hmacsign
 
 function getsignature (r) {
   var sign
-  r.headers.authorization.slice('OAuth '.length).replace(/,\ /g, ',').split(',').forEach(function (v) {
+  r.headers.Authorization.slice('OAuth '.length).replace(/,\ /g, ',').split(',').forEach(function (v) {
     if (v.slice(0, 'oauth_signature="'.length) === 'oauth_signature="') sign = v.slice('oauth_signature="'.length, -1)
   })
   return decodeURIComponent(sign)


### PR DESCRIPTION
ran into this with the tumblr oauth implementation in particular. it seems way strict. it requires `Authorization:` as the header and not just `authorization:`. I'm not sure if any other oauth providers break on this or not.

not sure what the policy is on lowercase vs. titlecase headers though. my change seems quite arbitrary and confusing unless it's somehow applied to all headers or made case-insensitively somehow.

any guidance?
