### PR TITLE
Use Cookie.parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,5 +153,5 @@ request.jar = function () {
 request.cookie = function (str) {
   if (str && str.uri) str = str.uri
   if (typeof str !== 'string') throw new Error("The cookie function only accepts STRING as param")
-  return new Cookie(str)
+  return Cookie.parse(str)
 }

--- a/tests/test-cookies.js
+++ b/tests/test-cookies.js
@@ -1,0 +1,19 @@
+try {
+  require('tough-cookie')
+} catch (e) {
+  console.error('tough-cookie must be installed to run this test.')
+  console.error('skipping this test. please install tough-cookie and run again if you need to test this feature.')
+  process.exit(0)
+}
+
+var assert = require('assert')
+  , request = require('../index')
+
+
+function simpleCookieCreationTest() {
+  var cookie = request.cookie('foo=bar')
+  assert(cookie.key === 'foo')
+  assert(cookie.value === 'bar')
+}
+
+simpleCookieCreationTest()


### PR DESCRIPTION
Using `new Cookie(str)` doesn't actually set the attributes in the cookie. This is because Cookie takes in an object and in our case we only accept a string. Using `Cookie.parse` will set the appropriate properties on the cookie.

discussed in #743
