### PR TITLE
tunnel-agent ~0.5.0 breaks npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "oauth-sign": "~0.3.0",
     "http-signature": "~0.9.1",
     "forever-agent": "~0.3.0",
-    "tunnel-agent": "~0.5.0",
+    "tunnel-agent": "~0.2.0",
     "json-stringify-safe": "~3.0.0",
     "qs": "~0.5.4"
   },


### PR DESCRIPTION
The previous pull request put a non-existent version of tunnel-agent here. The real version should be 0.2.0, 0.3.0 or 0.3.1. We reverted to 0.2.0 as the last known working configuration.
