### PR TITLE
store initial request uri in request object

### DIFF
--- a/request.js
+++ b/request.js
@@ -139,6 +139,11 @@ Request.prototype.init = function (options) {
     if (typeof self.uri == "string") self.uri = url.parse(self.uri)
   }
 
+  // set the initial uri on the first init() call
+  if (typeof (self.initialUri) === 'undefined') {
+    self.initialUri = self.uri;
+  }
+
   if (self.strictSSL === false) {
     self.rejectUnauthorized = false
   }


### PR DESCRIPTION
if you are doing simultaneous http requests and redirects are involved, there is no hint to the initial request uri inside the response callback function.

this commit adds the attribute initialUri to the request object. it will be set on the first call of the init() function. unlike the attribute uri, it will not be overwritten later.
