### PR TITLE
multipart allow body === '' ( the empty string )

### DIFF
--- a/main.js
+++ b/main.js
@@ -645,7 +645,7 @@ Request.prototype.multipart = function (multipart) {
 
   multipart.forEach(function (part) {
     var body = part.body
-    if(!body) throw Error('Body attribute missing in multipart.')
+    if(body == null) throw Error('Body attribute missing in multipart.')
     delete part.body
     var preamble = '--' + self.boundary + '\r\n'
     Object.keys(part).forEach(function(key){


### PR DESCRIPTION
Hi

When sending POST request, with empty fields (multipart/form-data), `request` fails with the message `Body attribute missing in multipart.`.

`body === null` and `body === undefined` should be avoided, 
but not `body === 0` or `body === ""`

Here is a dump of what I want to send (done with chrome) :

```
------WebKitFormBoundaryya1smvvViLvINIOb

Content-Disposition: form-data; name="title"





------WebKitFormBoundaryya1smvvViLvINIOb

Content-Disposition: form-data; name="upload"; filename=""

Content-Type: application/octet-stream





------WebKitFormBoundaryya1smvvViLvINIOb--
```
