### PR TITLE
add basic linting to request library

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,26 @@
+{
+  "env": {
+    "node": true
+  },
+  "rules": {
+    // Disallow semi-colons, except to disambiguate some statements (warning until all violations fixed)
+    "semi": [1, "never"],
+    "no-extra-semi": 1,
+    // Allow only single-quotes, disallow double-quotes (warning until all violations fixed)
+    "quotes": [1, "single"],
+    // Require curly braces for all control statements (warning until all violations fixed)
+    "curly": 1,
+    // Disallow using variables and functions before they've been defined (warning until all violations fixed)
+    "no-use-before-define": 1,
+    // Allow any case for variable naming
+    "camelcase": 0,
+    // Disallow unused variables, except as function arguments
+    "no-unused-vars": [2, {"args":"none"}],
+    // Allow leading underscores for method names
+    // REASON: we use underscores to denote private methods
+    "no-underscore-dangle": 0,
+    // Allow non-require statements mixed in with module require statements
+    // REASON: we use the `optional()` helper, which makes this rule impossible to enforce
+    "no-mixed-requires": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node" : ">=0.8.0"
+    "node": ">=0.8.0"
   },
   "main": "index.js",
   "dependencies": {
@@ -41,9 +41,11 @@
     "stringstream": "~0.0.4"
   },
   "scripts": {
-    "test": "node tests/run.js"
+    "test": "npm run lint && node tests/run.js",
+    "lint": "./node_modules/eslint/bin/eslint.js lib/ *.js"
   },
   "devDependencies": {
-    "rimraf": "~2.2.8"
+    "rimraf": "~2.2.8",
+    "eslint": "0.5.1"
   }
 }


### PR DESCRIPTION
- Add eslint as devDependency for linting
- Add `.eslintrc` file to define our custom rules
- Define `lint` script in package.json to lint the library. You can run this manually via `$ npm run lint`

List of custom rules taken from #1106, based on proposal and comments. 
Changes and bikeshedding still allowed and even encouraged (Check http://eslint.org/docs/rules/ for any rules you'd like to see added as well that aren't enabled by default)

/cc @mikeal @nylen & everyone else
