### PR TITLE
Remove cruft left over from optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,6 @@ request('http://www.google.com', function () {
 OR
 
 ```javascript
-// `npm install --save tough-cookie` before this works
 var j = request.jar();
 var cookie = request.cookie('key1=value1');
 var url = 'http://www.google.com';

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -13,9 +13,6 @@ exports.parse = function(str) {
   if (typeof str !== 'string') {
     throw new Error('The cookie function only accepts STRING as param')
   }
-  if (!Cookie) {
-    return null
-  }
   return Cookie.parse(str)
 }
 
@@ -38,13 +35,5 @@ RequestJar.prototype.getCookies = function(uri) {
 }
 
 exports.jar = function(store) {
-  if (!CookieJar) {
-    // tough-cookie not loaded, return a stub object:
-    return {
-      setCookie: function(){},
-      getCookieString: function(){},
-      getCookies: function(){}
-    }
-  }
   return new RequestJar(store)
 }


### PR DESCRIPTION
Now that tough-cookie is always installed we can remove a few things.
