### PR TITLE
Remove stray `console.log()` call in multipart generator.

### DIFF
--- a/main.js
+++ b/main.js
@@ -659,8 +659,6 @@ Request.prototype.multipart = function (multipart) {
     self.headers['content-type'] = self.headers['content-type'].split(';')[0] + '; boundary=' + self.boundary;
   }
 
-  console.log('boundary >> ' + self.boundary)
-
   if (!multipart.forEach) throw new Error('Argument error, options.multipart.')
 
   multipart.forEach(function (part) {


### PR DESCRIPTION
Just spotted this in my test output after upgrading. I'd assume it's not meant to be there :)

Thanks for keeping this project amazingly up-to-date and constantly improving!
