### PR TITLE
Empty response body (3-rd argument) must be passed to callback as an empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -853,6 +853,9 @@ Request.prototype.onResponse = function (response) {
           } catch (e) {}
         }
         debug('emitting complete', self.uri.href)
+        if(response.body == undefined && !self._json) {
+          response.body = "";
+        }
         self.emit('complete', response, response.body)
       })
     }

--- a/tests/test-emptyBody.js
+++ b/tests/test-emptyBody.js
@@ -1,0 +1,20 @@
+var request = require('../index')
+  , http = require('http')
+  , assert = require('assert')
+  ;
+
+var s = http.createServer(function (req, resp) {
+  resp.statusCode = 200
+  resp.end('')
+}).listen(8080, function () {
+  var r = request('http://localhost:8080', function (e, resp, body) {
+    assert.equal(resp.statusCode, 200)
+    assert.equal(body, "")
+
+    var r2 = request({ url: 'http://localhost:8080', json: {} }, function (e, resp, body) {
+	    assert.equal(resp.statusCode, 200)
+	    assert.equal(body, undefined)
+	    s.close()
+ 	 });
+  })
+})


### PR DESCRIPTION
Docs sates: "The callback argument gets 3 arguments. ... The third is the response body String or Buffer."
If response has an empty body (Content-length is 0) third argument is `undefined`, not `String` nor `Buffer`.

The "edge case" is JSON response. Empty body can't be parsed to something convinient, so, this case still results in `undefined` (may be it must be handled different way?).
