### PR TITLE
Destroy the response if present when destroying the request

### DIFF
--- a/main.js
+++ b/main.js
@@ -970,6 +970,7 @@ Request.prototype.resume = function () {
 }
 Request.prototype.destroy = function () {
   if (!this._ended) this.end()
+  else if (this.response) this.response.abort();
 }
 
 // organize params for post, put, head, del


### PR DESCRIPTION
Right now calling `req.destroy` does nothing when the response is present and the request will continue to emit data.

This makes sure to call `response.destroy` if there is a response present which ensures that the stream will stop emitting data when destroy is called.
