### PR TITLE
Bump version of hawk dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tunnel-agent": "~0.4.0",
     "http-signature": "~0.10.0",
     "oauth-sign": "~0.3.0",
-    "hawk": "~1.0.0",
+    "hawk": "1.1.1",
     "aws-sign2": "~0.5.0"
   },
   "scripts": {


### PR DESCRIPTION
Hawk used to be locked to node 8 and below.
This was fixed in the 1.1.1 release:
https://github.com/hueniverse/hawk/commit/a523a412afbda2eca1fb1d253b8e3511fdbd371d

I did test this with the 2.x release of hawk and everything worked but I figured bumping by a major version could have some bad side effects.
