### PR TITLE
Specify servername when creating secureSocket over tunneling proxy

### DIFF
--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -50,8 +50,9 @@ squid.on('exit', function (c) {
 
 setTimeout(function F () {
   if (!ready) return setTimeout(F, 100)
-  request({ uri: 'https://registry.npmjs.org/request/'
+  request({ uri: 'https://registry.npmjs.org/'
           , proxy: 'http://localhost:3128'
+          , strictSSL: true
           , ca: ca
           , json: true }, function (er, body) {
     hadError = er

--- a/tunnel.js
+++ b/tunnel.js
@@ -188,6 +188,7 @@ function createSecureSocket(options, cb) {
   TunnelingAgent.prototype.createSocket.call(self, options, function(socket) {
     // 0 is dummy port for v0.6
     var secureSocket = tls.connect(0, mergeOptions({}, self.options, {
+      servername: options.host,
       socket: socket
     }));
     cb(secureSocket);


### PR DESCRIPTION
This makes the https-over-http proxy work when strictSSL is turned on.

In v0.8.4, we fixed a security bug where an otherwise valid cert would be
accepted for a host that was not listed in the CN or subjectaltnames
sections of the certificate.

However, this breaks proxying, because you want to accept the cert if
it comes from the origin server, not tested against the proxy's
hostname.

This fixes isaacs/npm#2719
