### PR TITLE
Return empty buffer (instead of empty string) when an empty response body is received and encoding is set to null

### DIFF
--- a/request.js
+++ b/request.js
@@ -1312,7 +1312,7 @@ Request.prototype.onRequestResponse = function (response) {
         }
         debug('emitting complete', self.uri.href)
         if(typeof response.body === 'undefined' && !self._json) {
-          response.body = ''
+          response.body = self.encoding === null ? new Buffer(0) : '';
         }
         self.emit('complete', response, response.body)
       })


### PR DESCRIPTION
I manually set `encoding: null`, and indeed receive the body as a Buffer. However, if the response body is empty (`Content-Length: 0`), then the body is returned as an empty string (and of course type errors are thrown everywhere).
