### PR TITLE
Fix fallback for browserify for optional modules.

### DIFF
--- a/lib/optional.js
+++ b/lib/optional.js
@@ -1,5 +1,13 @@
 module.exports = function(moduleName) {
   try {
     return module.parent.require(moduleName);
-  } catch (e) {}
+  } catch (e) {
+    // This could mean that we are in a browser context.
+    // Add another try catch like it used to be, for backwards compability
+    // and browserify reasons.
+    try {
+      return require(moduleName);
+    }
+    catch (e) {}
+  }
 };


### PR DESCRIPTION
Hello. In the commit 811dddc4090b4a6d69d470d356f35756eb03e340 there was a change that made request incompatible with browserify again. The error being thrown is `"Cannot read property 'require' of undefined"`. Not sure if this is the best way to fix it, but it sure fixes it :)

If I have the time one of these days (and you think it is a good idea, and want to keep supporting a browserified request) I could try to look into writing a small test-suite for the browser, so at least these things will get picked up by CI.

Also. I think I said it before, but thanks again for this awesome module! Please tell me if you want anything changed with the patch, and I'll fix it up.
