### PR TITLE
Check hasOwnProperty in prototype.qs

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ var http = require('http')
   , Cookie = require('cookie-jar')
   , CookieJar = Cookie.Jar
   , cookieJar = new CookieJar
+
+  , _ = require('underscore')
   ;
 
 try {
@@ -906,12 +908,11 @@ Request.prototype.qs = function (q, clobber) {
   var base
   if (!clobber && this.uri.query) base = qs.parse(this.uri.query)
   else base = {}
-  
-  for (var i in q) {
-    if (q.hasOwnProperty(i)) {
-      base[i] = q[i]
-    }
-  }
+ 
+  // Sadly _.extend also copies the prototypes
+  _.each(q, function(v, k, l) {
+    base[k] = v;
+  });
 
   if (qs.stringify(base) === ''){
     return this


### PR DESCRIPTION
Hi,

I'm working on a project where some functions get added to Object's prototype.

When request.prototype.qs copied over params into "base" this meant it also added these functions, and so all my requests with qs options had &extraFunctionName&anotherExtra... on the end, which made some APIs we were using very unhappy.

This fix just adds a hasOwnProperty check inside the for loop.

Thanks,
Thomas
