### PR TITLE
Fix lint error: undeclared var i

### DIFF
--- a/request.js
+++ b/request.js
@@ -584,7 +584,7 @@ Request.prototype.init = function (options) {
     var length = 0
     if (!Buffer.isBuffer(self.body)) {
       if (Array.isArray(self.body)) {
-        for (i = 0; i < self.body.length; i++) {
+        for (var i = 0; i < self.body.length; i++) {
           length += self.body[i].length
         }
       } else {


### PR DESCRIPTION
It looks like with the combination of #1190 and #1191 this variable got
undeclared by mistake.
