### PR TITLE
Allow explicitly empty user field for basic authentication.

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,7 +303,7 @@ Request.prototype.init = function (options) {
 
   if (options.auth) {
     self.auth(
-      options.auth.user || options.auth.username,
+      (options.auth.user==="") ? options.auth.user : (options.auth.user || options.auth.username ),
       options.auth.pass || options.auth.password,
       options.auth.sendImmediately)
   }

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -14,6 +14,8 @@ var basicServer = http.createServer(function (req, res) {
   if (req.headers.authorization) {
     if (req.headers.authorization == 'Basic ' + new Buffer('test:testing2').toString('base64')) {
       ok = true;
+    } else if ( req.headers.authorization == 'Basic ' + new Buffer(':apassword').toString('base64')) {
+      ok = true;
     } else {
       // Bad auth header, don't send back WWW-Authenticate header
       ok = false;
@@ -106,6 +108,24 @@ var tests = [
       assert.equal(numBasicRequests, 6);
       next();
     });
+  },
+
+  function(next) {
+    assert.doesNotThrow( function() {
+      request({
+        'method': 'GET',
+        'uri': 'http://localhost:6767/allow_empty_user/',
+        'auth': {
+          'user': '',
+          'pass': 'apassword',
+          'sendImmediately': false
+        }
+      }, function(error, res, body ) {
+        assert.equal(res.statusCode, 200);
+        assert.equal(numBasicRequests, 8);
+        next();
+      });
+    })
   }
 ];
 


### PR DESCRIPTION
The heroku api expects an empty username for authentication. request works OK if you provide that via a "username" field in the auth options, however it raises an exception if you provide an empty "user" field. Simply checking to see if the "user" field is the empty string avoids this.
