### PR TITLE
require aws-sign2

### DIFF
--- a/request.js
+++ b/request.js
@@ -11,7 +11,7 @@ var optional = require('./lib/optional')
 
   , oauth = optional('oauth-sign')
   , hawk = optional('hawk')
-  , aws = optional('aws-sign')
+  , aws = optional('aws-sign2')
   , httpSignature = optional('http-signature')
   , uuid = require('node-uuid')
   , mime = require('mime')


### PR DESCRIPTION
package.json specifies aws-sign2 as an optional dependency yet request.js optionally requires aws-sign (which seems to be incompatible with the latest version).
