### PR TITLE
Outputs headers in Pascal-Case.

### DIFF
--- a/request.js
+++ b/request.js
@@ -190,11 +190,11 @@ Request.prototype.init = function (options) {
 
   self.setHost = false
   if (!self.hasHeader('host')) {
-    self.setHeader('host', self.uri.hostname)
+    self.setHeader('Host', self.uri.hostname)
     if (self.uri.port) {
       if ( !(self.uri.port === 80 && self.uri.protocol === 'http:') &&
            !(self.uri.port === 443 && self.uri.protocol === 'https:') )
-      self.setHeader('host', self.getHeader('host') + (':'+self.uri.port) )
+      self.setHeader('Host', self.getHeader('host') + (':'+self.uri.port) )
     }
     self.setHost = true
   }
@@ -293,7 +293,7 @@ Request.prototype.init = function (options) {
       self.auth(authPieces[0], authPieces.slice(1).join(':'), true)
     }
     if (self.proxy && self.proxy.auth && !self.hasHeader('proxy-authorization') && !self.tunnel) {
-      self.setHeader('proxy-authorization', "Basic " + toBase64(self.proxy.auth.split(':').map(function(item){ return querystring.unescape(item)}).join(':')))
+      self.setHeader('Proxy-Authorization', "Basic " + toBase64(self.proxy.auth.split(':').map(function(item){ return querystring.unescape(item)}).join(':')))
     }
 
 
@@ -321,7 +321,7 @@ Request.prototype.init = function (options) {
         length = self.body.length
       }
       if (length) {
-        if (!self.hasHeader('content-length')) self.setHeader('content-length', length)
+        if (!self.hasHeader('content-length')) self.setHeader('Content-Length', length)
       } else {
         throw new Error('Argument error, options.body.')
       }
@@ -367,7 +367,7 @@ Request.prototype.init = function (options) {
       if (self.ntick && self._started) throw new Error("You cannot pipe to this stream after the outbound request has started.")
       self.src = src
       if (isReadStream(src)) {
-        if (!self.hasHeader('content-type')) self.setHeader('content-type', mime.lookup(src.path))
+        if (!self.hasHeader('content-type')) self.setHeader('Content-Type', mime.lookup(src.path))
       } else {
         if (src.headers) {
           for (var i in src.headers) {
@@ -377,7 +377,7 @@ Request.prototype.init = function (options) {
           }
         }
         if (self._json && !self.hasHeader('content-type'))
-          self.setHeader('content-type', 'application/json')
+          self.setHeader('Content-Type', 'application/json')
         if (src.method && !self.explicitMethod) {
           self.method = src.method
         }
@@ -395,7 +395,7 @@ Request.prototype.init = function (options) {
         self.setHeaders(self._form.getHeaders())
         try {
           var length = self._form.getLengthSync()
-          self.setHeader('content-length', length)
+          self.setHeader('Content-Length', length)
         } catch(e){}
         self._form.pipe(self)
       }
@@ -413,7 +413,7 @@ Request.prototype.init = function (options) {
         self.requestBodyStream.pipe(self)
       } else if (!self.src) {
         if (self.method !== 'GET' && typeof self.method !== 'undefined') {
-          self.setHeader('content-length', 0)
+          self.setHeader('Content-Length', 0)
         }
         self.end()
       }
@@ -658,7 +658,7 @@ Request.prototype.start = function () {
   self.href = self.uri.href
 
   if (self.src && self.src.stat && self.src.stat.size && !self.hasHeader('content-length')) {
-    self.setHeader('content-length', self.src.stat.size)
+    self.setHeader('Content-Length', self.src.stat.size)
   }
   if (self._aws) {
     self.aws(self._aws, true)
@@ -839,7 +839,7 @@ Request.prototype.onResponse = function (response) {
           }
         }
         authHeader = 'Digest ' + authHeader.join(', ')
-        self.setHeader('authorization', authHeader)
+        self.setHeader('Authorization', authHeader)
         self._sentAuth = true
 
         redirectTo = self.uri
@@ -1076,7 +1076,7 @@ Request.prototype.qs = function (q, clobber) {
 }
 Request.prototype.form = function (form) {
   if (form) {
-    this.setHeader('content-type', 'application/x-www-form-urlencoded; charset=utf-8')
+    this.setHeader('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')
     this.body = qs.stringify(form).toString('utf8')
     return this
   }
@@ -1089,7 +1089,7 @@ Request.prototype.multipart = function (multipart) {
   self.body = []
 
   if (!self.hasHeader('content-type')) {
-    self.setHeader('content-type', 'multipart/related; boundary=' + self.boundary)
+    self.setHeader('Content-Type', 'multipart/related; boundary=' + self.boundary)
   } else {
     var headerName = self.hasHeader('content-type');
     self.setHeader(headerName, self.headers[headerName].split(';')[0] + '; boundary=' + self.boundary)
@@ -1120,19 +1120,19 @@ Request.prototype.multipart = function (multipart) {
 Request.prototype.json = function (val) {
   var self = this
 
-  if (!self.hasHeader('accept')) self.setHeader('accept', 'application/json')
+  if (!self.hasHeader('accept')) self.setHeader('Accept', 'application/json')
 
   this._json = true
   if (typeof val === 'boolean') {
     if (typeof this.body === 'object') {
       this.body = safeStringify(this.body)
       if (!self.hasHeader('content-type'))
-        self.setHeader('content-type', 'application/json')
+        self.setHeader('Content-Type', 'application/json')
     }
   } else {
     this.body = safeStringify(val)
     if (!self.hasHeader('content-type'))
-      self.setHeader('content-type', 'application/json')
+      self.setHeader('Content-Type', 'application/json')
   }
 
   return this
@@ -1159,7 +1159,7 @@ Request.prototype.auth = function (user, pass, sendImmediately) {
   this._hasAuth = true
   var header = typeof pass !== 'undefined' ? user + ':' + pass : user
   if (sendImmediately || typeof sendImmediately == 'undefined') {
-    this.setHeader('authorization', 'Basic ' + toBase64(header))
+    this.setHeader('Authorization', 'Basic ' + toBase64(header))
     this._sentAuth = true
   }
   return this
@@ -1170,7 +1170,7 @@ Request.prototype.aws = function (opts, now) {
     return this
   }
   var date = new Date()
-  this.setHeader('date', date.toUTCString())
+  this.setHeader('Date', date.toUTCString())
   var auth =
     { key: opts.key
     , secret: opts.secret
@@ -1190,7 +1190,7 @@ Request.prototype.aws = function (opts, now) {
     auth.resource = '/'
   }
   auth.resource = aws.canonicalizeResource(auth.resource)
-  this.setHeader('authorization', aws.authorization(auth))
+  this.setHeader('Authorization', aws.authorization(auth))
 
   return this
 }
@@ -1284,9 +1284,9 @@ Request.prototype.jar = function (jar) {
   if (cookies && cookies.length) {
     if (this.originalCookieHeader) {
       // Don't overwrite existing Cookie header
-      this.setHeader('cookie', this.originalCookieHeader + '; ' + cookies)
+      this.setHeader('Cookie', this.originalCookieHeader + '; ' + cookies)
     } else {
-      this.setHeader('cookie', cookies)
+      this.setHeader('Cookie', cookies)
     }
   }
   this._jar = jar


### PR DESCRIPTION
I understand that according to the RFC headers aren't case-sensitive. But I ran into a server where they were, phantomjs-ghostdriver (version: 1.9.7). And because this library is used in @webdriverjs. Well you see the problem. The issue is fixed in the phantomjs webserver, but apparently still not shipped :shipit: or it's due to me running on windows (https://github.com/ariya/phantomjs/issues/11487). Since it doesn't really matter and most clients do output the headers in Pascal-Case. I thought it might be a good idea to address it here.

@camme I ran into the "cannot get a session token" issue. When connection directly to phantomjs from webdriverjs. With this "fix" it works. 
