### PR TITLE
Remove bundleDepdendencies from package.json to pull in latest versions of form-data and mime, also bump major version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "request"
 , "description" : "Simplified HTTP request client."
 , "tags" : ["http", "simple", "util", "utility"]
-, "version" : "3.12.1"
+, "version" : "3.0.0"
 , "author" : "Mikeal Rogers <mikeal.rogers@gmail.com>"
 , "repository" :
   { "type" : "git"


### PR DESCRIPTION
So I've been trying to fix a bug with request when using the multi-part forms where a form value of empty string will cause the everything to fail.  So one by one I've been moving from package to package putting all the bits in to fix this. 

The bug originated in node-combined-stream which is required by node-form-data which is required by request. 

Bug in node-combined-stream:
https://github.com/felixge/node-combined-stream/pull/4

Bug in node-form-data
https://github.com/felixge/node-form-data/issues/25

And due to an issue with the package.json node-form-data needed to be updated as well. Now this bug has propagated all the way up to request being the next dependency in line :(

The fix to finally resolve this issue is to remove the line:

``` javascript
, "bundleDependencies":["form-data","mime"]
```

And to bump the package version for request up a major version as request will use much newer versions of form-data and mime. 

If this is done I believe the following bugs in request will be resolved 
#385
#424

And the following issues may be resolved
#394
#316
