### PR TITLE
Global cookie jar disabled by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The first argument can be either a url or an options object. The only required o
 * `oauth` - Options for OAuth HMAC-SHA1 signing, see documentation above.
 * `hawk` - Options for [Hawk signing](https://github.com/hueniverse/hawk). The `credentials` key must contain the necessary signing info, [see hawk docs for details](https://github.com/hueniverse/hawk#usage-example).
 * `strictSSL` - Set to `true` to require that SSL certificates be valid. Note: to use your own certificate authority, you need to specify an agent that was created with that ca as an option.
-* `jar` - Set to `false` if you don't want cookies to be remembered for future use or define your custom cookie jar (see examples section)
+* `jar` - Set to `true` if you want cookies to be remembered for future use, or define your custom cookie jar (see examples section)
 * `aws` - object containing aws signing information, should have the properties `key` and `secret` as well as `bucket` unless you're specifying your bucket as part of the path, or you are making a request that doesn't use a bucket (i.e. GET Services)
 * `httpSignature` - Options for the [HTTP Signature Scheme](https://github.com/joyent/node-http-signature/blob/master/http_signing.md) using [Joyent's library](https://github.com/joyent/node-http-signature). The `keyId` and `key` properties must be specified. See the docs for other options.
 * `localAddress` - Local interface to bind for network connections.
@@ -314,10 +314,10 @@ request.jar()
     }
   )
 ```
-Cookies are enabled by default (so they can be used in subsequent requests). To disable cookies set jar to false (either in defaults or in the options sent).
+Cookies are disabled by default (else, they would be used in subsequent requests). To enable cookies set jar to true (either in defaults or in the options sent).
 
 ```javascript
-var request = request.defaults({jar: false})
+var request = request.defaults({jar: true})
 request('http://www.google.com', function () {
   request('http://images.google.com')
 })

--- a/index.js
+++ b/index.js
@@ -673,8 +673,13 @@ Request.prototype.onResponse = function (response) {
   }
 
   var addCookie = function (cookie) {
-    if (self._jar) self._jar.add(new Cookie(cookie))
-    else cookieJar.add(new Cookie(cookie))
+    if (self._jar){
+      if(self._jar.add){
+        self._jar.add(new Cookie(cookie))  
+      }
+      else cookieJar.add(new Cookie(cookie))      
+    } 
+    
   }
 
   if (response.headers['set-cookie'] && (!self._disableCookies)) {
@@ -1140,11 +1145,11 @@ Request.prototype.jar = function (jar) {
     this.originalCookieHeader = this.headers.cookie
   }
 
-  if (jar === false) {
+  if (!jar) {
     // disable cookies
     cookies = false
     this._disableCookies = true
-  } else if (jar) {
+  } else if (jar && jar.get) {
     // fetch cookie from the user defined cookie jar
     cookies = jar.get({ url: this.uri.href })
   } else {

--- a/tests/test-follow-all.js
+++ b/tests/test-follow-all.js
@@ -26,6 +26,7 @@ server.listen(6767);
 
 request.post({ url: 'http://localhost:6767/foo',
                followAllRedirects: true,
+               jar: true,
                form: { foo: 'bar' } }, function (er, req, body) {
   if (er) throw er;
   assert.equal(body, 'ok: 5');


### PR DESCRIPTION
As per #571, it's dangerous for the global cookie jar to be on by default. This commit disables that behaviour. To use the global cookie jar, use jar:true. 

I think I've got this right, but I'd appreciate a code review. 

Thanks!
