### PR TITLE
updating setCookie example to make it clear that the callback is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,12 @@ request('http://www.google.com', function () {
 ```
 OR
 
+Note that `setCookie` requires at least three parameters, and the last is required to be a callback.
+
 ```javascript
 var j = request.jar()
 var cookie = request.cookie('your_cookie_here')
-j.setCookie(cookie, uri)
+j.setCookie(cookie, uri, function (err, cookie){})
 request({url: 'http://www.google.com', jar: j}, function () {
   request('http://images.google.com')
 })


### PR DESCRIPTION
`setCookie` requires a callback as the last parameter.

discussed in #743
