### PR TITLE
Don't create a Content-Length header if we already have it set

### DIFF
--- a/main.js
+++ b/main.js
@@ -290,6 +290,7 @@ Request.prototype.init = function (options) {
       length = self.body.length
     }
     if (length) {
+      if(!self.headers['content-length'] && !self.headers['Content-Length'])
       self.headers['content-length'] = length
     } else {
       throw new Error('Argument error, options.body.')
@@ -509,13 +510,12 @@ Request.prototype.start = function () {
   self.href = self.uri.href
   if (log) log('%method %href', self)
 
-  if (self.src && self.src.stat && self.src.stat.size) {
+  if (self.src && self.src.stat && self.src.stat.size && !self.headers['content-length'] && !self.headers['Content-Length']) {
     self.headers['content-length'] = self.src.stat.size
   }
   if (self._aws) {
     self.aws(self._aws, true)
   }
-
   self.req = self.httpModule.request(self, function (response) {
     if (response.connection.listeners('error').indexOf(self._parserErrorHandler) === -1) {
       response.connection.once('error', self._parserErrorHandler)


### PR DESCRIPTION
We've had issues where we need to send Content-Length as a header, rather than content-length; when content-length lowercase is in the request, the request fails.

I've put some more checks around content-length so that request doesn't do this if we've already worked out Content-Length

I thought it was part of the HTTP spec that headers we in fact uppercase? According to RFC2616?

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
