### PR TITLE
request.cookie() expects a string while tough-cookie.Cookie() expects an object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,8 +150,6 @@ request.del = function (uri, options, callback) {
 request.jar = function () {
   return new CookieJar
 }
-request.cookie = function (str) {
-  if (str && str.uri) str = str.uri
-  if (typeof str !== 'string') throw new Error("The cookie function only accepts STRING as param")
-  return new Cookie(str)
+request.cookie = function (options) {
+  return new Cookie(options)
 }


### PR DESCRIPTION
`request.cookie()` which constructs a new instance of a tough-cookie `Cookie()`
expects a string as a parameter and throws an error if something else is
passed.

However the constructor of `Cookie()` expects, if anything at all, an object for
configuration, see:
https://github.com/goinstant/node-cookie/blob/v0.9.15/lib/cookie.js#L530-L537

This patch removes the parameter check inside `request.cookie()` and just passes
on the optional options object to the `Cookie()` constructor.
