### PR TITLE
[fix] Support httpOver* outbound proxying.

### DIFF
--- a/request.js
+++ b/request.js
@@ -145,9 +145,11 @@ Request.prototype.init = function (options) {
     if (typeof self.proxy == 'string') self.proxy = url.parse(self.proxy)
 
     // do the HTTP CONNECT dance using koichik/node-tunnel
-    if (http.globalAgent && self.uri.protocol === "https:" && self.canTunnel) {
-      var tunnelFn = self.proxy.protocol === "http:"
-                   ? tunnel.httpsOverHttp : tunnel.httpsOverHttps
+    // do the HTTP CONNECT dance using koichik/node-tunnel
+    if (http.globalAgent && self.canTunnel) {
+      var tunnelFn = self.proxy.protocol === 'http:'
+        ? (self.proxy.protocol === 'http:' ? tunnel.httpOverHttp : tunnel.httpsOverHttp)
+        : (self.proxy.protocol === 'https:' ? tunnel.httpsOverHttps : tunnel.httpOverHttps);
 
       var tunnelOptions = { proxy: { host: self.proxy.hostname
                                    , port: +self.proxy.port
@@ -631,7 +633,7 @@ Request.prototype.getAgent = function () {
       if (poolKey) poolKey += ':'
       poolKey += options.secureProtocol
     }
-    
+
     if (options.secureOptions) {
       if (poolKey) poolKey += ':'
       poolKey += options.secureOptions


### PR DESCRIPTION
Thanks to @jcrugzz for finding this, but it appears that outbound proxy tunneling was only setup for `httpsOver*` and not for `httpOver*`. Assuming there wasn't a reason for that, this adds that functionality.
