### PR TITLE
fix no-use-before-define lint warnings

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -30,13 +30,13 @@ function constructOptionsFrom(uri, options) {
   return params.done()
 }
 
+function isFunction(value) {
+  return typeof value === 'function'
+}
+
 function filterForCallback(values) {
   var callbacks = values.filter(isFunction)
   return callbacks[0]
-}
-
-function isFunction(value) {
-  return typeof value === 'function'
 }
 
 function paramsHaveRequestBody(params) {


### PR DESCRIPTION
This should fix the rest of the lint warnings. I moved all the helper functions to the top. There were 1 or 2 that were not throwing a warning because they were not in use in this file, but I moved them anyways since I had to move the others. I thought up at the top was a good place. Any objections?

@FredKSchott @nylen @mikeal 
