### PR TITLE
use Request.abort() to abort the request when the request has timed-out

### DIFF
--- a/request.js
+++ b/request.js
@@ -803,7 +803,7 @@ Request.prototype.start = function () {
 
   if (self.timeout && !self.timeoutTimer) {
     self.timeoutTimer = setTimeout(function () {
-      self.req.abort()
+      self.abort()
       var e = new Error("ETIMEDOUT")
       e.code = "ETIMEDOUT"
       self.emit("error", e)

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -41,7 +41,8 @@ s.listen(s.port, function () {
   request(shouldTimeoutWithEvents)
     .on('error', function (err) {
       eventsEmitted++;
-      assert.equal(err.code, eventsEmitted == 1 ? "ETIMEDOUT" : "ECONNRESET");
+      assert.equal(1, eventsEmitted);
+      assert.equal(err.code, "ETIMEDOUT");
       checkDone();
     })
 


### PR DESCRIPTION
This change will affect the behavior of request that has timed-out.
Now when a user is listening for the error event on a request and that request times-out,
The error handler will only be called once. The error given to the callback will be the timeout error.

Fixes: #304 
