### PR TITLE
check for content-length header before setting it in nextTick

### DIFF
--- a/request.js
+++ b/request.js
@@ -396,7 +396,7 @@ Request.prototype.init = function (options) {
         self.setHeaders(self._form.getHeaders())
         try {
           var length = self._form.getLengthSync()
-          self.setHeader('content-length', length)
+          if (!self.hasHeader('content-length')) self.setHeader('content-length', length)
         } catch(e){}
         self._form.pipe(self)
       }


### PR DESCRIPTION
extending https://github.com/mikeal/request/pull/793 so it does not override a custom content-length header.

Especially relevant when passing in a stream since `_form.getLengthSync` [doesn't calculate](https://github.com/felixge/node-form-data/blob/fdc52f3fa32198da44644bb158e6f5764feb3767/test/integration/test-errors.js#L61-L62) the length of the stream in form-data, making this statement: https://github.com/mikeal/request/issues/345#issuecomment-13818530 not technically correct.
