### PR TITLE
Enable no-mixed-requires linting rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,9 +17,6 @@
     "no-unused-vars": [2, {"args":"none"}],
     // Allow leading underscores for method names
     // REASON: we use underscores to denote private methods
-    "no-underscore-dangle": 0,
-    // Allow non-require statements mixed in with module require statements
-    // REASON: we use the `optional()` helper, which makes this rule impossible to enforce
-    "no-mixed-requires": 0
+    "no-underscore-dangle": 0
   }
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@
 var extend                = require('util')._extend
   , cookies               = require('./lib/cookies')
   , helpers               = require('./lib/helpers')
-  , isFunction            = helpers.isFunction
+
+var isFunction            = helpers.isFunction
   , constructObject       = helpers.constructObject
   , filterForCallback     = helpers.filterForCallback
   , constructOptionsFrom  = helpers.constructOptionsFrom

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,8 +1,9 @@
 'use strict'
 
 var tough = require('tough-cookie')
-  , Cookie = tough && tough.Cookie
-  , CookieJar = tough && tough.CookieJar
+
+var Cookie = tough.Cookie
+  , CookieJar = tough.CookieJar
 
 
 exports.parse = function(str) {

--- a/request.js
+++ b/request.js
@@ -9,11 +9,6 @@ var http = require('http')
   , querystring = require('querystring')
   , zlib = require('zlib')
   , helpers = require('./lib/helpers')
-  , safeStringify = helpers.safeStringify
-  , md5 = helpers.md5
-  , isReadStream = helpers.isReadStream
-  , toBase64 = helpers.toBase64
-  , defer = helpers.defer
   , bl = require('bl')
   , oauth = require('oauth-sign')
   , hawk = require('hawk')
@@ -24,20 +19,23 @@ var http = require('http')
   , tunnel = require('tunnel-agent')
   , stringstream = require('stringstream')
   , caseless = require('caseless')
-
   , ForeverAgent = require('forever-agent')
   , FormData = require('form-data')
-
   , cookies = require('./lib/cookies')
-  , globalCookieJar = cookies.jar()
-
   , copy = require('./lib/copy')
   , debug = require('./lib/debug')
   , net = require('net')
 
+var safeStringify = helpers.safeStringify
+  , md5 = helpers.md5
+  , isReadStream = helpers.isReadStream
+  , toBase64 = helpers.toBase64
+  , defer = helpers.defer
+  , globalCookieJar = cookies.jar()
+
 
 var globalPool = {}
-var isUrl = /^https?:|^unix:/
+  , isUrl = /^https?:|^unix:/
 
 var defaultProxyHeaderWhiteList = [
   'accept',


### PR DESCRIPTION
Don't allow non-require statements mixed in with module require
statements.  We can do this now that optional dependencies were removed
in #1173.
