### PR TITLE
Support for setNoDelay for request socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 * `aws` - `object` containing AWS signing information. Should have the properties `key`, `secret`. Also requires the property `bucket`, unless you’re specifying your `bucket` as part of the path, or the request doesn’t use a bucket (i.e. GET Services)
 * `httpSignature` - Options for the [HTTP Signature Scheme](https://github.com/joyent/node-http-signature/blob/master/http_signing.md) using [Joyent's library](https://github.com/joyent/node-http-signature). The `keyId` and `key` properties must be specified. See the docs for other options.
 * `localAddress` - Local interface to bind for network connections.
+* `noDelay` - If `true`, sets 'no delay' mode (disables the Nagle algorithm) on request's socket
 
 
 The callback argument gets 3 arguments: 

--- a/request.js
+++ b/request.js
@@ -245,6 +245,10 @@ Request.prototype.init = function (options) {
   self._buildRequest = function(){
     var self = this;
 
+    if (options.noDelay) {
+       self.noDelay = true;
+    }
+
     if (options.form) {
       self.form(options.form)
     }
@@ -698,6 +702,10 @@ Request.prototype.start = function () {
         }
       })
     }
+  }
+
+  if (self.noDelay && self.req.setNoDelay) {
+     self.req.setNoDelay();
   }
 
   self.req.on('error', self.clientErrorHandler)


### PR DESCRIPTION
Support for the following request method: http://nodejs.org/api/http.html#http_request_setnodelay_nodelay
