### PR TITLE
Expose Request class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1233,6 +1233,8 @@ function request (uri, options, callback) {
 
 module.exports = request
 
+request.Request = Request;
+
 request.debug = process.env.NODE_DEBUG && /request/.test(process.env.NODE_DEBUG)
 
 request.initParams = initParams


### PR DESCRIPTION
This exposes the Request class so that the following is possible:

``` javascript
var request = require('request');

// disable strictSSL globally
request.Request.prototype.strictSSL = false;
```

Currently, this is only possible with `request.defaults()`, which is rather cumbersome when request is used in a lot of different places.
