### PR TITLE
Use strict mode in request

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+'use strict';
+
 var extend                = require('util')._extend
   , cookies               = require('./lib/cookies')
   , copy                  = require('./lib/copy')
@@ -136,7 +138,7 @@ request.defaults = function (options, requester) {
     }
   }
 
-  defaults          = wrap(self)
+  var defaults      = wrap(self)
   defaults.get      = wrap(self.get)
   defaults.patch    = wrap(self.patch)
   defaults.post     = wrap(self.post)

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var optional = require('./optional')
   , tough = optional('tough-cookie')
   , Cookie = tough && tough.Cookie

--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports =
 function copy (obj) {
   var o = {}

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var util = require('util')
   , request = require('../index')
   ;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var extend = require('util')._extend
 
 function constructObject(initialObject) {

--- a/lib/optional.js
+++ b/lib/optional.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = function(moduleName) {
   try {
     return module.parent.require(moduleName);

--- a/request.js
+++ b/request.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var optional = require('./lib/optional')
   , http = require('http')
   , https = optional('https')
@@ -582,7 +584,7 @@ Request.prototype.init = function (options) {
 
     var lookup_table = {};
     do { lookup_table[lookup.join('/')]={} } while(lookup.pop())
-    for (r in lookup_table){
+    for (var r in lookup_table){
       try_next(r);
     }
 
@@ -596,7 +598,7 @@ Request.prototype.init = function (options) {
 
     wait_for_socket_response();
 
-    response_counter = 0;
+    var response_counter = 0;
 
     function wait_for_socket_response(){
       var detach;


### PR DESCRIPTION
Catch a few hidden bugs caused by accidental global variables, and enable strict mode so that bugs like this aren't ever introduced again.

Related: #1103
