### PR TITLE
Correct Host header for proxy tunnel CONNECT

### DIFF
--- a/main.js
+++ b/main.js
@@ -138,6 +138,7 @@ Request.prototype.init = function (options) {
   } else {
     if (typeof self.uri == "string") self.uri = url.parse(self.uri)
   }
+  
   if (self.proxy) {
     if (typeof self.proxy == 'string') self.proxy = url.parse(self.proxy)
 
@@ -148,7 +149,9 @@ Request.prototype.init = function (options) {
 
       var tunnelOptions = { proxy: { host: self.proxy.hostname
                                    , port: +self.proxy.port
-                                   , proxyAuth: self.proxy.auth }
+                                   , proxyAuth: self.proxy.auth
+                                   , headers: { Host: self.uri.hostname + ':' + 
+                                        (self.uri.port || self.uri.protocol === 'https:' ? 443 : 80) }}
                           , ca: this.ca }
 
       self.agent = tunnelFn(tunnelOptions)

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -23,7 +23,7 @@ var ready = false
 squid.stderr.on('data', function (c) {
   console.error('SQUIDERR ' + c.toString().trim().split('\n')
                .join('\nSQUIDERR '))
-  ready = c.toString().match(/ready to serve requests/i)
+  ready = c.toString().match(/ready to serve requests|Accepting HTTP Socket connections/i)
 })
 
 squid.stdout.on('data', function (c) {


### PR DESCRIPTION
As per [RFC 2817](http://www.ietf.org/rfc/rfc2817.txt), section _5.2 Requesting a Tunnel with CONNECT_, there is a `Host` header to be set. The examples in the RFC use the same example host/port which is confusing, but logically, it makes no sense to use the same hostname in `CONNECT` statement and in the `Host` header. The `Host` header is meant to be set to the actual host to be proxied/tunelled to, and it looks like at least some of the proxies out there work that way.

I believe this also closes #367.

Notes:
1. it would probably be ideal if the tunnel options were overridable from the main api, e.g. via `opts = { tunnelOptions: { .. } }`
2. it would probably be better if the Host header for the tunnel was set after the logic for resolving the target hostname/port/protocol, which is below the tunnel config code, but it contains a few references to self.tunnel, so I'm not sure on that.
