### PR TITLE
Fix multiple redirects and `self.followRedirect`

### DIFF
--- a/request.js
+++ b/request.js
@@ -263,9 +263,9 @@ Request.prototype.init = function (options) {
   self.allowRedirect = (typeof self.followRedirect === 'function') ? self.followRedirect : function(response) {
     return true
   }
-  self.followRedirect = (self.followRedirect !== undefined) ? !!self.followRedirect : true
+  self.followRedirects = (self.followRedirect !== undefined) ? !!self.followRedirect : true
   self.followAllRedirects = (self.followAllRedirects !== undefined) ? self.followAllRedirects : false
-  if (self.followRedirect || self.followAllRedirects)
+  if (self.followRedirects || self.followAllRedirects)
     self.redirects = self.redirects || []
 
   self.setHost = false
@@ -885,7 +885,7 @@ Request.prototype.onResponse = function (response) {
 
     if (self.followAllRedirects) {
       redirectTo = location
-    } else if (self.followRedirect) {
+    } else if (self.followRedirects) {
       switch (self.method) {
         case 'PATCH':
         case 'PUT':


### PR DESCRIPTION
Currently when a redirect occurs, the `self.init` function is being run. However, since it’s already been run on the initial execution, the original value for `self.followRedirect` has been lost. This means the custom function for `self.allowRedirect` will only ever work on the first redirect and not subsequent redirects.
