### PR TITLE
Allow not forwarding certain headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,8 @@ Request.prototype.init = function (options) {
   if (!self.pool && self.pool !== false) self.pool = globalPool
   self.dests = self.dests || []
   self.__isRequestRequest = true
-  
+  self.forwardedHeaderBlacklist = self.forwardedHeaderBlacklist || {};
+
   // Protect against double callback
   if (!self._callback && self.callback) {
     self._callback = self.callback
@@ -887,7 +888,9 @@ Request.prototype.pipeDest = function (dest) {
   }
   if (dest.setHeader) {
     for (var i in response.headers) {
-      dest.setHeader(i, response.headers[i])
+      if (!dest.forwardedHeaderBlacklist[i]) {
+        dest.setHeader(i, response.headers[i])
+      }
     }
     dest.statusCode = response.statusCode
   }


### PR DESCRIPTION
I'm using request to pipe a stream between a remote Web host and a file upload API. The API in question uses ETag as an MD5 hash, and when using request to pipe directly to the API endpint, the automatically forwarded Etag causes the API to fail.

One possible solution (I'm very open to discussion) is to allow explicitly opting out forwarded headers. That's what I've implemented here.

You could also do wholesale disallow (except for content-length, type, etc) or some other solution (whitelist?)

Thoughts?

Sample code:

``` Javascript
request('http://my.server.with.etag.com/foo.jpg').pipe(request({
    method: 'PUT',
    uri: 'http://somewhere.else',
    forwardedHeaderBlacklist: {
        etag: true
    }
}, callback);
```
