### PR TITLE
Adds content-length calculation when submitting forms using form-data li...

### DIFF
--- a/request.js
+++ b/request.js
@@ -389,6 +389,10 @@ Request.prototype.init = function (options) {
 
     if (self._form) {
       self.setHeaders(self._form.getHeaders())
+      try {
+        var length = self._form.getLengthSync()
+        self.setHeader('content-length', length)
+      } catch(e){}
       self._form.pipe(self)
     }
     if (self.body) {


### PR DESCRIPTION
...brary. This is related to issue 345.

The try/catch is needed because the sync content-length calculation cannot work for for streams. If used with streams, behavior is unchanged by this pull request.
