### PR TITLE
Dynamic boundary

### DIFF
--- a/main.js
+++ b/main.js
@@ -237,7 +237,7 @@ Request.prototype.init = function (options) {
   if (options.json) {
     self.json(options.json)
   } else if (options.multipart) {
-	self.boundary = uuid()
+    self.boundary = uuid()
     self.multipart(options.multipart)
   }
 


### PR DESCRIPTION
Hi.. I added a dynamic boundary ID using the UUID lib to make those requests more generic. Before, it was submiting the same boundary ID to every request ('frontier').

Regards,
zephrax
