### PR TITLE
Correct repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/mikeal/request.git"
+    "url": "https://github.com/mikeal/request.git"
   },
   "bugs": {
     "url": "http://github.com/mikeal/request/issues"


### PR DESCRIPTION
It's `https://` instead, though it would automatically redirect.
