### PR TITLE
Update internal path state on post-creation QS changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -930,6 +930,7 @@ Request.prototype.qs = function (q, clobber) {
 
   this.uri = url.parse(this.uri.href.split('?')[0] + '?' + qs.stringify(base))
   this.url = this.uri
+  this.path = this.uri.path
 
   return this
 }

--- a/tests/test-qs.js
+++ b/tests/test-qs.js
@@ -32,3 +32,11 @@ var req5 = request.get({ uri: 'http://www.google.com', qs: {}})
 setTimeout(function(){
 	assert.equal('/', req5.path)
 }, 1)
+
+
+// Test modifying the qs after creating the request
+var req6 = request.get({ uri: 'http://www.google.com', qs: {}});
+req6.qs({ q: "test" });
+process.nextTick(function() {
+    assert.equal('/?q=test', req6.path);
+});


### PR DESCRIPTION
If the querystring is changed _after_ creating a request object, update
the internal path to ensure that the proper request is sent over the
wire.
