### PR TITLE
README example is using old cookie jar api

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ OR
 ```javascript
 var j = request.jar()
 var cookie = request.cookie('your_cookie_here')
-j.add(cookie)
+j.setCookie(cookie, uri)
 request({url: 'http://www.google.com', jar: j}, function () {
   request('http://images.google.com')
 })


### PR DESCRIPTION
`j.add` is no longer with us. 
