### PR TITLE
added secureOptions back

### DIFF
--- a/request.js
+++ b/request.js
@@ -580,6 +580,7 @@ Request.prototype.getAgent = function () {
   if (this.ca) options.ca = this.ca
   if (this.ciphers) options.ciphers = this.ciphers
   if (this.secureProtocol) options.secureProtocol = this.secureProtocol
+  if (this.secureOptions) options.secureOptions = this.secureOptions
   if (typeof this.rejectUnauthorized !== 'undefined') options.rejectUnauthorized = this.rejectUnauthorized
 
   if (this.cert && this.key) {


### PR DESCRIPTION
It appears that secureOptions is an undocumented feature to fix issues with broken server. See joynet/node #5119
- fixes issue introduced in #666
