### PR TITLE
Fix for the fix of your (closed) issue #89 where self.headers[content-length] is set to 0 for all methods

### DIFF
--- a/main.js
+++ b/main.js
@@ -338,9 +338,11 @@ Request.prototype.init = function (options) {
       console.warn("options.requestBodyStream is deprecated, please pass the request object to stream.pipe.")
       self.requestBodyStream.pipe(self)
     } else if (!self.src) {
-      self.headers['content-length'] = 0
-      self.end()
-    }
+        if (self.method !== 'GET' && typeof self.method !== 'undefined') {
+           self.headers['content-length'] = 0;
+        }
+        self.end();
+     }
     self.ntick = true
   })
 }


### PR DESCRIPTION
turns out that setting content length to 0 for GETs to some servers causes them to respond with status 403.

For example, try out http://govwin.com.

The request:

GET / HTTP/1.1
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,_/_;q=0.8
Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
Accept-Language: en-US,en;q=0.8
Cache-Control: max-age=0
host: govwin.com
Accept-Encoding: gzip,deflate,sdch
Connection: keep-alive
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.151 Safari/535.19
content-length: 0

The response:

HTTP/1.1 403 Forbidden
Date: Fri, 04 May 2012 22:53:43 GMT
Server: Apache/2.2.8 (CentOS)
Accept-Ranges: bytes
Vary: Accept-Encoding
Content-Encoding: gzip
Content-Length: 2021
Connection: close
Content-Type: text/html; charset=UTF-8
Set-Cookie: BIGipServerdeltek_govwin.com_p=409138605.20480.0000; expires=Fri, 04-May-2012 23:08:43 GMT; path=/

This commit checks self.method before setting content-length:0 and only sets this value if the method is not a GET and not undefined (which resolves to GET).
