### PR TITLE
Update README.md to explain custom file use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ var formData = {
     fs.createReadStream(__dirname + '/attachment2.jpg')
   ],
   // Pass optional meta-data with an 'options' object with style: {value: DATA, options: OPTIONS}
+  // Use case: for some types of streams, you'll need to provide "file"-related information manually.
   // See the `form-data` README for more information about options: https://github.com/felixge/node-form-data
   custom_file: {
     value:  fs.createReadStream('/dev/urandom'),


### PR DESCRIPTION
Add documentation to indicate a use case for custom file values and options in multipart form data requests. 

The added sentence may have saved my team a few hours.

Our specific use case:
- We wanted to receive uploaded files and send them directly to an external service without allowing the files to be written to disk.
- Because we were uploading a file from a stream, we needed to add custom file-related information in our request to the external service.
