### PR TITLE
Fixed a syntax error / typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ var formData = {
   my_file: fs.createReadStream(__dirname + '/unicycle.jpg'),
   // Pass multiple values /w an Array
   attachments: [
-    fs.createReadStream(__dirname + '/attacment1.jpg')
+    fs.createReadStream(__dirname + '/attacment1.jpg'),
     fs.createReadStream(__dirname + '/attachment2.jpg')
   ],
   // Pass optional meta-data with an 'options' object with style: {value: DATA, options: OPTIONS}


### PR DESCRIPTION
Sample code for multipart/form-data section missed a comma in the array. 
