### PR TITLE
Update eslintrc file to no longer allow past errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,10 +7,10 @@
     "semi": [2, "never"],
     // Require strings to use single quotes
     "quotes": [2, "single"],
-    // Require curly braces for all control statements (warning until all violations fixed)
-    "curly": 1,
-    // Disallow using variables and functions before they've been defined (warning until all violations fixed)
-    "no-use-before-define": 1,
+    // Require curly braces for all control statements
+    "curly": 2,
+    // Disallow using variables and functions before they've been defined
+    "no-use-before-define": 2,
     // Allow any case for variable naming
     "camelcase": 0,
     // Disallow unused variables, except as function arguments


### PR DESCRIPTION
@emkay @nylen @mikeal Does this new rule list work? I'm not sure where we ended up re: #1156 and one-line if-statements, but it sounds like it's not possible to allow only those
