### PR TITLE
The exported request function doesn't have an auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ form.append('remote_file', request('http://google.com/doodle.png'))
 ## HTTP Authentication
 
 ```javascript
-request.auth('username', 'password', false).get('http://some.server.com/');
+request.get('http://some.server.com/').auth('username', 'password', false);
 // or
 request.get('http://some.server.com/', {
   'auth': {


### PR DESCRIPTION
Looks like you need to create a Request instance before calling auth.

Without this change, following the readme leads to this:

```
     TypeError: Object function request(uri, options, callback) {
  if (typeof uri === 'undefined') throw new Error('undefined is not a valid uri or options object.')
  if ((typeof options === 'function') && !callback) callback = options
  if (options && typeof options === 'object') {
    options.uri = uri
  } else if (typeof uri === 'string') {
    options = {uri:uri}
  } else {
    options = uri
  }

  options = copy(options)

  if (callback) options.callback = callback
  var r = new Request(options)
  return r
} has no method 'auth'
```
