### PR TITLE
Don't remove x_auth_mode for Twitter reverse auth

### DIFF
--- a/main.js
+++ b/main.js
@@ -883,7 +883,10 @@ Request.prototype.oauth = function (_oauth) {
       // skip 
     } else {
       delete oa['oauth_'+i]
-      delete oa[i]
+      
+      if (i !== 'x_auth_type') {
+        delete oa[i]
+      }
     }
   }
   this.headers.Authorization = 


### PR DESCRIPTION
Twitter's reverse auth requires passing an x_auth_mode parameter.  See more: https://dev.twitter.com/docs/ios/using-reverse-auth. 
