### PR TITLE
Use Date.now() instead of (new Date()).getTime()

### DIFF
--- a/main.js
+++ b/main.js
@@ -984,7 +984,7 @@ Request.prototype.oauth = function (_oauth) {
   for (var i in form) oa[i] = form[i]
   for (var i in _oauth) oa['oauth_'+i] = _oauth[i]
   if (!oa.oauth_version) oa.oauth_version = '1.0'
-  if (!oa.oauth_timestamp) oa.oauth_timestamp = Math.floor( (new Date()).getTime() / 1000 ).toString()
+  if (!oa.oauth_timestamp) oa.oauth_timestamp = Math.floor( Date.now() / 1000 ).toString()
   if (!oa.oauth_nonce) oa.oauth_nonce = uuid().replace(/-/g, '')
   
   oa.oauth_signature_method = 'HMAC-SHA1'


### PR DESCRIPTION
Date.now() is shown to be faster than (new Date()).getTime()

http://jsperf.com/date-now-vs-new-date-gettime
