### PR TITLE
Test that browserify works with request.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "http-signature": "~0.10.0",
     "oauth-sign": "~0.3.0",
     "hawk": "~1.0.0",
+    "browserify" : "*",
     "aws-sign2": "~0.5.0"
   },
   "scripts": {

--- a/tests/test-browserify.js
+++ b/tests/test-browserify.js
@@ -1,0 +1,6 @@
+var browserify = require('browserify'),
+  assert = require('assert'),
+  b = browserify();
+
+b.add('..');
+b.bundle({}, assert.ifError)


### PR DESCRIPTION
This test is currently failing. It's kind of brutal because changes in browserify could cause it to fail without any code changes in request. I've tried to capture that by using `*` in the package.json file.

If there is a more constructive way for me to gripe, let me know!
