### PR TITLE
Twitter Oauth Stuff Out of Date; Now Updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ request.post({url:url, oauth:oauth}, function (e, r, body) {
       , consumer_secret: CONSUMER_SECRET
       , token: access_token.oauth_token
       , verifier: access_token.oauth_verifier
-      , token_secret: access_token.oauth_token_secret
       }
     , url = 'https://api.twitter.com/oauth/access_token'
     ;


### PR DESCRIPTION
Updated the twitter oauth dance. The comments weren't clear. Also removed token_key. No longer needed with twitter oauth.
