### PR TITLE
Fix uncatchable errors. Update tests/test-errors.js for coverage.

### DIFF
--- a/main.js
+++ b/main.js
@@ -133,8 +133,12 @@ Request.prototype.init = function (options) {
   }
 
   if (!self.uri) {
-    // this will throw if unhandled but is handleable when in a redirect
-    return self.emit('error', new Error("options.uri is a required argument"))
+    // this is handleable when in a redirect, but not on initial request
+    // unless fired on process.nextTick
+    process.nextTick(function () {
+      self.emit('error', new Error("options.uri is a required argument"))
+    })
+    return // This error was fatal
   } else {
     if (typeof self.uri == "string") self.uri = url.parse(self.uri)
   }
@@ -167,7 +171,9 @@ Request.prototype.init = function (options) {
       // he should be warned that it can be caused by a redirection (can save some hair)
       message += '. This can be caused by a crappy redirection.'
     }
-    self.emit('error', new Error(message))
+    process.nextTick(function () {
+      self.emit('error', new Error(message))
+    })
     return // This error was fatal
   }
 

--- a/tests/test-errors.js
+++ b/tests/test-errors.js
@@ -34,4 +34,20 @@ try {
   assert.equal(e.message, 'Body attribute missing in multipart.')
 }
 
+try {
+  request('/invalid').on('error', function (e) {
+    assert.equal(e.message, 'Invalid URI "/invalid"')
+  });
+} catch (e) {
+  assert.fail("Should not throw");
+}
+
+try {
+  request('').on('error', function (e) {
+    assert.equal(e.message, 'options.uri is a required argument')
+  });
+} catch (e) {
+  assert.fail("Should not throw");
+}
+
 console.log("All tests passed.")


### PR DESCRIPTION
Request#init has two places where it will emit an 'error' event, but listeners have not had a chance to attach yet. So any emitted errors actually throw.

Tests included.

Example:

``` js
request('/invalid').on('error', function (e){
  console.error('Hey... I should have been caught!');
})
// Throws
Error: Invalid URI "/invalid"
```
