### PR TITLE
Added check for originalHost before splitting

### DIFF
--- a/request.js
+++ b/request.js
@@ -1186,7 +1186,7 @@ Request.prototype.onRequestResponse = function (response) {
         self.removeHeader('host')
         self.removeHeader('content-type')
         self.removeHeader('content-length')
-        if (self.uri.hostname !== self.originalHost.split(':')[0]) {
+        if (self.originalHost && self.uri.hostname !== self.originalHost.split(':')[0]) {
           // Remove authorization if changing hostnames (but not if just
           // changing ports or protocols).  This matches the behavior of curl:
           // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710


### PR DESCRIPTION
I encountered an issue when following all redirects on a request:

../node_modules/request/request.js:1195
        if (self.uri.hostname !== self.originalHost.split(':')[0]) {
                                                    ^
TypeError: Cannot call method 'split' of undefined
    at Request.onRequestResponse (../node_modules/request/request.js:1195:53)
    at ClientRequest.EventEmitter.emit (events.js:95:17)
    at HTTPParser.parserOnIncomingClient [as onIncoming](http.js:1688:21)
    at HTTPParser.parserOnHeadersComplete [as onHeadersComplete](http.js:121:23)
    at Socket.socketOnData [as ondata](http.js:1583:20)
    at TCP.onread (net.js:527:27)

Upon further debugging, it appeared that self.originalHost was undefined at one point in the series of redirects, a simple check for self.originalHost seems to have resolved this issue.
