### PR TITLE
Request.multipart no longer crashes when header 'Content-type' present

### DIFF
--- a/request.js
+++ b/request.js
@@ -989,7 +989,8 @@ Request.prototype.multipart = function (multipart) {
   if (!self.hasHeader('content-type')) {
     self.setHeader('content-type', 'multipart/related; boundary=' + self.boundary)
   } else {
-    self.setHeader('content-type', self.headers['content-type'].split(';')[0] + '; boundary=' + self.boundary)
+    var headerName = self.hasHeader('content-type');
+    self.setHeader(headerName, self.headers[headerName].split(';')[0] + '; boundary=' + self.boundary)
   }
 
   if (!multipart.forEach) throw new Error('Argument error, options.multipart.')


### PR DESCRIPTION
Request.multipart used to crash when options contained a header 'Content-type' which is not purely lowercase. That is because hasHeader is case-insensitive and returns true, then the split method gets applied to undefined and crashes the application.

One could argue that headers should be spelled using only lowercase. However, mixed case headers used to work with a previous version of request, thus I suggest to incorporate this patch to ensure that legacy code does not suddenly crash after updating request.
