### PR TITLE
Headers lost on redirect

### DIFF
--- a/main.js
+++ b/main.js
@@ -111,7 +111,7 @@ Request.prototype.init = function (options) {
   if (!options) options = {}
   if (process.env.NODE_DEBUG && /request/.test(process.env.NODE_DEBUG)) console.error('REQUEST', options)
   if (!self.pool && self.pool !== false) self.pool = globalPool
-  self.dests = []
+  self.dests = self.dests || []
   self.__isRequestRequest = true
   
   // Protect against double callback


### PR DESCRIPTION
When piping request into another stream, which supports setHeader, the headers aren't included if a redirect occurres. It's because the `self.dests` in the `init` ([linie 114 in main.js](https://github.com/mikeal/request/blob/master/main.js#L114)) method is reset to an empty array on every redirect. I think this also fixes issue [#348](https://github.com/mikeal/request/issues/348).
