### PR TITLE
Delete self._form along with everything else on redirect

### DIFF
--- a/main.js
+++ b/main.js
@@ -585,6 +585,7 @@ Request.prototype.start = function () {
       delete self.agent
       delete self._started
       delete self.body
+      delete self._form
       if (self.headers) {
         delete self.headers.host
         delete self.headers['content-type']


### PR DESCRIPTION
When posting a file to a url that does a redirect I was getting this error from request:

```
You have already piped to this stream. Pipeing twice is likely to break the request.
```

The post callback would never get fired.  When I deleted self._form it fixed the issue and I think it makes sense since its already deleting self.body etc.
