### PR TITLE
fix tests with boundary by injecting boundry from header

### DIFF
--- a/tests/server.js
+++ b/tests/server.js
@@ -51,11 +51,15 @@ exports.createPostValidator = function (text) {
     var r = '';
     req.on('data', function (chunk) {r += chunk})
     req.on('end', function () {
-    if (r !== text) console.log(r, text);
-    assert.equal(r, text)
-    resp.writeHead(200, {'content-type':'text/plain'})
-    resp.write('OK')
-    resp.end()
+      if (req.headers['content-type'] && req.headers['content-type'].indexOf('boundary=') >= 0) {
+        var boundary = req.headers['content-type'].split('boundary=')[1];
+        text = text.replace(/__BOUNDARY__/g, boundary);
+      }
+      if (r !== text) console.log(r, text);
+      assert.equal(r, text)
+      resp.writeHead(200, {'content-type':'text/plain'})
+      resp.write('OK')
+      resp.end()
     })
   }
   return l;

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -50,23 +50,22 @@ var tests =
     , method: "PUT"
     , json: {foo: 'bar'}
     }
-  // , testPutMultipart :
-  //   { resp: server.createPostValidator(
-  //       '--frontier\r\n' +
-  //       '--15F6786B-D0A8-4AB8-B0A5-DDF721BC6192\\r\\n'
-  //       'content-type: text/html\r\n' +
-  //       '\r\n' +
-  //       '<html><body>Oh hi.</body></html>' +
-  //       '\r\n--frontier\r\n\r\n' +
-  //       'Oh hi.' +
-  //       '\r\n--frontier--'
-  //       )
-  //   , method: "PUT"
-  //   , multipart:
-  //     [ {'content-type': 'text/html', 'body': '<html><body>Oh hi.</body></html>'}
-  //     , {'body': 'Oh hi.'}
-  //     ]
-  //   }
+  , testPutMultipart :
+    { resp: server.createPostValidator(
+        '--__BOUNDARY__\r\n' +
+        'content-type: text/html\r\n' +
+        '\r\n' +
+        '<html><body>Oh hi.</body></html>' +
+        '\r\n--__BOUNDARY__\r\n\r\n' +
+        'Oh hi.' +
+        '\r\n--__BOUNDARY__--'
+        )
+    , method: "PUT"
+    , multipart:
+      [ {'content-type': 'text/html', 'body': '<html><body>Oh hi.</body></html>'}
+      , {'body': 'Oh hi.'}
+      ]
+    }
   }
 
 s.listen(s.port, function () {

--- a/tests/test-https-strict.js
+++ b/tests/test-https-strict.js
@@ -52,13 +52,13 @@ var tests =
     }
   , testPutMultipart :
     { resp: server.createPostValidator(
-        '--frontier\r\n' +
+        '--__BOUNDARY__\r\n' +
         'content-type: text/html\r\n' +
         '\r\n' +
         '<html><body>Oh hi.</body></html>' +
-        '\r\n--frontier\r\n\r\n' +
+        '\r\n--__BOUNDARY__\r\n\r\n' +
         'Oh hi.' +
-        '\r\n--frontier--'
+        '\r\n--__BOUNDARY__--'
         )
     , method: "PUT"
     , multipart:

--- a/tests/test-https.js
+++ b/tests/test-https.js
@@ -44,13 +44,13 @@ var tests =
     }
   , testPutMultipart :
     { resp: server.createPostValidator(
-        '--frontier\r\n' +
+        '--__BOUNDARY__\r\n' +
         'content-type: text/html\r\n' +
         '\r\n' +
         '<html><body>Oh hi.</body></html>' +
-        '\r\n--frontier\r\n\r\n' +
+        '\r\n--__BOUNDARY__\r\n\r\n' +
         'Oh hi.' +
-        '\r\n--frontier--'
+        '\r\n--__BOUNDARY__--'
         )
     , method: "PUT"
     , multipart:

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -50,13 +50,13 @@ var tests =
       }
     , testPutMultipart :
       { resp: server.createPostValidator(
-          '--frontier\r\n' +
+          '--__BOUNDARY__\r\n' +
           'content-type: text/html\r\n' +
           '\r\n' +
           '<html><body>Oh hi.</body></html>' +
-          '\r\n--frontier\r\n\r\n' +
+          '\r\n--__BOUNDARY__\r\n\r\n' +
           'Oh hi.' +
-          '\r\n--frontier--'
+          '\r\n--__BOUNDARY__--'
           )
       , method: "PUT"
       , multipart:

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -32,9 +32,10 @@ squid.stdout.on('data', function (c) {
 })
 
 squid.on('exit', function (c) {
-  console.error('exit '+c)
+  console.error('squid: exit '+c)
   if (c && !ready) {
     console.error('squid must be installed to run this test.')
+    console.error('skipping this test. please install squid and run again if you need to test tunneling.')
     c = null
     hadError = null
     process.exit(0)


### PR DESCRIPTION
This is in response to #277. I traced the error and found that it was due to a change that made the request text contain a randomly generated UUID. This made it so that it couldn't be compared with a static piece of text. I added a token to it and made it find the boundary in the header and put the boundary into the text. All tests pass now. More info is in my comments on #277.

I also clarified what happens when Squid isn't installed, so the person running the test knows that all tests that ran passed, that the test was skipped, and that squid needs to be installed to test tunneling.
