### PR TITLE
Allow recursive request.defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,15 +77,17 @@ request.defaults = function (options, requester) {
     }
     return d
   }
-  var de = def(request)
-  de.get = def(request.get)
-  de.patch = def(request.patch)
-  de.post = def(request.post)
-  de.put = def(request.put)
-  de.head = def(request.head)
-  de.del = def(request.del)
-  de.cookie = def(request.cookie)
-  de.jar = request.jar
+  
+  var de = def(this)
+  de.get = def(this.get)
+  de.patch = def(this.patch)
+  de.post = def(this.post)
+  de.put = def(this.put)
+  de.head = def(this.head)
+  de.del = def(this.del)
+  de.cookie = def(this.cookie)
+  de.jar = this.jar
+  de.defaults = this.defaults
   return de
 }
 


### PR DESCRIPTION
This change allows you to call `request.defaults` on the function that is returned from a call to `request.defaults`

The idea is to be able to recursively call `.defaults` to override or add new configs to the previous defaults.

For example

```
var proxiedRequest = request.defaults({proxy: "http://proxy1.com"});
var nonRedirectedProxyRequest = proxiedRequest.defaults({followRedirect: false});
```

In this example `proxiedRequest` would just have the `proxy` as the default and `nonRedirectedProxyRequest` would have both the `proxy` and `followRedirects` as defaults.

You can also do something like

```
var r1 = request.defaults({
  timeout: 1000,
  followRedirect: false
});
var r2 = r1.defaults({timeout: 3000});
```

in which case `r1` would not follow redirects and have a timeout of 1000ms and `r2` would also not follow redirects but would have a timeout of 3000ms
