### PR TITLE
Pass error+body when json requests fail parsing

### DIFF
--- a/request.js
+++ b/request.js
@@ -884,7 +884,12 @@ Request.prototype.onResponse = function (response) {
         if (self._json) {
           try {
             response.body = JSON.parse(response.body)
-          } catch (e) {}
+          } catch (e) {
+            e.body = response.body;
+            self.emit('error', e);
+            debug('JSON.parse error', self.uri.href)
+            return
+          }
         }
         debug('emitting complete', self.uri.href)
         if(response.body == undefined && !self._json) {


### PR DESCRIPTION
To safely use json requests, I need to be able to trust that error handling of unexpected non-json responses works. This passes back the JSON.parse error as a request failure, attatching the non-json to a data attribute of the error object.

Points to consider: should it substitute its own error message with a human-readable one mentioning the url, like a few of the others? Attach the url just as it now does the body? Fine as suggested?
