### PR TITLE
Manual `piping`

### DIFF
--- a/main.js
+++ b/main.js
@@ -245,6 +245,8 @@ Request.prototype.init = function (options) {
   if (options.aws) {
     self.aws(options.aws)
   }
+  
+  self._endOnTick = options.endOnTick === null ? true : options.endOnTick;
 
   if (self.uri.auth && !self.headers.authorization) {
     self.headers.authorization = "Basic " + toBase64(self.uri.auth.split(':').map(function(item){ return qs.unescape(item)}).join(':'))
@@ -329,8 +331,6 @@ Request.prototype.init = function (options) {
     }
   }
   
-  self._endOnTick = options.endOnTick ? options.endOnTick : true;
-
   self.once('pipe', function (src) {
     if (self.ntick && self._started) throw new Error("You cannot pipe to this stream after the outbound request has started.")
     self.src = src


### PR DESCRIPTION
I had to override the `process.nextTick` function call in `request.prototype.init` to perform manual `piping`.

I had to break the response body of a get request into multiple chunks and perform put requests with those chunks. The server that I was posting to did not allow `Transfer Coding: Chunked`.

So all I did was create a new option `endOnTick: true`in `request`. When this option is `true`, nothing's different. When `false`, whatever the state of the request, the code in the `process.nextTick` call is not executed.
