### PR TITLE
Show optional modules as being loaded by the module that reqeusted them

### DIFF
--- a/lib/optional.js
+++ b/lib/optional.js
@@ -1,5 +1,5 @@
-module.exports = function(module) {
+module.exports = function(moduleName) {
   try {
-    return require(module);
+    return module.parent.require(moduleName);
   } catch (e) {}
 };

--- a/tests/test-optional.js
+++ b/tests/test-optional.js
@@ -1,0 +1,5 @@
+var assert = require('assert')
+  , optional = require('../lib/optional')
+  , copy = optional('../lib/copy');
+
+assert.equal(module,module.children[1].parent);


### PR DESCRIPTION
Accurately tracking who loaded whom isn't usually required, but there are times when it's nice to know, eg, https://www.npmjs.org/package/require-timer
