### PR TITLE
Support gzip with encoding on node pre-v0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "http-signature": "~0.10.0",
     "oauth-sign": "~0.3.0",
     "hawk": "1.1.1",
-    "aws-sign2": "~0.5.0"
+    "aws-sign2": "~0.5.0",
+    "stringstream": "~0.0.4"
   },
   "scripts": {
     "test": "node tests/run.js"

--- a/request.js
+++ b/request.js
@@ -18,6 +18,7 @@ var optional = require('./lib/optional')
   , mime = require('mime-types')
   , tunnel = optional('tunnel-agent')
   , _safeStringify = require('json-stringify-safe')
+  , stringstream = optional('stringstream')
 
   , ForeverAgent = require('forever-agent')
   , FormData = optional('form-data')
@@ -959,9 +960,13 @@ Request.prototype.onResponse = function (response) {
     if (self.encoding) {
       if (self.dests.length !== 0) {
         console.error("Ignoring encoding parameter as this stream is being piped to another stream which makes the encoding option invalid.")
+      } else if (dataStream.setEncoding) {
+        dataStream.setEncoding(self.encoding)
       } else {
-        // gz streams don't have setEncoding in v0.8
-        if (dataStream.setEncoding) dataStream.setEncoding(self.encoding)
+        // Should only occur on node pre-v0.9.4 (joyent/node@9b5abe5) with
+        // zlib streams.
+        // If/When support for 0.9.4 is dropped, this should be unnecessary.
+        dataStream = dataStream.pipe(stringstream(self.encoding))
       }
     }
 

--- a/tests/test-gzip.js
+++ b/tests/test-gzip.js
@@ -3,6 +3,16 @@ var request = require('../index')
   , assert = require('assert')
   , zlib = require('zlib')
 
+if (!zlib.Gunzip.prototype.setEncoding) {
+  try {
+    require('stringstream')
+  } catch (e) {
+    console.error('stringstream must be installed to run this test.')
+    console.error('skipping this test. please install stringstream and run again if you need to test this feature.')
+    process.exit(0)
+  }
+}
+
 var testContent = 'Compressible response content.\n'
   , testContentGzip
 


### PR DESCRIPTION
This pull request addresses an oversight from #951 that before 0.9.4 `zlib` streams did not support the `setEncoding` method.  This means that on these versions of node, using the `encoding` and `gzip` options together would cause an error and result in test failures on these versions.

This pull request addresses the issue by chaining the zlib stream with a [stringstream](https://www.npmjs.org/package/stringstream) when both the `encoding` and `gzip` options are specified and `setEncoding` is not available on the zlib stream.
