### PR TITLE
add metadata for form-data file field

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,13 @@ var formData = {
   my_buffer: new Buffer([1, 2, 3]),
   my_file: fs.createReadStream(__dirname + '/unicycle.jpg'),
   remote_file: request(remoteFile),
+  attachments: [
+    fs.createReadStream(__dirname + '/attacment1.jpg')
+    fs.createReadStream(__dirname + '/attachment2.jpg')
+  ],
   custom_file: {
     value:  fs.createReadStream('/dev/urandom'),
+    // See the [form-data](https://github.com/felixge/node-form-data) README for more information about options.
     options: {
       filename: 'topsecret.jpg',
       contentType: 'image/jpg'

--- a/request.js
+++ b/request.js
@@ -472,13 +472,22 @@ Request.prototype.init = function (options) {
     if (options.formData) {
       var formData = options.formData
       var requestForm = self.form()
+      var appendFormValue = function (key, value) {
+        if (value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
+          requestForm.append(key, value.value, value.options)
+        } else {
+          requestForm.append(key, value)
+        }
+      }
       for (var formKey in formData) {
         if (formData.hasOwnProperty(formKey)) {
           var formValue = formData[formKey]
-          if (formValue.hasOwnProperty('value') && formValue.hasOwnProperty('options')) {
-            requestForm.append(formKey, formValue.value, formValue.options)
+          if (formValue instanceof Array) {
+            for (var j = 0; j < formValue.length; j++) {
+              appendFormValue(formKey, formValue[j])
+            }
           } else {
-            requestForm.append(formKey, formValue)
+            appendFormValue(formKey, formValue)
           }
         }
       }


### PR DESCRIPTION
Some web servers don't want to receive multipart form data with files without mime type and file name.

And as bonus i removed all trailing spaces in readme.
