### PR TITLE
Add ability to specifiy querystring lib in options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 * `uri` || `url` - fully qualified uri or a parsed url object from `url.parse()`
 * `qs` - object containing querystring values to be appended to the `uri`
+* `useQs` - If true, use `qs` to stringify and parse querystrings, otherwise use `querystring` (default: `true`)
 * `method` - http method (default: `"GET"`)
 * `headers` - http headers (default: `{}`)
 * `body` - entity body for PATCH, POST and PUT requests. Must be a `Buffer` or `String`.

--- a/request.js
+++ b/request.js
@@ -107,6 +107,8 @@ Request.prototype.init = function (options) {
   if (!self.method) self.method = options.method || 'GET'
   self.localAddress = options.localAddress
 
+  if (!self.qsLib) self.qsLib = options.useQs ? qs: querystring
+
   debug(options)
   if (!self.pool && self.pool !== false) self.pool = globalPool
   self.dests = self.dests || []
@@ -1063,18 +1065,18 @@ var hasHeader = Request.prototype.hasHeader
 
 Request.prototype.qs = function (q, clobber) {
   var base
-  if (!clobber && this.uri.query) base = qs.parse(this.uri.query)
+  if (!clobber && this.uri.query) base = this.qsLib.parse(this.uri.query)
   else base = {}
 
   for (var i in q) {
     base[i] = q[i]
   }
 
-  if (qs.stringify(base) === ''){
+  if (this.qsLib.stringify(base) === ''){
     return this
   }
 
-  this.uri = url.parse(this.uri.href.split('?')[0] + '?' + qs.stringify(base))
+  this.uri = url.parse(this.uri.href.split('?')[0] + '?' + this.qsLib.stringify(base))
   this.url = this.uri
   this.path = this.uri.path
 
@@ -1083,7 +1085,7 @@ Request.prototype.qs = function (q, clobber) {
 Request.prototype.form = function (form) {
   if (form) {
     this.setHeader('content-type', 'application/x-www-form-urlencoded; charset=utf-8')
-    this.body = qs.stringify(form).toString('utf8')
+    this.body = this.qsLib.stringify(form).toString('utf8')
     return this
   }
   // create form-data object
@@ -1239,10 +1241,10 @@ Request.prototype.oauth = function (_oauth) {
       this.getHeader('content-type').slice(0, 'application/x-www-form-urlencoded'.length) ===
         'application/x-www-form-urlencoded'
      ) {
-    form = qs.parse(this.body)
+    form = this.qsLib.parse(this.body)
   }
   if (this.uri.query) {
-    form = qs.parse(this.uri.query)
+    form = this.qsLib.parse(this.uri.query)
   }
   if (!form) form = {}
   var oa = {}

--- a/tests/test-querystring.js
+++ b/tests/test-querystring.js
@@ -1,0 +1,54 @@
+var request = request = require('../index')
+  , assert = require('assert')
+  ;
+
+
+// Test adding a querystring
+var req1 = request.get({ uri: 'http://www.google.com', useQs: false, qs: { q : 'search' }})
+setTimeout(function() {
+  assert.equal('/?q=search', req1.path)
+}, 1)
+
+// Test replacing a querystring value
+var req2 = request.get({ uri: 'http://www.google.com?q=abc', useQs: false, qs: { q : 'search' }})
+setTimeout(function() {
+  assert.equal('/?q=search', req2.path)
+}, 1)
+
+// Test appending a querystring value to the ones present in the uri
+var req3 = request.get({ uri: 'http://www.google.com?x=y', useQs: false, qs: { q : 'search' }})
+setTimeout(function() {
+  assert.equal('/?x=y&q=search', req3.path)
+}, 1)
+
+// Test leaving a querystring alone
+var req4 = request.get({ uri: 'http://www.google.com?x=y', useQs: false})
+setTimeout(function() {
+  assert.equal('/?x=y', req4.path)
+}, 1)
+
+// Test giving empty qs property
+var req5 = request.get({ uri: 'http://www.google.com', qs: {}, useQs: false})
+setTimeout(function(){
+  assert.equal('/', req5.path)
+}, 1)
+
+
+// Test modifying the qs after creating the request
+var req6 = request.get({ uri: 'http://www.google.com', qs: {}, useQs: false})
+req6.qs({ q: "test" });
+process.nextTick(function() {
+  assert.equal('/?q=test', req6.path);
+});
+
+// Test using array param
+var req7 = request.get({ uri: 'http://www.google.com', qs: {foo: ['bar', 'baz']}, useQs: false})
+process.nextTick(function() {
+  assert.equal('/?foo=bar&foo=baz', req7.path);
+});
+
+// Test using array param
+var req7 = request.get({ uri: 'http://www.google.com', qs: {foo: ['bar', 'baz']}, useQs: false})
+process.nextTick(function() {
+  assert.equal('/?foo=bar&foo=baz', req7.path);
+});


### PR DESCRIPTION
Add the ability to specify whether `qs` or `querystring` should be used for parsing and stringifying by passing a `useQs` boolean option. Fixes #644
