### PR TITLE
append secureOptions to poolKey

### DIFF
--- a/request.js
+++ b/request.js
@@ -631,6 +631,11 @@ Request.prototype.getAgent = function () {
       if (poolKey) poolKey += ':'
       poolKey += options.secureProtocol
     }
+    
+    if (options.secureOptions) {
+      if (poolKey) poolKey += ':'
+      poolKey += options.secureOptions
+    }
   }
 
   if (this.pool === globalPool && !poolKey && Object.keys(options).length === 0 && this.httpModule.globalAgent) {


### PR DESCRIPTION
secureOptions was removed in #666 and then reintroduced in #821 but we also need secureOptions reintroduced back in the poolKey
