### PR TITLE
Return Buffer if encoding is undefined

### DIFF
--- a/request.js
+++ b/request.js
@@ -964,7 +964,7 @@ Request.prototype.onResponse = function (response) {
             chunk.copy(body, i, 0, chunk.length)
             i += chunk.length
           })
-          if (self.encoding === null) {
+          if (self.encoding == null) {
             response.body = body
           } else {
             response.body = body.toString(self.encoding)


### PR DESCRIPTION
I just ran into issue #823 today as well. It seems like it makes the most sense to have not providing an `encoding` value (i.e. `encoding` is `undefined`) do the same thing as setting `encoding` to `null`. This can be easily done by changing [one character](https://github.com/mikeal/request/blob/master/request.js#L967) (`===` to `==`).
