### PR TITLE
Provide ability to override content-type when `json` option used

### DIFF
--- a/request.js
+++ b/request.js
@@ -1033,12 +1033,15 @@ Request.prototype.json = function (val) {
   if (typeof val === 'boolean') {
     if (typeof this.body === 'object') {
       this.body = safeStringify(this.body)
-      self.setHeader('content-type', 'application/json')
+      if (!self.hasHeader('content-type'))
+        self.setHeader('content-type', 'application/json')
     }
   } else {
     this.body = safeStringify(val)
-    self.setHeader('content-type', 'application/json')
+    if (!self.hasHeader('content-type'))
+      self.setHeader('content-type', 'application/json')
   }
+
   return this
 }
 Request.prototype.getHeader = function (name, headers) {

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -52,6 +52,18 @@ s.listen(s.port, function () {
     assert.equal(req.headers.cookie, 'foo=bar; quux=baz')
   })
 
+  // Issue #784: override content-type when json is used
+  // https://github.com/mikeal/request/issues/784
+  createTest({
+    json: true,
+    method: 'POST',
+    headers: {'content-type': 'application/json; charset=UTF-8'},
+    body: {hello: 'my friend'}},function(req, res) {
+      assert.ok(req.headers['content-type']);
+      assert.equal(req.headers['content-type'], 'application/json; charset=UTF-8');
+    }
+  )
+
   // There should be no cookie header when neither headers.cookie nor a cookie jar is specified
   createTest({}, function (req, res) {
     assert.ok(!req.headers.cookie)


### PR DESCRIPTION
Fixes #784
