### PR TITLE
fix requester bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,14 @@ request.defaults = function (options, requester) {
   return de
 }
 
+function requester(params) {
+  if(typeof params.options._requester === 'function') {
+    return params.options._requester
+  } else {
+    return request
+  }
+}
+
 request.forever = function (agentOptions, optionsArg) {
   var options = {}
   if (optionsArg) {
@@ -109,17 +117,17 @@ request.get = request
 request.post = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'POST'
-  return request(params.uri || null, params.options, params.callback)
+  return requester(params)(params.uri || null, params.options, params.callback)
 }
 request.put = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PUT'
-  return request(params.uri || null, params.options, params.callback)
+  return requester(params)(params.uri || null, params.options, params.callback)
 }
 request.patch = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PATCH'
-  return request(params.uri || null, params.options, params.callback)
+  return requester(params)(params.uri || null, params.options, params.callback)
 }
 request.head = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
@@ -130,15 +138,13 @@ request.head = function (uri, options, callback) {
       params.options.multipart) {
     throw new Error("HTTP HEAD requests MUST NOT include a request body.")
   }
-  return request(params.uri || null, params.options, params.callback)
+
+  return requester(params)(params.uri || null, params.options, params.callback)
 }
 request.del = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'DELETE'
-  if(typeof params.options._requester === 'function') {
-    request = params.options._requester
-  }
-  return request(params.uri || null, params.options, params.callback)
+  return requester(params)(params.uri || null, params.options, params.callback)
 }
 request.jar = function () {
   return new CookieJar


### PR DESCRIPTION
the ability to wrap the callback wasn't available for verbs aside from GET and DELETE, so I made it work for all verbs
