### PR TITLE
Pipe back pressure issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -581,6 +581,9 @@ Request.prototype.start = function () {
   }
   
   self.req.on('error', self.clientErrorHandler)
+  self.req.on('drain', function() {
+    self.emit('drain')
+  })
   
   self.emit('request', self.req)
 }
@@ -807,7 +810,7 @@ Request.prototype.pipe = function (dest, opts) {
 }
 Request.prototype.write = function () {
   if (!this._started) this.start()
-  this.req.write.apply(this.req, arguments)
+  return this.req.write.apply(this.req, arguments)
 }
 Request.prototype.end = function (chunk) {
   if (chunk) this.write(chunk)


### PR DESCRIPTION
Currently request doesn't return a boolean from write to indicate whether or not the write was flushed nor does it emit a drain event.

This can result in a large memory overhead when piping large files to request because of back pressure.
Consider:

``` js
fs.createReadStream('i_am_large.file').pipe(request.put('http://...');
```

If the above readstream reads faster than request can write we'll end up having most of the file in memory.
This patch fixes this issue by adding the `drain` event and returning the boolean from `req.write`.
