### PR TITLE
linting-fix: remove unused variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@
 
 var extend                = require('util')._extend
   , cookies               = require('./lib/cookies')
-  , copy                  = require('./lib/copy')
   , helpers               = require('./lib/helpers')
   , isFunction            = helpers.isFunction
   , constructObject       = helpers.constructObject

--- a/request.js
+++ b/request.js
@@ -1,7 +1,6 @@
 var optional = require('./lib/optional')
   , http = require('http')
   , https = optional('https')
-  , tls = optional('tls')
   , url = require('url')
   , util = require('util')
   , stream = require('stream')
@@ -578,7 +577,6 @@ Request.prototype.init = function (options) {
     var full_path = self.uri.href.replace(self.uri.protocol+'/', '');
 
     var lookup = full_path.split('/');
-    var error_connecting = true;
 
     var lookup_table = {};
     do { lookup_table[lookup.join('/')]={} } while(lookup.pop())


### PR DESCRIPTION
`copy` No longer used within index.js
`tls` No longer used within index.js
`error_connecting` was never used, and seems to have been added by accident here: 54e6dfb77d57757d4006982f813ebaab9e005cd5
