### PR TITLE
Allow 'Host' header instead of 'host' and remember case across redirects

### DIFF
--- a/request.js
+++ b/request.js
@@ -448,11 +448,12 @@ Request.prototype.init = function (options) {
 
   self.setHost = false
   if (!self.hasHeader('host')) {
-    self.setHeader('host', self.uri.hostname)
+    var hostHeaderName = self.originalHostHeaderName || 'host'
+    self.setHeader(hostHeaderName, self.uri.hostname)
     if (self.uri.port) {
       if ( !(self.uri.port === 80 && self.uri.protocol === 'http:') &&
            !(self.uri.port === 443 && self.uri.protocol === 'https:') ) {
-        self.setHeader('host', self.getHeader('host') + (':' + self.uri.port) )
+        self.setHeader(hostHeaderName, self.getHeader('host') + (':' + self.uri.port) )
       }
     }
     self.setHost = true
@@ -1013,8 +1014,13 @@ Request.prototype.onRequestResponse = function (response) {
   }
 
   // Save the original host before any redirect (if it changes, we need to
-  // remove any authorization headers)
-  self.originalHost = self.headers.host
+  // remove any authorization headers).  Also remember the case of the header
+  // name because lots of broken servers expect Host instead of host and we
+  // want the caller to be able to specify this.
+  self.originalHost = self.getHeader('host')
+  if (!self.originalHostHeaderName) {
+    self.originalHostHeaderName = self.hasHeader('host')
+  }
   if (self.setHost) {
     self.removeHeader('host')
   }


### PR DESCRIPTION
As of v2.46.0 (because of #1184) we get a crash when the user specifies `{ headers : Host }` and a redirect occurs.  This fixes #1210, see that issue for details.

We should also preserve the case of the header name if the user specifies `Host`, because lots of (broken) servers expect the header name to be `Host` and not `host`, and this has been an issue for a lot of people:  #346, #406, #411, #426, #430, #990, #1210.

Needs review @mikeal @FredKSchott @seanstrom @tbuchok and anyone else.  The test especially is a little hairy, so I'm definitely open to better ways of doing it.
