### PR TITLE
Correct README about pre and postamble CRLF using multipart and not mult...

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ form.append('my_buffer', fs.createReadStream(__dirname + '/unicycle.jpg'), {file
 ```
 See the [form-data](https://github.com/felixge/node-form-data) README for more information & examples.
 
-Some variations in different HTTP implementations require a newline/CRLF before, after, or both before and after the boundary of a `multipart` (or `multipart/related`) request. This has been observed in the .NET WebAPI version 4.0. You can turn on a boundary preambleCRLF or postamble by passing them as `true` to your request options.
+Some variations in different HTTP implementations require a newline/CRLF before, after, or both before and after the boundary of a `multipart/related` request (using the multipart option). This has been observed in the .NET WebAPI version 4.0. You can turn on a boundary preambleCRLF or postamble by passing them as `true` to your request options.
 
 ```javascript
   request(


### PR DESCRIPTION
...ipart/formdata

Documentation now matches internal working of the library, see https://github.com/mikeal/request/commit/b4e3241a63f5b7342780f1ee36cab20ebd878d2b#commitcomment-8199579
