### PR TITLE
Fix custom request handler to work with other request methods (put, post, etc)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1283,26 +1283,20 @@ request.get = request
 request.post = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'POST'
-  if(typeof params.options._requester === 'function') {
-    request = params.options._requester
-  }
-  return request(params.uri || null, params.options, params.callback)
+  var req = params.options._requester || request
+  return req(params.uri || null, params.options, params.callback)
 }
 request.put = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PUT'
-  if(typeof params.options._requester === 'function') {
-    request = params.options._requester
-  }
-  return request(params.uri || null, params.options, params.callback)
+  var req = params.options._requester || request
+  return req(params.uri || null, params.options, params.callback)
 }
 request.patch = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PATCH'
-  if(typeof params.options._requester === 'function') {
-    request = params.options._requester
-  }
-  return request(params.uri || null, params.options, params.callback)
+  var req = params.options._requester || request
+  return req(params.uri || null, params.options, params.callback)
 }
 request.head = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
@@ -1313,18 +1307,14 @@ request.head = function (uri, options, callback) {
       params.options.multipart) {
     throw new Error("HTTP HEAD requests MUST NOT include a request body.")
   }
-  if(typeof params.options._requester === 'function') {
-    request = params.options._requester
-  }
-  return request(params.uri || null, params.options, params.callback)
+  var req = params.options._requester || request
+  return req(params.uri || null, params.options, params.callback)
 }
 request.del = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'DELETE'
-  if(typeof params.options._requester === 'function') {
-    request = params.options._requester
-  }
-  return request(params.uri || null, params.options, params.callback)
+  var req = params.options._requester || request
+  return req(params.uri || null, params.options, params.callback)
 }
 request.jar = function () {
   return new CookieJar


### PR DESCRIPTION
The custom handler implementation was only partially finished. When creating a custom handler such as:

var req = request.defaults({}, customHandler);

Only req(), req.get(), req.del() would use the custom handler. req.put(), req.post(), req.patch(), and req.head() would not. This fixes the problem using the same solution that existed, only filling in the other methods that were missed.
