### PR TITLE
Increment major version due to API change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "util",
     "utility"
   ],
-  "version": "2.14.1",
+  "version": "3.0.0",
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
New version of #424 that tracks the changes to master.

The new auth API changes are not backwards compatible, which I discovered trying to use the current master README against the 2.12 release.

Semantic Versioning demains that backwards incompatible changes result in a new major version. You might not be currently applying semantic versioning to this project, but I would strongly recommend it.

Alternatively, you could patch the code to continue to accept "user:pass" string as auth parameters. In this case you would only need to increment the minor version to 2.13, to indicate the presence of the new "auth" api.
