### PR TITLE
Make AWS auth signing find headers correctly

### DIFF
--- a/main.js
+++ b/main.js
@@ -799,6 +799,15 @@ Request.prototype.json = function (val) {
   }
   return this
 }
+function getHeader(name, headers) {
+    var result, re, match
+    Object.keys(headers).forEach(function (key) {
+        re = new RegExp(name, 'i')
+        match = key.match(re)
+        if (match) result = headers[key]
+    })
+    return result
+}
 Request.prototype.aws = function (opts, now) {
   if (!now) {
     this._aws = opts
@@ -811,8 +820,8 @@ Request.prototype.aws = function (opts, now) {
     , secret: opts.secret
     , verb: this.method.toUpperCase()
     , date: date
-    , contentType: this.headers['content-type'] || ''
-    , md5: this.headers['content-md5'] || ''
+    , contentType: getHeader('content-type', this.headers) || ''
+    , md5: getHeader('content-md5', this.headers) || ''
     , amazonHeaders: aws.canonicalizeHeaders(this.headers)
     }
   if (opts.bucket && this.path) {


### PR DESCRIPTION
The AWS function was using 'content-type' as the header name, which causes access denied errors if the header is actually set as 'Content-Type' since it is an important part of the signing process.

To resolve it, I wrapped the header in a short case-insensitive getter to make sure they are always correctly set for the auth signing.
