### PR TITLE
OAuth Authorization header contains non-"oauth_" parameters

### DIFF
--- a/main.js
+++ b/main.js
@@ -747,6 +747,7 @@ Request.prototype.oauth = function (_oauth) {
       // skip 
     } else {
       delete oa['oauth_'+i]
+      delete oa[i]
     }
   }
   this.headers.Authorization = 


### PR DESCRIPTION
This could be related to #204 or #244 and it's included in @jdub's pull request https://github.com/mikeal/request/pull/245

but this line in particular is causing requests OAuth functionality not to work with an OAuth provider I'm using.  I'd be great to get this merged in.  Thanks.
