### PR TITLE
Setting 'pool' to 'false' does NOT disable Agent pooling

### DIFF
--- a/main.js
+++ b/main.js
@@ -108,7 +108,7 @@ Request.prototype.init = function (options) {
   
   if (!options) options = {}
   
-  if (!self.pool) self.pool = globalPool
+  if (!self.pool && self.pool !== false) self.pool = globalPool
   self.dests = []
   self.__isRequestRequest = true
   

--- a/tests/run.js
+++ b/tests/run.js
@@ -14,6 +14,7 @@ var tests = [
   , 'test-https-strict.js'
   , 'test-oauth.js'
   , 'test-pipes.js'
+  , 'test-pool.js'
   , 'test-proxy.js'
   , 'test-qs.js'
   , 'test-redirect.js'

--- a/tests/test-pool.js
+++ b/tests/test-pool.js
@@ -1,0 +1,16 @@
+var request = require('../main')
+  , http = require('http')
+  , assert = require('assert')
+  ;
+
+var s = http.createServer(function (req, resp) {
+  resp.statusCode = 200;
+  resp.end('asdf');
+}).listen(8080, function () {
+  request({'url': 'http://localhost:8080', 'pool': false}, function (e, resp) {
+    var agent = resp.request.agent;
+    assert.strictEqual(typeof agent, 'boolean');
+    assert.strictEqual(agent, false);
+    s.close();
+  });
+});


### PR DESCRIPTION
An incorrect check of `if (!self.pool)..` caused the `globalPool` overwrite `self.pool` before a check later in the code `if (self.pool === false) ...` which is intended to turn off pooling, but is never triggered. The result was that the typical `http.Agent` is used, with it's default max connections of 5.

--Tim Shadel github@timshadel.com
