### PR TITLE
Fix for OAuth encoding taken from node-oauth. This fixes auth validation...

### DIFF
--- a/request.js
+++ b/request.js
@@ -1607,11 +1607,11 @@ Request.prototype.oauth = function (_oauth) {
         'application/x-www-form-urlencoded'
      ) {
     form = self.body = self.body
-      .replace(/\!/g, "%21")
-      .replace(/\'/g, "%27")
-      .replace(/\(/g, "%28")
-      .replace(/\)/g, "%29")
-      .replace(/\*/g, "%2A")
+      .replace(/\!/g, '%21')
+      .replace(/\'/g, '%27')
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
+      .replace(/\*/g, '%2A')
   }
   if (self.uri.query) {
     query = self.uri.query


### PR DESCRIPTION
... breaking when body contains these characters. Taken from here https://github.com/ciaranj/node-oauth/blob/master/lib/oauth.js

Discovered this problem while trying to post status "Schoolin' (EE#3)" with image to Twitter https://twitter.com/olado/status/537307357420998656
