### PR TITLE
protect against double callbacks on error path

### DIFF
--- a/main.js
+++ b/main.js
@@ -124,8 +124,8 @@ Request.prototype.init = function (options) {
     self._callback = self.callback
     self.callback = function () {
       if (self._callbackCalled) return // Print a warning maybe?
-      self._callback.apply(self, arguments)
       self._callbackCalled = true
+      self._callback.apply(self, arguments)
     }
     self.on('error', self.callback.bind())
     self.on('complete', self.callback.bind(self, null))


### PR DESCRIPTION
In the case that the client callback passed into request throws an error, the request callback may get called twice. Setting request's _callbackCalled flag before invoking the callback protects against this. 

See here for some background:
https://github.com/visionmedia/mocha/issues/755
https://github.com/mikeal/request/issues/330

Here is a simple mocha testcase that shows one example of this happening. In this case, i'm forcing the issue by using a url that request will fail to fetch, and then throwing an error in the callback. 

```
var request = require('request');

function testFunction(requestOptions, onCompletion) {

    var hasBeenCalled = false;

    request(requestOptions, function (error) {
        if (hasBeenCalled) {
            console.log('WARNING multiple callback');
        }
        hasBeenCalled = true;

        throw new Error('whoops');

        onCompletion(error);
    });
}

describe('testFunction', function () {
    it('should not invoke the request callback twice', function (done) {
        testFunction({url:'http://localhost:6789'}, done);
    });
});
```
