### PR TITLE
stop sending erroneous headers on redirected requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -587,6 +587,8 @@ Request.prototype.start = function () {
       delete self.body
       if (self.headers) {
         delete self.headers.host
+        delete self.headers['content-type']
+        delete self.headers['content-length']
       }
       if (log) log('Redirect to %uri', self)
       self.init()


### PR DESCRIPTION
if you delete the body, you should also delete any existing content-type and content-length, otherwise you're sending erroneous values: e.g. content-type form-encoded, content-length 1415, empty body 
