### PR TITLE
Fixing the set-cookie header

### DIFF
--- a/main.js
+++ b/main.js
@@ -417,11 +417,14 @@ Request.prototype.start = function () {
       self.timeoutTimer = null
     }  
     
+    var addCookie = function(cookie){
+      if (self._jar) self._jar.add(new Cookie(cookie))
+      else cookieJar.add(new Cookie(cookie))
+    }
+
     if (response.headers['set-cookie'] && (!self._disableCookies)) {
-      response.headers['set-cookie'].forEach(function(cookie) {
-        if (self._jar) self._jar.add(new Cookie(cookie))
-        else cookieJar.add(new Cookie(cookie))
-      })
+      if (Array.isArray(response.headers['set-cookie'])) response.headers['set-cookie'].forEach(addCookie)
+      else addCookie(response.headers['set-cookie'])
     }
 
     if (response.statusCode >= 300 && response.statusCode < 400  &&


### PR DESCRIPTION
Sometimes the "set-cookie" response header wasn't parsed as an Array. This had the effect of throwing an error about the cookie string not having the forEach method.

I'm honestly not sure how to write a test for that with the current way tests are made. I'm also unsure where that header was converted to an Array in the first place.

This is tentative at best. I can't claim to know the intricacies of Request, but I'm willing to learn them if you point me in the right direction.
