### PR TITLE
Fix redirections

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ Request.prototype.init = function (options) {
     self.on('complete', self.callback.bind(self, null))
   }
 
-  if (self.url) {
+  if (self.url && !self.uri) {
     // People use this property instead all the time so why not just support it.
     self.uri = self.url
     delete self.url


### PR DESCRIPTION
# The problem

Request  module was ignoring the new location
# Why:

when there are a new redirection  self.uri is set  to the new location

``` javascript
self.uri = url.parse(redirectTo)
```

after that again , call  the init function with this

``` javascript
if (self.url ) {
    // People use this property instead all the time so why not just support it.
    self.uri = self.url
    delete self.url
  }
```

so the location is ignored, have not effect, and the second request is done to the original url
# solution

``` javascript
if (self.url && !self.uri) {
    // People use this property instead all the time so why not just support it.
    self.uri = self.url
    delete self.url
  }
```

Regards
