### PR TITLE
Add ability to specifiy querystring lib in options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 * `uri` || `url` - fully qualified uri or a parsed url object from `url.parse()`
 * `qs` - object containing querystring values to be appended to the `uri`
+* `useQuerystring` - If true, use `querystring` to stringify and parse
+  querystrings, otherwise use `qs` (default: `false`).  Set this option to
+  `true` if you need arrays to be serialized as `foo=bar&foo=baz` instead of the
+  default `foo[0]=bar&foo[1]=baz`.
 * `method` - http method (default: `"GET"`)
 * `headers` - http headers (default: `{}`)
 * `body` - entity body for PATCH, POST and PUT requests. Must be a `Buffer` or `String`.

--- a/tests/test-querystring.js
+++ b/tests/test-querystring.js
@@ -1,0 +1,54 @@
+var request = request = require('../index')
+  , assert = require('assert')
+  ;
+
+
+// Test adding a querystring
+var req1 = request.get({ uri: 'http://www.google.com', useQuerystring: true, qs: { q : 'search' }})
+setTimeout(function() {
+  assert.equal('/?q=search', req1.path)
+}, 1)
+
+// Test replacing a querystring value
+var req2 = request.get({ uri: 'http://www.google.com?q=abc', useQuerystring: true, qs: { q : 'search' }})
+setTimeout(function() {
+  assert.equal('/?q=search', req2.path)
+}, 1)
+
+// Test appending a querystring value to the ones present in the uri
+var req3 = request.get({ uri: 'http://www.google.com?x=y', useQuerystring: true, qs: { q : 'search' }})
+setTimeout(function() {
+  assert.equal('/?x=y&q=search', req3.path)
+}, 1)
+
+// Test leaving a querystring alone
+var req4 = request.get({ uri: 'http://www.google.com?x=y', useQuerystring: true})
+setTimeout(function() {
+  assert.equal('/?x=y', req4.path)
+}, 1)
+
+// Test giving empty qs property
+var req5 = request.get({ uri: 'http://www.google.com', qs: {}, useQuerystring: true})
+setTimeout(function(){
+  assert.equal('/', req5.path)
+}, 1)
+
+
+// Test modifying the qs after creating the request
+var req6 = request.get({ uri: 'http://www.google.com', qs: {}, useQuerystring: true})
+req6.qs({ q: "test" });
+process.nextTick(function() {
+  assert.equal('/?q=test', req6.path);
+});
+
+// Test using array param
+var req7 = request.get({ uri: 'http://www.google.com', qs: {foo: ['bar', 'baz']}, useQuerystring: true})
+process.nextTick(function() {
+  assert.equal('/?foo=bar&foo=baz', req7.path);
+});
+
+// Test using array param
+var req7 = request.get({ uri: 'http://www.google.com', qs: {foo: ['bar', 'baz']}, useQuerystring: true})
+process.nextTick(function() {
+  assert.equal('/?foo=bar&foo=baz', req7.path);
+});


### PR DESCRIPTION
Add the ability to specify whether qs or querystring should be used for parsing and stringifying by passing a useQuerystring boolean option. Fixes #644.

Has been addressed earlier in https://github.com/mikeal/request/pull/847 and will now merge cleanly.
