### PR TITLE
Silence EventEmitter memory leak warning #311

### DIFF
--- a/request.js
+++ b/request.js
@@ -723,6 +723,7 @@ Request.prototype.onResponse = function (response) {
 
   // The check on response.connection is a workaround for browserify.
   if (response.connection && response.connection.listeners('error').indexOf(self._parserErrorHandler) === -1) {
+    response.connection.setMaxListeners(0)
     response.connection.once('error', self._parserErrorHandler)
   }
   if (self._aborted) {


### PR DESCRIPTION
When performing a lot of concurrent requests on a keep-alive connection, a lot of error handlers can be added, which in turn will result in the following warning: "possible EventEmitter memory leak detected. 11 listeners added". This isn't really a memory leak and should just be silenced.
