### PR TITLE
Emit complete event when there is no callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -891,6 +891,16 @@ Request.prototype.onResponse = function (response) {
         self.emit('complete', response, response.body)
       })
     }
+    //if no callback
+    else{
+      self.on("end", function () {
+        if (self._aborted) {
+          debug('aborted', self.uri.href)
+          return
+        }
+        self.emit('complete', response);
+      });
+    }
   }
   debug('finish init function', self.uri.href)
 }


### PR DESCRIPTION
Following issue #575, a simple fix so that request emit a `complete` event even if there is no callback. However it has come to my attention that the number of parameters has to be different when doing so, since we are streaming, we do not pass a body to the event receiver.
