### PR TITLE
Moving response emit above setHeaders on destination streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -795,6 +795,8 @@ Request.prototype.onResponse = function (response) {
       }
     }
 
+    self.emit('response', response)
+
     self.dests.forEach(function (dest) {
       self.pipeDest(dest)
     })
@@ -808,8 +810,6 @@ Request.prototype.onResponse = function (response) {
       self.emit("end", chunk)
     })
     response.on("close", function () {self.emit("close")})
-
-    self.emit('response', response)
 
     if (self.callback) {
       var buffer = []


### PR DESCRIPTION
This change proposes moving `self.emit('response', response);` above the loop that ultimately calls self.pipeDest() on each of the destination streams.

This is to allow modifying the response headers before they are cloned to the destination Requests.
