### PR TITLE
Running `rfc3986` on `base_uri` in `oauth.hmacsign` instead of just `encodeURIComponent`

### DIFF
--- a/oauth.js
+++ b/oauth.js
@@ -16,18 +16,26 @@ function rfc3986 (str) {
     ;
 }
 
-function hmacsign (httpMethod, base_uri, params, consumer_secret, token_secret, body) {
-  // adapted from https://dev.twitter.com/docs/auth/oauth
-  var base = 
-    (httpMethod || 'GET') + "&" +
-    encodeURIComponent(  base_uri ) + "&" +
-    Object.keys(params).sort().map(function (i) {
-      // big WTF here with the escape + encoding but it's what twitter wants
-      return escape(rfc3986(i)) + "%3D" + escape(rfc3986(params[i]))
-    }).join("%26")
-  var key = encodeURIComponent(consumer_secret) + '&'
-  if (token_secret) key += encodeURIComponent(token_secret)
-  return sha1(key, base)
+function hmacsign (httpMethod, base_uri, params, consumer_secret, token_secret) {
+  // adapted from https://dev.twitter.com/docs/auth/oauth and 
+  // https://dev.twitter.com/docs/auth/creating-signature
+
+  var querystring = Object.keys(params).sort().map(function(key){
+    return key +"="+ params[key];
+  }).join('&');
+
+  var base = [
+    httpMethod ? httpMethod.toUpperCase : 'GET',
+    rfc3986(base_uri),
+    rfc3986(querystring),
+  ].join('&');
+
+  var key = [
+    consumer_secret,
+    token_secret || ''
+  ].map(rfc3986).join('&');
+
+  return sha1(key, base);
 }
 
 exports.hmacsign = hmacsign


### PR DESCRIPTION
All I've changed in terms of output is that the base_uri is encoded with the rfc3986 function before being included in the sha1 base. I was getting 401 errors with the LinkedIn API because my signatures were wrong when I used [field selectors](https://developer.linkedin.com/documents/field-selectors) in an api call.
