### PR TITLE
Upgrade tough-cookie to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mime": "~1.2.9"
   },
   "optionalDependencies": {
-    "tough-cookie": "~0.10.0",
+    "tough-cookie": "~0.11.0",
     "form-data": "~0.1.0",
     "tunnel-agent": "~0.3.0",
     "http-signature": "~0.10.0",


### PR DESCRIPTION
Fixes `removeCookie` (via https://github.com/goinstant/node-cookie/pull/14).  Thanks again @lalitkapoor!
