### PR TITLE
proxy missing events from client request to returned stream

### DIFF
--- a/main.js
+++ b/main.js
@@ -779,6 +779,18 @@ Request.prototype.start = function () {
   self.req.on('drain', function() {
     self.emit('drain')
   })
+  self.req.on('socket', function(socket) {
+    self.emit('socket', socket);
+  });
+  self.req.on('connect', function(response, socket, head) {
+    self.emit('connect', response, socket, head);
+  });
+  self.req.on('upgrade', function(response, socket, head) {
+    self.emit('upgrade', response, socket, head);
+  });
+  self.req.on('continue', function() {
+    self.emit('continue');
+  });
   self.on('end', function() {
     if ( self.req.connection ) self.req.connection.removeListener('error', self._parserErrorHandler)
   })


### PR DESCRIPTION
A bunch of of events are missing from being emitted in the returned stream, `socket`, `connect`, `upgrade`, `continue`.

http://nodejs.org/api/http.html#http_event_socket

I'm only really interested in the `socket` event so I can use `socket.emit('agentRemove')` on it instead of having to increase the max sockets.

I'm aware I can also listen for the `request` event, which I can then listen to all of these events on. Wanted to know what you thought of this API design.

Thanks for an awesome library. :)
