### PR TITLE
linting fix: Restructure bad empty if statement

### DIFF
--- a/request.js
+++ b/request.js
@@ -1021,12 +1021,12 @@ Request.prototype.onResponse = function (response) {
 
         authHeader = []
         for (var k in authValues) {
-          if (!authValues[k]) {
-            //ignore
-          } else if (k === 'qop' || k === 'nc' || k === 'algorithm') {
-            authHeader.push(k + '=' + authValues[k])
-          } else {
-            authHeader.push(k + '="' + authValues[k] + '"')
+          if (authValues[k]) {
+            if (k === 'qop' || k === 'nc' || k === 'algorithm') {
+              authHeader.push(k + '=' + authValues[k])
+            } else {
+              authHeader.push(k + '="' + authValues[k] + '"')
+            }
           }
         }
         authHeader = 'Digest ' + authHeader.join(', ')


### PR DESCRIPTION
The intent wasn't super clear here, what the author meant was that only run this code if `authValues` is defined. 

This will also allow us to enforce no empty code blocks
