### PR TITLE
Fixing 'Content-Length' bug

### DIFF
--- a/request.js
+++ b/request.js
@@ -1132,6 +1132,7 @@ Request.prototype.form = function (form) {
   if (form) {
     this.setHeader('content-type', 'application/x-www-form-urlencoded; charset=utf-8')
     this.body = (typeof form === 'string') ? form.toString('utf8') : qs.stringify(form).toString('utf8')
+    this.setHeader('content-length', this.body.length)
     return this
   }
   // create form-data object


### PR DESCRIPTION
Adding Content-Length header when using form options.

There is a problem with the header when using

``` javascript
var r = request('http://example.com/upload', fn);
r.form({ form: data });
```

This does not create a Content-Length header, even though the code would say it does.
