### PR TITLE
Fix TypeError when calling request.cookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,9 @@
 //    limitations under the License.
 
 var optional = require('./lib/optional')
-  , Cookie = optional('tough-cookie')
-  , CookieJar = Cookie && Cookie.CookieJar
+  , cookie = optional('tough-cookie')
+  , Cookie = cookie && cookie.Cookie
+  , CookieJar = cookie && cookie.CookieJar
   , cookieJar = CookieJar && new CookieJar
 
   , copy = require('./lib/copy')


### PR DESCRIPTION
It looks like there is a bug when using the tough-cookie library.

https://npmjs.org/package/tough-cookie

From the source example:

var cookies = require('tough-cookie'); // note: not 'cookie', 'cookies' or 'node-cookie'
var Cookie = cookies.Cookie;
var cookie = Cookie.parse(header);
