### PR TITLE
add some exposition to mpu example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ form.append('my_file', fs.createReadStream(path.join(__dirname, 'doodle.png'))
 form.append('remote_file', request('http://google.com/doodle.png'))
 
 // Just like always, `r` is a writable stream, and can be used as such (you have until nextTick to pipe it, etc.)
-// Alternatively, you can use the callback (that's what this example does-- see `optionalCallback` above).
+// Alternatively, you can provide a callback (that's what this example does-- see `optionalCallback` above).
 ```
 
 ## HTTP Authentication


### PR DESCRIPTION
This is re @mikeal's comment here:
https://github.com/mikeal/request/issues/345#issuecomment-13998419

This updates the mpu example in the README with some more comments and a callback to make the usage unmistakably clear for beginners and especially forgetful developers (e.g. @mikermcneil)
