### PR TITLE
request.defaults() doesn't need to wrap jar()

### DIFF
--- a/main.js
+++ b/main.js
@@ -997,7 +997,7 @@ request.defaults = function (options, requester) {
   de.head = def(request.head)
   de.del = def(request.del)
   de.cookie = def(request.cookie)
-  de.jar = def(request.jar)
+  de.jar = request.jar
   return de
 }
 


### PR DESCRIPTION
...he same signature as get, meaning undefined is passed into initParams, which subsequently fails.  now passing jar function directly as it has no need of defaults anyway seeing as it only creates a new cookie jar
