### PR TITLE
linting fix: authPieces was getting redeclared

### DIFF
--- a/request.js
+++ b/request.js
@@ -416,16 +416,16 @@ Request.prototype.init = function (options) {
     }
 
     if (self.uri.auth && !self.hasHeader('authorization')) {
-      var authPieces = self.uri.auth.split(':').map(function(item){ return querystring.unescape(item) })
-      self.auth(authPieces[0], authPieces.slice(1).join(':'), true)
+      var uriAuthPieces = self.uri.auth.split(':').map(function(item){ return querystring.unescape(item) })
+      self.auth(uriAuthPieces[0], uriAuthPieces.slice(1).join(':'), true)
     }
 
     if (self.proxy && !self.tunnel) {
       if (self.proxy.auth && !self.proxyAuthorization) {
-        var authPieces = self.proxy.auth.split(':').map(function(item){
+        var proxyAuthPieces = self.proxy.auth.split(':').map(function(item){
           return querystring.unescape(item)
         })
-        var authHeader = 'Basic ' + toBase64(authPieces.join(':'))
+        var authHeader = 'Basic ' + toBase64(proxyAuthPieces.join(':'))
         self.proxyAuthorization = authHeader
       }
       if (self.proxyAuthorization)


### PR DESCRIPTION
Small fix to stop redeclaring an already-declared variable
