### PR TITLE
Changing so if Accept header is explicitly set, sending json does not ov...

### DIFF
--- a/index.js
+++ b/index.js
@@ -963,15 +963,21 @@ Request.prototype.multipart = function (multipart) {
   return self
 }
 Request.prototype.json = function (val) {
-  this.setHeader('accept', 'application/json')
+  var self = this;
+  var setAcceptHeader = function() {
+  	if (!self.headers['accept'] && !self.headers['Accept']) {
+			  self.setHeader('accept', 'application/json')
+		}
+	}
+  setAcceptHeader();
   this._json = true
   if (typeof val === 'boolean') {
     if (typeof this.body === 'object') {
-      this.setHeader('content-type', 'application/json')
+      setAcceptHeader();
       this.body = safeStringify(this.body)
     }
   } else {
-    this.setHeader('content-type', 'application/json')
+    setAcceptHeader();
     this.body = safeStringify(val)
   }
   return this


### PR DESCRIPTION
This change handles a case where the user has set the Accept header (other than application/json) for the request and wants to send JSON. Accept header is not overwritten.
A valid use case for this is a REST API where the API expects a custom Accept header for versioning reasons (i.e. application/vnd.custom.v1+json)
