### PR TITLE
Automatically decode JSON responses based on Content-type

### DIFF
--- a/main.js
+++ b/main.js
@@ -650,8 +650,13 @@ Request.prototype.start = function () {
             try {
               response.body = JSON.parse(response.body)
             } catch (e) {}
+          } else if (response.headers && response.headers['content-type']) {
+            var contentType = response.headers['content-type'].split(';')[0]
+            if (contentType == 'application/json') {
+              response.body = JSON.parse(response.body)
+            }
           }
-          
+
           self.emit('complete', response, response.body)
         })
       }


### PR DESCRIPTION
This change addresses a shortcoming of the current JSON handling: it doesn't seem to be possible to send a non-JSON request while accepting a JSON response, or vice-versa.  I've made it so that responses will always be parsed as JSON if the response `Content-type` header is `application/json`.

Do we need more options here?  Should I try to rework the JSON handling further?
