### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,23 +150,22 @@ If passed as an option, `auth` should be a hash containing values `user` || `use
 
 `sendImmediately` defaults to `true`, which causes a basic authentication header to be sent.  If `sendImmediately` is `false`, then `request` will retry with a proper authentication header after receiving a `401` response from the server (which must contain a `WWW-Authenticate` header indicating the required authentication method).
 
-Digest authentication is supported, but it only works with `sendImmediately` set to `false`; otherwise `request` will send basic authentication on the initial request, which will probably cause the request to fail.
-
-Bearer authentication is supported, and is activated when the `bearer` value is available. The value may be either a `String` or a `Function` returning a `String`. Using a function to supply the bearer token is particularly useful if used in conjuction with `defaults` to allow a single function to supply the last known token at the time or sending a request or to compute one on the fly.
-
-Note that you can also use a trick using the URL itself, as specified in [RFC 1738](http://www.ietf.org/rfc/rfc1738.txt). 
+Note that you can also use for basic authentication a trick using the URL itself, as specified in [RFC 1738](http://www.ietf.org/rfc/rfc1738.txt). 
 Simply pass the `user:password` before the host with an `@` sign.
 
 ```javascript
-
-var username = "username",
-    password = "password",
-    url = "http://" + username + ":" + password + "@example.com";
+var username = 'username',
+    password = 'password',
+    url = 'http://' + username + ':' + password + '@some.server.com';
 
 request({url: url}, function (error, response, body) {
    // Do more stuff with 'body' here
 });
 ```
+
+Digest authentication is supported, but it only works with `sendImmediately` set to `false`; otherwise `request` will send basic authentication on the initial request, which will probably cause the request to fail.
+
+Bearer authentication is supported, and is activated when the `bearer` value is available. The value may be either a `String` or a `Function` returning a `String`. Using a function to supply the bearer token is particularly useful if used in conjuction with `defaults` to allow a single function to supply the last known token at the time or sending a request or to compute one on the fly.
 
 ## OAuth Signing
 


### PR DESCRIPTION
Hi guys!

Updated README.md. Added example to `HTTP Authentication` section, how to make basic authentication using the URL itself as specified in RFC 1738: http://www.ietf.org/rfc/rfc1738.txt

Best regards, 
Pavlo Voznenko
