### PR TITLE
Pipefilter test

### DIFF
--- a/tests/test-pipes.js
+++ b/tests/test-pipes.js
@@ -213,4 +213,19 @@ s.listen(s.port, function () {
 
   counter++
   request({url:'http://localhost:3453/opts'}).pipe(optsStream, { end : false })
+
+  // test request.pipefilter is called correctly
+  counter++
+  s.on('/pipefilter', function(req, resp) {
+    resp.end('d')
+  })
+  var validatePipeFilter = new ValidationStream('d')
+
+  var r3 = request.get('http://localhost:3453/pipefilter')
+  r3.pipe(validatePipeFilter)
+  r3.pipefilter = function(resp, dest) {
+    assert.equal(resp, r3.response)
+    assert.equal(dest, validatePipeFilter)
+    check()
+  }
 })


### PR DESCRIPTION
This pull request adds test for `request.pipefilter`. If the attribute is present, it should be called when do `requires.pipe(dest)` (https://github.com/mikeal/request/blob/master/request.js#L1037)

This is a useful but undocumented feature :grin: 
