### PR TITLE
Multipart content-type change

### DIFF
--- a/main.js
+++ b/main.js
@@ -623,9 +623,9 @@ Request.prototype.multipart = function (multipart) {
   self.body = []
 
   if (!self.headers['content-type']) {
-    self.headers['content-type'] = 'multipart/related;boundary="frontier"';
+    self.headers['content-type'] = 'multipart/related; boundary=frontier';
   } else {
-    self.headers['content-type'] = self.headers['content-type'].split(';')[0] + ';boundary="frontier"';
+    self.headers['content-type'] = self.headers['content-type'].split(';')[0] + '; boundary=frontier';
   }
 
   if (!multipart.forEach) throw new Error('Argument error, options.multipart.')


### PR DESCRIPTION
I am currently using request to do some multipart work and I notice that there are some parsers that don't like the way request formats it multipart headers. I especially think of Ruby, but it might be a coincidence.

The changes here are small and shouldn't break compatibility.
1. In [RFC1341](http://www.w3.org/Protocols/rfc1341/7_2_Multipart.html) the quotes are omitted in all cases but one, when there was a space in the identifier. Let's remove that as some sucky parsers fall over it, it won't make a difference because according to [RFC2045](http://www.ietf.org/rfc/rfc2045.txt) the quotes are optional.
2. I have no clue whether the the space after the `;` is mandatory, I can't really find anything in the RFC's (but then again, I'm a sloppy reader), but I have noticed that some parsers (like CloudFoundry) break over this if the space is omitted.
