### PR TITLE
Defaults should not overwrite defined options

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ request.defaults = function (options, requester) {
 
     return function (uri, opts, callback) {
       var params = initParams(uri, opts, callback)
-      params.options = extend(params.options, headerlessOptions(options))
+      params.options = extend(headerlessOptions(options), params.options)
 
       if (options.headers)
         params.options.headers = getHeaders(params, options)

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -160,6 +160,27 @@ s.listen(s.port, function () {
     return request(params.uri, params.options, params.callback);
   });
 
+  s.on('/set-undefined', function (req, resp) {
+    assert.equal(req.method, 'POST')
+    assert.equal(req.headers['content-type'], 'application/json');
+    assert.equal(req.headers['x-foo'], 'baz');
+    var data = '';
+    req.on('data', function(d) {
+      data += d;
+    });
+    req.on('end', function() {
+      resp.writeHead(200, {'Content-Type': 'application/json'});
+      resp.end(data);
+    });
+  });
+
+  // test only setting undefined properties
+  request.defaults({method:'post',json:true,headers:{'x-foo':'bar'}})({uri:s.url + '/set-undefined',json:{foo:'bar'},headers:{'x-foo':'baz'}}, function (e, r, b){
+    if (e) throw e;
+    assert.deepEqual({foo:'bar'}, b);
+    counter += 1;
+  });
+
   var msg = 'defaults test failed. head request should throw earlier';
   assert.throws(function() {
     defaultRequest.head(s.url + '/get_custom', function(e, r, b) {


### PR DESCRIPTION
In a recent commit, the applying of defaults changed from a `forEach` loop that only applied a default if the option is `undefined`, to using node's `util._extend`, which simply copies from one object to another. This change introduced a regression where defaults overwrite defined options.
