### PR TITLE
if query params are empty, then request path shouldn't end with a '?'

### DIFF
--- a/main.js
+++ b/main.js
@@ -852,6 +852,10 @@ Request.prototype.qs = function (q, clobber) {
   for (var i in q) {
     base[i] = q[i]
   }
+
+  if (qs.stringify(base) === ''){
+    return this
+  }
   
   this.uri = url.parse(this.uri.href.split('?')[0] + '?' + qs.stringify(base))
   this.url = this.uri

--- a/tests/test-qs.js
+++ b/tests/test-qs.js
@@ -26,3 +26,9 @@ var req4 = request.get({ uri: 'http://www.google.com?x=y'})
 setTimeout(function() {
 	assert.equal('/?x=y', req4.path)
 }, 1)
+
+// Test giving empty qs property
+var req5 = request.get({ uri: 'http://www.google.com', qs: {}})
+setTimeout(function(){
+	assert.equal('/', req5.path)
+}, 1)


### PR DESCRIPTION
If you do this:

``` javascript
req = request.get({ uri: 'http://www.google.com', qs: {}})`
```

Then req.path equates to /?, which only makes sense if there are some query parameters.
