### PR TITLE
Correct infinite loop with the same location

### DIFF
--- a/request.js
+++ b/request.js
@@ -883,6 +883,10 @@ Request.prototype.onResponse = function (response) {
     var location = response.caseless.get('location')
     debug('redirect', location)
 
+    if (!isUrl.test(location)) {
+      location = url.resolve(self.uri.href, location)
+    }
+
     if (self.followAllRedirects) {
       redirectTo = location
     } else if (self.followRedirect) {
@@ -973,7 +977,7 @@ Request.prototype.onResponse = function (response) {
     }
   }
 
-  if (redirectTo && self.allowRedirect.call(self, response)) {
+  if (redirectTo && redirectTo !== self.uri.href && self.allowRedirect.call(self, response)) {
     debug('redirect to', redirectTo)
 
     // ignore any potential response body.  it cannot possibly be useful
@@ -985,10 +989,6 @@ Request.prototype.onResponse = function (response) {
       return
     }
     self._redirectsFollowed += 1
-
-    if (!isUrl.test(redirectTo)) {
-      redirectTo = url.resolve(self.uri.href, redirectTo)
-    }
 
     var uriPrev = self.uri
     self.uri = url.parse(redirectTo)

--- a/tests/test-redirect-loop.js
+++ b/tests/test-redirect-loop.js
@@ -1,0 +1,17 @@
+var request = require('../index')
+  , http = require('http')
+  , assert = require('assert')
+  ;
+
+var server = http.createServer(function (req, res) {
+  res.statusCode = 304
+  res.setHeader('Location', req.url)
+  res.end()
+}).listen(8080, function () {
+  request('http://localhost:8080/test', function (e, res, body) {
+    assert.equal(res.statusCode, 304)
+    assert.equal(body, '')
+
+    server.close()
+  })
+})


### PR DESCRIPTION
The issue is apparent when loading from Google Drive (e.g. `https://dd7777360edd06ed6fa7cbc0725dbd736cbda015.googledrive.com/host/0B9Vee7pZ81xmUzBqUmluT3FWVkU/my.js`). The root cause is that the `304 Not Modified` responds with a location header, which results in an infinite loop to the same url. This patch only does a redirect now if the url has changed.
