### PR TITLE
Added transformRedirects option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The first argument can be either a url or an options object. The only required o
 * `multipart` - (experimental) array of objects which contains their own headers and `body` attribute. Sends `multipart/related` request. See example below.
 * `followRedirect` - follow HTTP 3xx responses as redirects. defaults to true.
 * `followAllRedirects` - follow non-GET HTTP 3xx responses as redirects. defaults to false.
+* `transformRedirects` - when passed a function, any redirects will have their urls sent as the first parameter into this function and the return value will be used as the new url
 * `maxRedirects` - the maximum number of redirects to follow, defaults to 10.
 * `encoding` - Encoding to be used on `setEncoding` of response data. If set to `null`, the body is returned as a Buffer.
 * `pool` - A hash object containing the agents for these requests. If omitted this request will use the global pool which is set to node's default maxSockets.

--- a/index.js
+++ b/index.js
@@ -749,6 +749,10 @@ Request.prototype.onResponse = function (response) {
       redirectTo = url.resolve(self.uri.href, redirectTo)
     }
 
+    if(self.transformRedirects) {
+      redirectTo=self.transformRedirects(redirectTo);
+    }
+
     var uriPrev = self.uri
     self.uri = url.parse(redirectTo)
 


### PR DESCRIPTION
This option allows you to alter redirects before they are executed.  This would mostly be used when you don't know the final url you are trying to hit, but want to append query parameters onto it.  Using this function has the advantage over catching each individual request and appending the query yourself in both ease of use and taking advantage of any optimizations/error handling request already has in place for redirects.

Example usage:

``` javascript
var search="?query=somedata";
request({
  url: "http://www.test.com"+search,
  followRedirect: true,
  transformRedirects: function(url) {
    return url+search;
  }
},function(error,response,body) {
  res.send(body);
});
```

For comparison, this is the current alternative I am using:

``` javascript
function requestTransform(options,transform,callback) {
  request(options,function(error,response,body) {
    var redirect=response.headers.location;
    if(redirect!==undefined) {
      options.url=transform(redirect);
      requestTransform(options,transform,callback);
    }
    else {
      callback(error,response,body);
    }
  })
}
```
