### PR TITLE
Use no_proxy when self.proxy is falsey

### DIFF
--- a/request.js
+++ b/request.js
@@ -354,7 +354,7 @@ Request.prototype.init = function (options) {
     self.rejectUnauthorized = false
   }
 
-  if(!self.hasOwnProperty('proxy')) {
+  if(!self.proxy) {
     // check for HTTP(S)_PROXY environment variables
     if(self.uri.protocol === 'http:') {
         self.proxy = process.env.HTTP_PROXY || process.env.http_proxy || null


### PR DESCRIPTION
When `self.proxy === undefined` or `self.proxy === null`, the no_proxy logic is not executed. Change test to look for falsey value of `self.proxy` instead of existence of property.

See https://github.com/mikeal/request/issues/1194 for more details.
