### PR TITLE
Support formData array fields

### DIFF
--- a/request.js
+++ b/request.js
@@ -476,8 +476,8 @@ Request.prototype.init = function (options) {
       for (var formKey in formData) {
         if (formData.hasOwnProperty(formKey)) {
           if (formData[formKey] instanceof Array) {
-            for (var i=0; i < formData[formKey].length; i++) {
-              requestForm.append(formKey, formData[formKey][i])
+            for (var j = 0; j < formData[formKey].length; j++) {
+              requestForm.append(formKey, formData[formKey][j])
             }
           } else {
             requestForm.append(formKey, formData[formKey])


### PR DESCRIPTION
:wave: 

I don't have a unit test for this one, but here is how I system tested it

``` js
request.post('https://api.mailgun.net/v2/[your-domain].mailgun.org/messages', {
  auth:{user:'api',pass:'apikey'},
  headers:{'content-type':'multipart/form-data'},
  formData:{
    from:'request@mailinator.com',
    to:'request@mailinator.com',
    subject:'Multiple Attachments',
    html:'<h1>Awesome!</h1>',
    text:'True idd!',
    attachment:[fs.createReadStream('cat.png'), fs.createReadStream('coffee.png')]
  }
},
function (err, res, body) {});
```

The result is an email with two attachments to it

[Mailgun Sending](http://documentation.mailgun.com/api-sending.html#sending)

> `attachment` - File attachment. You can post **multiple** attachment values. Important: You must use multipart/form-data encoding when sending attachments.

Same thing with Sendgrid

[Sendgrid Sending](https://sendgrid.com/docs/API_Reference/Web_API/mail.html)

> `files` - Files to be attached. The file contents must be part of the multipart HTTP POST. Ex: files[file1.jpg]=file1.jpg&[file2.pdf]=file2.pdf

Now when I think about it, why is the `headers:{'content-type':'multipart/form-data'}` not set by default when the `formData` key is present?
