### PR TITLE
Clean up some code around setting the agent

### DIFF
--- a/request.js
+++ b/request.js
@@ -626,15 +626,7 @@ Request.prototype.init = function (options) {
   if (self.pool === false) {
     self.agent = false
   } else {
-    self.agent = self.agent || self.getAgent()
-    if (self.maxSockets) {
-      // Don't use our pooling if node has the refactored client
-      self.agent.maxSockets = self.maxSockets
-    }
-    if (self.pool.maxSockets) {
-      // Don't use our pooling if node has the refactored client
-      self.agent.maxSockets = self.pool.maxSockets
-    }
+    self.agent = self.agent || self.getNewAgent()
   }
 
   self.on('pipe', function (src) {
@@ -745,7 +737,7 @@ Request.prototype._updateProtocol = function () {
 
     // if there's an agent, we need to get a new one.
     if (self.agent) {
-      self.agent = self.getAgent()
+      self.agent = self.getNewAgent()
     }
 
   } else {
@@ -766,12 +758,12 @@ Request.prototype._updateProtocol = function () {
     // if there's an agent, then get a new one.
     if (self.agent) {
       self.agent = null
-      self.agent = self.getAgent()
+      self.agent = self.getNewAgent()
     }
   }
 }
 
-Request.prototype.getAgent = function () {
+Request.prototype.getNewAgent = function () {
   var self = this
   var Agent = self.agentClass
   var options = {}
@@ -877,6 +869,10 @@ Request.prototype.getAgent = function () {
   // generate a new agent for this setting if none yet exists
   if (!self.pool[poolKey]) {
     self.pool[poolKey] = new Agent(options)
+    // properly set maxSockets on new agents
+    if (self.pool.maxSockets) {
+      self.pool[poolKey].maxSockets = self.pool.maxSockets
+    }
   }
 
   return self.pool[poolKey]


### PR DESCRIPTION
Some small cleanup around setting and getting the http/https agent. Looks like maxSockets weren't getting properly set when outside of init, so I moved that logic into `getAgent()`, which has been renamed to `_chooseAgent()` since it doesn't literally get the current agent, as the name suggests. (Underscore added since it looks like it should only be called privately) (happy to bikeshed on a name, I'm not particularly tied to `_chooseAgent` and I'm sure there are better names out there)

@mikeal I'd want your sign off on this since it's touching some older code
