### PR TITLE
update twitter api url to v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ request.post({url:url, oauth:oauth}, function (e, r, body) {
         , token: perm_token.oauth_token
         , token_secret: perm_token.oauth_token_secret
         }
-      , url = 'https://api.twitter.com/1/users/show.json?'
+      , url = 'https://api.twitter.com/1.1/users/show.json?'
       , params =
         { screen_name: perm_token.screen_name
         , user_id: perm_token.user_id


### PR DESCRIPTION
The Twitter REST API v1 is no longer active. Updated the example to use 1.1
