### PR TITLE
Increment major version due to API change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "request"
 , "description" : "Simplified HTTP request client."
 , "tags" : ["http", "simple", "util", "utility"]
-, "version" : "2.12.1"
+, "version" : "3.0.0"
 , "author" : "Mikeal Rogers <mikeal.rogers@gmail.com>"
 , "repository" :
   { "type" : "git"


### PR DESCRIPTION
The new auth API changes are not backwards compatible, which I discovered trying to use the current master README against the 2.12 release.

[Semantic Versioning](http://semver.org/) demains that backwards incompatible changes result in a new major version. You might not be currently applying semantic versioning to this project, but I would strongly recommend it.

Alternatively, you could patch the code to continue to accept "user:pass" string as auth parameters. In this case you would only need to increment the minor version to 2.13, to indicate the presence of the new "auth" api.
