### PR TITLE
Convenience method for PATCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The first argument can be either a url or an options object. The only required o
 * `qs` - object containing querystring values to be appended to the uri
 * `method` - http method, defaults to GET
 * `headers` - http headers, defaults to {}
-* `body` - entity body for POST and PUT requests. Must be buffer or string.
+* `body` - entity body for PATCH, POST and PUT requests. Must be buffer or string.
 * `form` - when passed an object this will set `body` but to a querystring representation of value and adds `Content-type: application/x-www-form-urlencoded; charset=utf-8` header. When passed no option a FormData instance is returned that will be piped to request.
 * `auth` - A hash containing values `user` || `username`, `password` || `pass`, and `sendImmediately` (optional).  See documentation above.
 * `json` - sets `body` but to JSON representation of value and adds `Content-type: application/json` header.  Additionally, parses the response body as json.
@@ -226,6 +226,14 @@ Same as request() but defaults to `method: "PUT"`.
 
 ```javascript
 request.put(url)
+```
+
+### request.patch
+
+Same as request() but defaults to `method: "PATCH"`.
+
+```javascript
+request.patch(url)
 ```
 
 ### request.post

--- a/main.js
+++ b/main.js
@@ -597,6 +597,7 @@ Request.prototype.start = function () {
         redirectTo = response.headers.location
       } else if (self.followRedirect) {
         switch (self.method) {
+          case 'PATCH':
           case 'PUT':
           case 'POST':
           case 'DELETE':
@@ -1087,7 +1088,7 @@ Request.prototype.destroy = function () {
   if (!this._ended) this.end()
 }
 
-// organize params for post, put, head, del
+// organize params for patch, post, put, head, del
 function initParams(uri, options, callback) {
   if ((typeof options === 'function') && !callback) callback = options
   if (options && typeof options === 'object') {
@@ -1143,6 +1144,7 @@ request.defaults = function (options, requester) {
   }
   var de = def(request)
   de.get = def(request.get)
+  de.patch = def(request.patch)
   de.post = def(request.post)
   de.put = def(request.put)
   de.head = def(request.head)
@@ -1173,6 +1175,11 @@ request.post = function (uri, options, callback) {
 request.put = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PUT'
+  return request(params.uri || null, params.options, params.callback)
+}
+request.patch = function (uri, options, callback) {
+  var params = initParams(uri, options, callback)
+  params.options.method = 'PATCH'
   return request(params.uri || null, params.options, params.callback)
 }
 request.head = function (uri, options, callback) {

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -36,6 +36,21 @@ s.listen(s.port, function () {
     counter += 1;
   });
 
+  s.on('/patch', function (req, resp) {
+    assert.equal(req.headers.foo, 'bar');
+    assert.equal(req.headers['content-type'], null);
+    assert.equal(req.method, 'PATCH')
+    resp.writeHead(200, {'Content-Type': 'application/json'});
+    resp.end(JSON.stringify({foo:'bar'}));
+  });
+
+  // test post(string, object, function)
+  request.defaults({headers:{foo:"bar"}}).patch(s.url + '/patch', {json: true}, function (e, r, b){
+    if (e) throw e;
+    assert.deepEqual('bar', b.foo);
+    counter += 1;
+  });
+
   s.on('/post-body', function (req, resp) {
     assert.equal(req.headers.foo, 'bar');
     assert.equal(req.headers['content-type'], 'application/json');


### PR DESCRIPTION
This adds a convenience method for the PATCH HTTP method defined in [RFC 5789](https://tools.ietf.org/html/rfc5789).
