### PR TITLE
Add noproxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The first argument can be either a url or an options object. The only required o
 * `pool.maxSockets` - Integer containing the maximum amount of sockets in the pool.
 * `timeout` - Integer containing the number of milliseconds to wait for a request to respond before aborting the request	
 * `proxy` - An HTTP proxy to be used. Support proxy Auth with Basic Auth the same way it's supported with the `url` parameter by embedding the auth info in the uri.
+* `noproxy` - String of hostnames which won't use proxy when being requested.
 * `oauth` - Options for OAuth HMAC-SHA1 signing, see documentation above.
 * `strictSSL` - Set to `true` to require that SSL certificates be valid. Note: to use your own certificate authority, you need to specify an agent that was created with that ca as an option.
 * `jar` - Set to `false` if you don't want cookies to be remembered for future use or define your custom cookie jar (see examples section)

--- a/main.js
+++ b/main.js
@@ -138,7 +138,15 @@ Request.prototype.init = function (options) {
   } else {
     if (typeof self.uri == "string") self.uri = url.parse(self.uri)
   }
-  
+
+  if(self.noproxy) {
+    if(typeof self.noproxy == 'string') {
+      if(self.noproxy.search(self.uri.hostname) !== -1) {
+        delete self.proxy
+      }
+    }
+  }
+
   if (self.proxy) {
     if (typeof self.proxy == 'string') self.proxy = url.parse(self.proxy)
 

--- a/tests/run.js
+++ b/tests/run.js
@@ -16,6 +16,7 @@ var tests = [
   , 'test-httpModule.js'
   , 'test-https.js'
   , 'test-https-strict.js'
+  , 'test-noproxy.js'
   , 'test-oauth.js'
   , 'test-params.js'
   , 'test-pipes.js'

--- a/tests/test-noproxy.js
+++ b/tests/test-noproxy.js
@@ -1,0 +1,94 @@
+/*
+** Test noproxy configuration.
+**
+** We create a server and a proxy.
+** Server listens on localhost:80.
+** Proxy listens on localhost:8080.
+** The proxy redirects all requests to /proxy on the server.
+** On the server, /proxy sends "proxy" .
+** When server is directly requested, it answers with "noproxy" .
+**
+**
+** So we perform 2 tests, both with proxy equal to "http://localhost:8080".
+** -A test is performed with noproxy equal to "null". In this case,
+**  the server responds with "proxy" because the proxy is used.
+** -In the other test, noproxy equal "localhost, example.com".
+**  Since localhost is part of noproxy, request is made directly
+**  to the server and proxy is ignored.
+*/
+
+var assert = require("assert")
+  , http = require('http')
+  , request = require('../main.js')
+  //We create a server and a proxy.
+  , server = http.createServer(function(req, res){
+      res.statusCode = 200
+      if(req.url == '/proxy') {
+          res.end('proxy')
+      } else {
+          res.end('noproxy')
+      }
+    })
+  , proxy = http.createServer(function (req, res) {
+      res.statusCode = 200
+      var url = 'http://localhost:80/proxy'
+      var x = request(url)
+      req.pipe(x)
+      x.pipe(res)
+    })
+  ;
+
+//Launch server and proxy
+var initialize = function (cb) {
+  server.listen(80, 'localhost', function () {
+    proxy.listen(8080, 'localhost', cb)
+  })
+}
+
+//Tests
+initialize(function () {
+  //Checking the route for server and proxy
+  request.get("http://localhost:80/test", function (err, res, body) {
+    assert.equal(res.statusCode, 200)
+    request.get("http://localhost:80/proxy", function (err, res2, body) {
+      assert.equal(res2.statusCode, 200)
+      request.get("http://localhost:8080/test", function (err, res3, body) {
+        assert.equal(res3.statusCode, 200)
+        makeNoProxyTest(function () {
+          makeProxyTest(function () {
+            closeServer(server)
+            closeServer(proxy)
+          })
+        })
+      })
+    })
+  })
+})
+
+//Request with noproxy
+var makeNoProxyTest = function (cb) {
+  request ({
+    url: 'http://localhost:80/test',
+    proxy: 'http://localhost:8080',
+    noproxy: 'localhost, example.com'
+  }, function (err, res, body) {
+    assert.equal(body, 'noproxy')
+    cb()
+  })
+}
+
+//Request with proxy
+var makeProxyTest = function (cb) {
+  request ({
+    url: 'http://localhost:80/test',
+    proxy: 'http://localhost:8080',
+    noproxy: 'null'
+  }, function (err, res, body) {
+    assert.equal(body, 'proxy')
+    cb()
+  })
+}
+
+var closeServer = function (s) {
+  s.close()
+}


### PR DESCRIPTION
When using request with noproxy, check if the url requested must use a proxy (if present) or not.
This allows requests on lan without having to change/disable the proxy parameter each time.

"noproxy" is a string containing hostnames. When using request with an url matching one of these hostnames, the specifed proxy won't be used.

So, this add a way to specify a list of hostnames that will not ever go through a proxy.
