### PR TITLE
simplify tls connection setup and make compatible with node v0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" : "request"
 , "description" : "Simplified HTTP request client."
 , "tags" : ["http", "simple", "util", "utility"]
-, "version" : "2.14.2"
+, "version" : "2.14.1"
 , "author" : "Mikeal Rogers <mikeal.rogers@gmail.com>"
 , "repository" :
   { "type" : "git"


### PR DESCRIPTION
(note that, as discussed on #437, this makes no attempt at compatibility with node <= v0.4, because AFAICT the `.forever()` agent was not working there already.)
