### PR TITLE
Update http-signature version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "json-stringify-safe": "~4.0.0",
     "forever-agent": "~0.5.0",
     "tunnel-agent": "~0.3.0",
-    "http-signature": "~0.9.11",
+    "http-signature": "~0.10.0",
     "hawk": "~0.13.0",
     "aws-sign": "~0.3.0",
     "oauth-sign": "~0.3.0",


### PR DESCRIPTION
Going from the 0.9 to 0.10 series includes a protocol incompatible change. The change was made by me in the spec and node code due to a security issue: https://github.com/joyent/node-http-signature/issues/10. Considering how new HTTP Signature support is and the limited use of this spec I think it's safe to potentially cause breakage for any limited users of this feature.
