### PR TITLE
Change `secureOptions' to `secureProtocol' for HTTPS request

### DIFF
--- a/request.js
+++ b/request.js
@@ -539,9 +539,9 @@ Request.prototype.getAgent = function () {
       poolKey += options.ciphers
     }
 
-    if (options.secureOptions) {
+    if (options.secureProtocol) {
       if (poolKey) poolKey += ':'
-      poolKey += options.secureOptions
+      poolKey += options.secureProtocol
     }
   }
 


### PR DESCRIPTION
to meet the nodejs https module
see: http://nodejs.org/api/https.html#https_https_request_options_callback

or the following error happens when requesting to some hosts through https:

```
[Error: 140735221531008:error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol:../deps/openssl/openssl/ssl/s23_clnt.c:766:
]
```
