### PR TITLE
Support Smarter Unix URL Scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,15 +201,15 @@ Here's some examples of valid `no_proxy` values:
 
 ## UNIX Socket
 
-`request` supports the `unix://` protocol for all requests. The path is assumed to be absolute to the root of the host file system.
-
-HTTP paths are extracted from the supplied URL by testing each level of the full URL against net.connect for a socket response.
-
-Thus the following request will GET `/httppath` from the HTTP server listening on `/tmp/unix.socket`
+`request` supports making requests to [UNIX Domain Sockets](http://en.wikipedia.org/wiki/Unix_domain_socket). To make one, use the following URL scheme:
 
 ```javascript
-request.get('unix://tmp/unix.socket/httppath')
+/* Pattern */ 'http://unix:SOCKET:PATH'
+/* Example */ request.get('http://unix:/absolute/path/to/unix.socket:/request/path')
 ```
+
+Note: The `SOCKET` path is assumed to be absolute to the root of the host file system.
+
 
 ## Forms
 

--- a/tests/test-errors.js
+++ b/tests/test-errors.js
@@ -31,6 +31,15 @@ tape('invalid uri 2', function(t) {
   t.end()
 })
 
+tape('deprecated unix URL', function(t) {
+  t.throws(function() {
+    request({
+      uri: 'unix://path/to/socket/and/then/request/path'
+    })
+  }, /^Error: `unix:\/\/` URL scheme is no longer supported/)
+  t.end()
+})
+
 tape('invalid body', function(t) {
   t.throws(function() {
     request({

--- a/tests/test-unix.js
+++ b/tests/test-unix.js
@@ -27,7 +27,7 @@ tape('setup', function(t) {
 })
 
 tape('unix socket connection', function(t) {
-  request(['unix://', socket, path].join(''), function(err, res, body) {
+  request('http://unix:' + socket + ':' +  path, function(err, res, body) {
     t.equal(err, null, 'no error in connection')
     t.equal(res.statusCode, statusCode, 'got HTTP 200 OK response')
     t.equal(body, expectedBody, 'expected response body is received')


### PR DESCRIPTION
A part of #1146 `Request.init()` Refactor
Fixes #1166 
- No longer validate UNIX URLs by attempting to connect to every possible combination of hosts and paths
- Now possible to bring `_buildRequest()` logic back into the `init()` method

So I went the "smarter URL scheme" route, and more or less copied the work done in ngx_http_proxy_module. We now use the URL scheme `'http://unix:SOCKET:PATH'`. No new option required, and the change is much less severe. It also makes more sense, since these requests were already using the http protocol behind the scenes.

```
OLD: request.get('unix://absolute/path/to/unix.socket/request/path')
NEW: request.get('http://unix:/absolute/path/to/unix.socket:/request/path')
```

An error is thrown if you use the old format.

/cc @mikeal & everyone from #1166
