### PR TITLE
linting fix: remove function call from if-else conditional statement

### DIFF
--- a/request.js
+++ b/request.js
@@ -864,8 +864,8 @@ Request.prototype.onResponse = function (response) {
     return
   }
   if (self._paused) response.pause()
-  // Check that response.resume is defined. Workaround for browserify.
-  else response.resume && response.resume()
+  // response.resume should be defined, but check anyway before calling. Workaround for browserify.
+  else if (response.resume) response.resume()
 
   self.response = response
   response.request = self


### PR DESCRIPTION
response.resume() was getting called as a part of the conditional check, which was really doing nothing (actually, there's a small chance that `self.response = response` was getting sucked up as the line to be executed only if that else-check passed, instead of all the time as intended.)
