### PR TITLE
Fix localAddress test on OS X

### DIFF
--- a/tests/test-localAddress.js
+++ b/tests/test-localAddress.js
@@ -19,7 +19,6 @@ tape('bind to local address', function(t) {
     localAddress: '127.0.0.1'
   }, function(err, res) {
     t.notEqual(err, null)
-    t.equal(err.message, 'connect EINVAL')
     t.equal(res, undefined)
     t.end()
   })


### PR DESCRIPTION
Don't test the error message because on OS X it's EADDRNOTAVAIL instead of EINVAL.  (We leave in the test that an error occurs, and the message wasn't tested before the test suite rewrite either.)

Would appreciate confirmation from @mikeal / @seanstrom / @emkay that this works as intended.  If so, this fixes #1148.
