### PR TITLE
Add note about JSON output body type

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The callback argument gets 3 arguments:
 
 1. An `error` when applicable (usually from [`http.ClientRequest`](http://nodejs.org/api/http.html#http_class_http_clientrequest) object)
 2. An [`http.IncomingMessage`](http://nodejs.org/api/http.html#http_http_incomingmessage) object
-3. The third is the `response` body (`String` or `Buffer`)
+3. The third is the `response` body (`String` or `Buffer`, or JSON object if the `json` option is supplied)
 
 ## Convenience methods
 


### PR DESCRIPTION
When PUTing/POSTing JSON using the `json` option, you might overlook the fact that Request will automatically parse the response as JSON before handing it back to the callback, thus causing confusion and heartbreak. Probably best to mention this behavior in all applicable places.
