### PR TITLE
Global agent is being used when pool is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -563,7 +563,7 @@ Request.prototype.getAgent = function () {
     }
   }
 
-  if (!poolKey && Object.keys(options).length === 0 && this.httpModule.globalAgent) {
+  if (this.pool === globalPool && !poolKey && Object.keys(options).length === 0 && this.httpModule.globalAgent) {
     // not doing anything special.  Use the globalAgent
     return this.httpModule.globalAgent
   }


### PR DESCRIPTION
When making a request of the form

```
request({
  uri: "http://localhost:4000",
  pool: {
    maxSockets: 1
  }
}, function(error, response, body) {
});
```

this.agent is still being set to this.httpModule.globalAgent, and then the global maxSockets is being overwritten with whatever is specified for the pool, which, in this case, is 1.

I'm not sure if this is the best way to check for this, but this change does fix the issue while still leaving an undefined pool as using the global agent and a false agent as not using a pool.
