### PR TITLE
Require npm version which supports `^` specifier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+before_install:
+  - npm install -g npm
 webhooks:
   urls: https://webhooks.gitter.im/e/237280ed4796c19cc626
   on_success: change  # options: [always|never|change] default: always

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.4.3"
   },
+  "engineStrict": true,
   "main": "index.js",
   "dependencies": {
     "bl": "~0.9.0",


### PR DESCRIPTION
- The only problem in [this error](https://travis-ci.org/request/request/builds/38507557) is that npm v1.2 doesn’t support `^` version specifier. It's not the problem of Node v0.8 itself. So I added `before_install` command to install the latest version of npm before installing the dependencies of request.
- This change requires the users of this module to use npm >= 1.4.3. So I updated [`engines`](https://www.npmjs.org/doc/files/package.json.html#engines) in package.json and added [`engineStrict`](https://www.npmjs.org/doc/files/package.json.html#enginestrict) field.

After merging this PR, we can also merge #1189 without dropping Node v0.8 support.
