### PR TITLE
Improve release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,37 @@
 #!/bin/sh
 
-npm version minor && npm publish && npm version patch && git push --tags && git push origin master
+if [ -z "`which github-changes`" ]; then
+  echo "First, do: [sudo] npm install -g github-changes"
+  exit 1
+fi
+
+if [ -d .git/refs/remotes/upstream ]; then
+  remote=upstream
+else
+  remote=origin
+fi
+
+# Increment v2.x.y -> v2.x+1.0
+npm version minor || exit 1
+
+# Generate changelog from pull requests
+github-changes -o mikeal -r request \
+  --auth --verbose \
+  --file CHANGELOG.md \
+  --only-pulls --use-commit-body \
+  || exit 1
+
+# This may fail if no changelog updates
+# TODO: would this ever actually happen?  handle it better?
+git add CHANGELOG.md; git commit -m 'Update changelog'
+
+# Publish the new version to npm
+npm publish || exit 1
+
+# Increment v2.x.0 -> v2.x.1
+# For rationale, see:
+# https://github.com/request/oauth-sign/issues/10#issuecomment-58917018
+npm version patch || exit 1
+
+# Push back to the main repo
+git push $remote master --tags || exit 1


### PR DESCRIPTION
#### Auto-detect upstream remote

If a remote named `upstream` exists, use it, otherwise use `origin`.
#### Update changelog

As discussed at #1205, update the changelog using [`github-changes`](/lalitkapoor/github-changes).  The changelog output will not be exactly the same until lalitkapoor/github-changes#40 and lalitkapoor/github-changes#41 are merged.

_[ Edit: Fixes #1206 ]_
