### PR TITLE
Added allowRedirect function. Should return true if redirect is allowed or false otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 * `auth` - A hash containing values `user` || `username`, `pass` || `password`, and `sendImmediately` (optional).  See documentation above.
 * `json` - sets `body` but to JSON representation of value and adds `Content-type: application/json` header.  Additionally, parses the response body as JSON.
 * `multipart` - (experimental) array of objects which contains their own headers and `body` attribute. Sends `multipart/related` request. See example below.
-* `followRedirect` - follow HTTP 3xx responses as redirects (default: `true`)
+* `followRedirect` - follow HTTP 3xx responses as redirects (default: `true`). This property can also be implemented as function which gets `response` object as a single argument and should return `true` if redirects should continue or `false` otherwise.
 * `followAllRedirects` - follow non-GET HTTP 3xx responses as redirects (default: `false`)
 * `maxRedirects` - the maximum number of redirects to follow (default: `10`)
 * `encoding` - Encoding to be used on `setEncoding` of response data. If `null`, the `body` is returned as a `Buffer`.

--- a/request.js
+++ b/request.js
@@ -195,14 +195,13 @@ Request.prototype.init = function (options) {
 
   self._redirectsFollowed = self._redirectsFollowed || 0
   self.maxRedirects = (self.maxRedirects !== undefined) ? self.maxRedirects : 10
-  self.followRedirect = (self.followRedirect !== undefined) ? self.followRedirect : true
+  self.allowRedirect = (typeof self.followRedirect === 'function') ? self.followRedirect : function(response) {
+    return true;
+  };
+  self.followRedirect = (self.followRedirect !== undefined) ? !!self.followRedirect : true
   self.followAllRedirects = (self.followAllRedirects !== undefined) ? self.followAllRedirects : false
   if (self.followRedirect || self.followAllRedirects)
     self.redirects = self.redirects || []
-
-  self.allowRedirect = (self.allowRedirect !== undefined) ? self.allowRedirect : function(response) {
-    return true;
-  };
 
   self.headers = self.headers ? copy(self.headers) : {}
 


### PR DESCRIPTION
Added allowRedirect function which should return true if redirect is allowed or false otherwise

This allows to stop following redirects based on response headers, status or any other response property. For example checking that certain URL has been reached would look like:

```
request(url, {
    followRedirect: true,
    allowRedirect: function(response) {
        var currentUrl = (response.headers && response.headers.location) || '';
        if (/some regex/.test(currentUrl)) {
            return false;
        }
        return true;
    }
})
```
