### PR TITLE
Added dependency badge for README file;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Request -- Simplified HTTP client
 
-[![NPM](https://nodei.co/npm/request.png)](https://nodei.co/npm/request/)
+[![NPM](https://nodei.co/npm/request.png)](https://nodei.co/npm/request/)[![Dependency Status](https://www.versioneye.com/nodejs/request/2.31.0/badge.png)](https://www.versioneye.com/nodejs/request/2.31.0)
 
 ## Super simple to use
 


### PR DESCRIPTION
I would like to add VersionEye dependency badge, which shows a current state of dependencies and when user clicks on badge, then he/she will see an additional metadata, that doesnt exists on npmjs page, for example previous versions, release cycle and  sub-dependencies.
