### PR TITLE
Show latest version number instead of "upcoming" in changelog

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -21,6 +21,11 @@ github-changes -o request -r request \
   --only-pulls --use-commit-body \
   || exit 1
 
+# Since the tag for the new version hasn't been pushed yet, any changes in it
+# will be marked as "upcoming"
+version="$(grep '"version"' package.json | cut -d'"' -f4)"
+sed -i -e "s/^### upcoming/### v$version/" CHANGELOG.md
+
 # This may fail if no changelog updates
 # TODO: would this ever actually happen?  handle it better?
 git add CHANGELOG.md; git commit -m 'Update changelog'


### PR DESCRIPTION
Since the tag for the new version hasn't been pushed to GitHub yet when the changelog is generated, any changes in it will be marked as "upcoming".  Fix this with some shell scripting.

@mikeal @emkay or anyone else who uses OS X:  does this `sed` invocation work correctly there?
