### PR TITLE
Ensure "safe" toJSON doesn't break EventEmitters

### DIFF
--- a/main.js
+++ b/main.js
@@ -1122,7 +1122,7 @@ function getSafe (self, uuid) {
 }
 
 function toJSON () {
-  return getSafe(this, (((1+Math.random())*0x10000)|0).toString(16))
+  return getSafe(this, '__' + (((1+Math.random())*0x10000)|0).toString(16))
 }
 
 Request.prototype.toJSON = toJSON


### PR DESCRIPTION
V8 and / or the JS spec are apparently extremely wily about interpreting values as potential indexes for arrays -- even hex strings can be converted internally back to numbers when passed to Object.defineProperty(). This should fix mikeal/request#387.

None of the tests break with this change, but as the bug is sort of a race condition, I couldn't easily come up with a new test case. The breaking test code on mikeal/request#387 no longer crashes when left running for a decent length of time, at least.
