### PR TITLE
JSON test should check for equality

### DIFF
--- a/tests/test-toJSON.js
+++ b/tests/test-toJSON.js
@@ -8,7 +8,7 @@ var s = http.createServer(function (req, resp) {
   resp.end('asdf')
 }).listen(8080, function () {
   var r = request('http://localhost:8080', function (e, resp) {
-    assert(JSON.parse(JSON.stringify(r)).response.statusCode, 200)
+    assert.equal(JSON.parse(JSON.stringify(r)).response.statusCode, 200)
     s.close()
   })
 })


### PR DESCRIPTION
`assert()` by itself only looks to see that the first argument is a value of some kind. This uses `assert.equal()` instead.

--Tim Shadel github@timshadel.com
