### PR TITLE
Use latest form-data 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   { "url" : "http://github.com/mikeal/request/issues" }
 , "engines" : ["node >= 0.3.6"]
 , "main" : "./main"
-, "dependencies": { "form-data":"~0.0.3", "mime":"~1.2.7" }
+, "dependencies": { "form-data":"~0.0.5", "mime":"~1.2.7" }
 , "bundleDependencies": ["form-data", "mime"]
 , "scripts": { "test": "node tests/run.js" }
 }


### PR DESCRIPTION
The [form-data](https://github.com/felixge/node-form-data) module has recently merged some very useful improvements to [working with multipart forms](https://github.com/felixge/node-form-data/pull/17#issuecomment-10047904), used by request. The latest release is 0.0.5, but request is still using 0.0.3. This bumps it up.
