### PR TITLE
Add support for gzip content decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 * `aws` - `object` containing AWS signing information. Should have the properties `key`, `secret`. Also requires the property `bucket`, unless you’re specifying your `bucket` as part of the path, or the request doesn’t use a bucket (i.e. GET Services)
 * `httpSignature` - Options for the [HTTP Signature Scheme](https://github.com/joyent/node-http-signature/blob/master/http_signing.md) using [Joyent's library](https://github.com/joyent/node-http-signature). The `keyId` and `key` properties must be specified. See the docs for other options.
 * `localAddress` - Local interface to bind for network connections.
+* `gzip` - If `true`, add an `Accept-Encoding` header to request compressed content encodings from the server (if not already present) and decode supported content encodings in the response.
 
 
 The callback argument gets 3 arguments: 

--- a/tests/test-gzip.js
+++ b/tests/test-gzip.js
@@ -1,0 +1,95 @@
+var request = require('../index')
+  , http = require('http')
+  , assert = require('assert')
+  , zlib = require('zlib')
+
+var testContent = 'Compressible response content.\n'
+  , testContentGzip
+
+var server = http.createServer(function (req, res) {
+  res.statusCode = 200
+  res.setHeader('Content-Type', 'text/plain')
+
+  if (/\bgzip\b/i.test(req.headers['accept-encoding'])) {
+    zlib.gzip(testContent, function (err, data) {
+      assert.ifError(err)
+      testContentGzip = data
+      res.setHeader('Content-Encoding', 'gzip')
+      res.end(data)
+    })
+  } else {
+    res.end(testContent)
+  }
+})
+
+server.listen(6767, function (err) {
+  assert.ifError(err)
+
+  var headers, options
+
+  // Transparently supports gzip decoding to callbacks
+  options = { url: 'http://localhost:6767/foo', gzip: true }
+  request.get(options, function (err, res, body) {
+    assert.ifError(err)
+    assert.strictEqual(res.headers['content-encoding'], 'gzip')
+    assert.strictEqual(body, testContent)
+  })
+
+
+  // Transparently supports gzip decoding to pipes
+  options = { url: 'http://localhost:6767/foo', gzip: true }
+  var chunks = []
+  request.get(options)
+    .on('data', function (chunk) { chunks.push(chunk) })
+    .on('end', function () {
+        assert.strictEqual(Buffer.concat(chunks).toString(), testContent)
+      })
+    .on('error', function (err) { assert.ifError(err) })
+
+
+  // Does not request gzip if user specifies Accepted-Encodings
+  headers = { 'Accept-Encoding': null }
+  options = {
+    url: 'http://localhost:6767/foo',
+    headers: headers,
+    gzip: true
+  }
+  request.get(options, function (err, res, body) {
+    assert.ifError(err)
+    assert.strictEqual(res.headers['content-encoding'], undefined)
+    assert.strictEqual(body, testContent)
+  })
+
+
+  // Does not decode user-requested encoding by default
+  headers = { 'Accept-Encoding': 'gzip' }
+  options = { url: 'http://localhost:6767/foo', headers: headers }
+  request.get(options, function (err, res, body) {
+    assert.ifError(err)
+    assert.strictEqual(res.headers['content-encoding'], 'gzip')
+    assert.strictEqual(body, testContentGzip.toString())
+  })
+
+
+  // Supports character encoding with gzip encoding
+  headers = { 'Accept-Encoding': 'gzip' }
+  options = {
+    url: 'http://localhost:6767/foo',
+    headers: headers,
+    gzip: true,
+    encoding: "utf8"
+  }
+  var strings = []
+  request.get(options)
+    .on('data', function (string) {
+        assert.strictEqual(typeof string, "string")
+        strings.push(string)
+      })
+    .on('end', function () {
+        assert.strictEqual(strings.join(""), testContent)
+
+        // Shutdown server after last test
+        server.close()
+      })
+    .on('error', function (err) { assert.ifError(err) })
+})


### PR DESCRIPTION
My apologies in advance for adding yet another gzip implementation for you to consider, but it appears that work on the alternative solutions (#303, #458, #464, #660) has stalled while interest in a solution is still high (#539, #725, #747) and requires non-trivial effort to implement outside of the library (although it's certainly not horrible).

Unlike the previous solutions, this pull request supports stream-based usage and does not introduce any backwards-incompatible behavior.  It is intended to serve as a bridge for the 2.x series until 3.0 is ready for release, at which points its existing gzip implementation can supersede this one.

This commit introduces the `decodeContent` boolean option to allow users to explicitly request decoding of supported response content and inclusion of the appropriate content negotiation header (`Accept-Encoding`), if unspecified.

Although `deflate` support is also common on servers, this commit does not add `deflate` support due to compatibility issues with non-conformant "raw" deflate encodings and the lack of a compelling reason to support it given `gzip`'s wide availability.

Thanks for considering,
Kevin
