### PR TITLE
Cleanup event listeners and remove function creation from init

### DIFF
--- a/request.js
+++ b/request.js
@@ -166,7 +166,19 @@ function getTunnelFn(request) {
   return tunnel[tunnelFnName]
 }
 
-// Helpers
+// Function for properly handling a connection error
+function connectionErrorHandler(error) {
+  var socket = this
+  if (socket.res) {
+    if (socket.res.request) {
+      socket.res.request.emit('error', error)
+    } else {
+      socket.res.emit('error', error)
+    }
+  } else {
+    socket._httpMessage.emit('error', error)
+  }
+}
 
 // Return a simpler request object to allow serialization
 function requestToJSON() {
@@ -429,37 +441,6 @@ Request.prototype.init = function (options) {
   } else {
     self.port = self.uri.port
     self.host = self.uri.hostname
-  }
-
-  self.clientErrorHandler = function (error) {
-    if (self._aborted) {
-      return
-    }
-    if (self.req && self.req._reusedSocket && error.code === 'ECONNRESET'
-        && self.agent.addRequestNoreuse) {
-      self.agent = { addRequest: self.agent.addRequestNoreuse.bind(self.agent) }
-      self.start()
-      self.req.end()
-      return
-    }
-    if (self.timeout && self.timeoutTimer) {
-      clearTimeout(self.timeoutTimer)
-      self.timeoutTimer = null
-    }
-    self.emit('error', error)
-  }
-
-  self._parserErrorHandler = function (error) {
-    var socket = this
-    if (socket.res) {
-      if (socket.res.request) {
-        socket.res.request.emit('error', error)
-      } else {
-        socket.res.emit('error', error)
-      }
-    } else {
-      socket._httpMessage.emit('error', error)
-    }
   }
 
   self._buildRequest = function(){
@@ -990,7 +971,7 @@ Request.prototype.start = function () {
   delete reqOptions.auth
 
   debug('make request', self.uri.href)
-  self.req = self.httpModule.request(reqOptions, self.onResponse.bind(self))
+  self.req = self.httpModule.request(reqOptions)
 
   if (self.timeout && !self.timeoutTimer) {
     self.timeoutTimer = setTimeout(function () {
@@ -1014,7 +995,8 @@ Request.prototype.start = function () {
     }
   }
 
-  self.req.on('error', self.clientErrorHandler)
+  self.req.on('response', self.onRequestResponse.bind(self))
+  self.req.on('error', self.onRequestError.bind(self))
   self.req.on('drain', function() {
     self.emit('drain')
   })
@@ -1024,22 +1006,42 @@ Request.prototype.start = function () {
 
   self.on('end', function() {
     if ( self.req.connection ) {
-      self.req.connection.removeListener('error', self._parserErrorHandler)
+      self.req.connection.removeListener('error', connectionErrorHandler)
     }
   })
   self.emit('request', self.req)
 }
-Request.prototype.onResponse = function (response) {
+
+Request.prototype.onRequestError = function (error) {
   var self = this
-  debug('onResponse', self.uri.href, response.statusCode, response.headers)
+  if (self._aborted) {
+    return
+  }
+  if (self.req && self.req._reusedSocket && error.code === 'ECONNRESET'
+      && self.agent.addRequestNoreuse) {
+    self.agent = { addRequest: self.agent.addRequestNoreuse.bind(self.agent) }
+    self.start()
+    self.req.end()
+    return
+  }
+  if (self.timeout && self.timeoutTimer) {
+    clearTimeout(self.timeoutTimer)
+    self.timeoutTimer = null
+  }
+  self.emit('error', error)
+}
+
+Request.prototype.onRequestResponse = function (response) {
+  var self = this
+  debug('onRequestResponse', self.uri.href, response.statusCode, response.headers)
   response.on('end', function() {
     debug('response end', self.uri.href, response.statusCode, response.headers)
   })
 
   // The check on response.connection is a workaround for browserify.
-  if (response.connection && response.connection.listeners('error').indexOf(self._parserErrorHandler) === -1) {
+  if (response.connection && response.connection.listeners('error').indexOf(connectionErrorHandler) === -1) {
     response.connection.setMaxListeners(0)
-    response.connection.once('error', self._parserErrorHandler)
+    response.connection.once('error', connectionErrorHandler)
   }
   if (self._aborted) {
     debug('aborted', self.uri.href)

--- a/tests/test-node-debug.js
+++ b/tests/test-node-debug.js
@@ -31,7 +31,7 @@ tape('a simple request should not fail with debugging enabled', function(t) {
     ;[
       /^REQUEST { uri: /,
       /^REQUEST make request http:\/\/localhost:6767\/\n$/,
-      /^REQUEST onResponse /,
+      /^REQUEST onRequestResponse /,
       /^REQUEST finish init /,
       /^REQUEST response end /,
       /^REQUEST end event /,


### PR DESCRIPTION
There was suprisingly no reason for these functions to be created in every call to `init()`. They are now instead created only once, boosting performance and removing lines from the already bloated init().

(Somewhat) a part of #1146 
