### PR TITLE
Wrong oauth signature when multiple same param keys exist

### DIFF
--- a/request.js
+++ b/request.js
@@ -1106,32 +1106,20 @@ Request.prototype.hawk = function (opts) {
 }
 
 Request.prototype.oauth = function (_oauth) {
-  var form, params = ''
+  var form, query
   if (this.hasHeader('content-type') &&
       this.getHeader('content-type').slice(0, 'application/x-www-form-urlencoded'.length) ===
         'application/x-www-form-urlencoded'
      ) {
-     params = this.body
+    form = this.body
   }
   if (this.uri.query) {
-    params = params ? params + '&' + this.uri.query : this.uri.query
+    query = this.uri.query
   }
 
-  form = qs.parse(params)
   var oa = {}
-  for (var i in form) oa[i] = form[i]
-
-  // logic from node's querystring.parse
-  for (var i in _oauth) {
-    var p = 'oauth_'+i;
-    if (!oa.hasOwnProperty(p)) {
-      oa[p] = _oauth[i]
-    } else if (Array.isArray(oa[p])) {
-      oa[p].push(_oauth[i])
-    } else {
-      oa[p] = [_oauth[i], oa[p]]
-    }
-  }
+  for (var i in _oauth) oa['oauth_'+i] = _oauth[i]
+  if ('oauth_realm' in oa) delete oa.oauth_realm
 
   if (!oa.oauth_version) oa.oauth_version = '1.0'
   if (!oa.oauth_timestamp) oa.oauth_timestamp = Math.floor( Date.now() / 1000 ).toString()
@@ -1143,22 +1131,14 @@ Request.prototype.oauth = function (_oauth) {
   delete oa.oauth_consumer_secret
   var token_secret = oa.oauth_token_secret
   delete oa.oauth_token_secret
-  var timestamp = oa.oauth_timestamp
 
   var baseurl = this.uri.protocol + '//' + this.uri.host + this.uri.pathname
-  var signature = oauth.hmacsign(this.method, baseurl, oa, consumer_secret, token_secret)
+  var params = qs.parse([].concat(query, form, qs.stringify(oa)).join('&'))
+  var signature = oauth.hmacsign(this.method, baseurl, params, consumer_secret, token_secret)
 
-  // oa.oauth_signature = signature
-  for (var i in form) {
-    if ( i.slice(0, 'oauth_') in _oauth) {
-      // skip
-    } else {
-      delete oa['oauth_'+i]
-      if (i !== 'x_auth_mode') delete oa[i]
-    }
-  }
-  oa.oauth_timestamp = timestamp
-  var authHeader = 'OAuth '+Object.keys(oa).sort().map(function (i) {return i+'="'+oauth.rfc3986(oa[i])+'"'}).join(',')
+  var realm = _oauth.realm ? 'realm="' + _oauth.realm + '",' : '';
+  var authHeader = 'OAuth ' + realm +
+    Object.keys(oa).sort().map(function (i) {return i+'="'+oauth.rfc3986(oa[i])+'"'}).join(',')
   authHeader += ',oauth_signature="' + oauth.rfc3986(signature) + '"'
   this.setHeader('Authorization', authHeader)
   return this

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -123,6 +123,7 @@ var rfc5849 = request.post(
     , timestamp: "137131201"
     , consumer_secret: "j49sk3j29djd"
     , token_secret: "dh893hdasih9"
+    , realm: 'Example'
     }
   , form: {
       c2: '',
@@ -133,7 +134,7 @@ var rfc5849 = request.post(
 setTimeout(function () {
   console.log(getsignature(rfc5849))
   // different signature in rfc5849 because request sets oauth_version by default
-  assert.equal('0+ZuE+gHTWozhkGpm2vHSdGF/bs=', getsignature(rfc5849))
+  assert.equal('OB33pYjWAnf+xtOHN4Gmbdil168=', getsignature(rfc5849))
   rfc5849.abort()
 }, 1)
 


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2,
when normalizing parameters to calculate base string for oauth signature,
oauth client should handle multiple pareters with same key name.

For example: (quotes from RFC5849)
when build base string for following request,

```
 POST /request?b5=%3D%253D&a3=a&c%40=&a2=r%20b HTTP/1.1
       Host: example.com
       Content-Type: application/x-www-form-urlencoded
       Authorization: OAuth realm="Example",
                      oauth_consumer_key="9djdj82h48djs9d2",
                      oauth_token="kkk9d7dh3k39sjv7",
                      oauth_signature_method="HMAC-SHA1",
                      oauth_timestamp="137131201",
                      oauth_nonce="7d8f3e4a",
                      oauth_signature="djosJKDKJSD8743243%2Fjdk33klY%3D"

       c2&a3=2+q
```

client should include two 'a3' param keys(in query string and in body) and its values.

Currently request can't do this because it builds a parameter map as object and pass it to oauth-sign.

For your information, http://oauth.googlecode.com/svn/code/javascript/oauth.js builds a parameter map as array of [key, value].
