### PR TITLE
update qs dependency to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "json-stringify-safe": "~5.0.0",
     "mime-types": "~1.0.1",
     "node-uuid": "~1.4.0",
-    "qs": "~1.2.0",
+    "qs": "~2.3.1",
     "tunnel-agent": "~0.4.0",
     "tough-cookie": ">=0.12.0",
     "http-signature": "~0.10.0",


### PR DESCRIPTION
Pulled out of #1189, changelog reviewed and confirmed that we're okay to upgrade

>  I dug into qs and it sounds like there have been some major performance improvements. The interface for passing options has totally changed, but luckily we don't use that so we should be fine upgrade to 2.3.1. Tests continue to pass if we do.
