### PR TITLE
Bug in OAuth key generation for sha1

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -25,8 +25,8 @@ function hmacsign (httpMethod, base_uri, params, consumer_secret, token_secret, 
       // big WTF here with the escape + encoding but it's what twitter wants
       return escape(rfc3986(i)) + "%3D" + escape(rfc3986(params[i]))
     }).join("%26")
-  var key = consumer_secret + '&'
-  if (token_secret) key += token_secret
+  var key = encodeURIComponent(consumer_secret) + '&'
+  if (token_secret) key += encodeURIComponent(token_secret)
   return sha1(key, base)
 }
 


### PR DESCRIPTION
Per spec (http://tools.ietf.org/html/rfc5849#section-3.4.2) the consumer_secret (client shared-secret) and token_secret should be encoded before being used as part of the key for sha1.
