### PR TITLE
Fixing HTTP redirects "not carrying pre-defined host-header value when the Location header is not a URL".

### DIFF
--- a/request.js
+++ b/request.js
@@ -1028,7 +1028,9 @@ Request.prototype.onResponse = function (response) {
       delete self.body
       delete self._form
       if (self.headers) {
-        self.removeHeader('host')
+        if (isUrl.test(redirectTo)) {
+          self.removeHeader('host')
+        }
         self.removeHeader('content-type')
         self.removeHeader('content-length')
       }


### PR DESCRIPTION
Fixing HTTP redirects "not carrying pre-defined host-header value when the Location header is not a URL".
