### PR TITLE
Strip out the UTF8 BOM when encoding is 'utf8'

### DIFF
--- a/main.js
+++ b/main.js
@@ -649,6 +649,11 @@ Request.prototype.start = function () {
               response.body = body.toString(self.encoding)
             }
           } else if (buffer.length) {
+            // The UTF8 BOM [0xEF,0xBB,0xBF] is converted to [0xFE,0xFF] in the JS UTC16/UCS2 representation.
+            // Strip this value out when the encoding is set to 'utf8', as upstream consumers won't expect it and it breaks JSON.parse().
+            if (self.encoding == 'utf8' && buffer[0].length > 0 && buffer[0][0] == "\uFEFF") {
+              buffer[0] = buffer[0].substring(1)
+            }
             response.body = buffer.join('')
           }
 

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -40,6 +40,11 @@ var tests =
      , json : true
      , expectBody: {"test":true}
      }
+  , testGetUTF8:
+     { resp: server.createGetResponse(new Buffer([0xEF, 0xBB, 0xBF, 226, 152, 131]))
+     , encoding: "utf8"
+     , expectBody: "☃"
+     }   
   , testPutString :
     { resp : server.createPostValidator("PUTTINGDATA")
     , method : "PUT"


### PR DESCRIPTION
Some frameworks, such as .NET in my case, often emit the UTF8 byte-order-mark in the HTTP response.

This commit strips out the BOM when the encoding is set to 'utf8' and improves compatibility with external services.
