### PR TITLE
fix(proxy): no-proxy false positive

### DIFF
--- a/request.js
+++ b/request.js
@@ -199,7 +199,8 @@ function getProxyFromURI(uri) {
         }
       } else {
         noProxyItem = noProxyItem.replace(/^\.*/, '.')
-        if (hostname.indexOf(noProxyItem) === hostname.length - noProxyItem.length) {
+        var isMatchedAt = hostname.indexOf(noProxyItem)
+        if (isMatchedAt > -1 && isMatchedAt === hostname.length - noProxyItem.length) {
           return null
         }
       }

--- a/tests/test-proxy.js
+++ b/tests/test-proxy.js
@@ -131,6 +131,13 @@ if (process.env.TEST_PROXY_HARNESS) {
     env : { http_proxy : s.url }
   }, true)
 
+  runTest('http_proxy with length of one more than the URL', {
+    env: {
+      HTTP_PROXY : s.url,
+      NO_PROXY: 'elgoog1.com' // one more char than google.com
+    }
+  }, true)
+
   runTest('NO_PROXY hostnames are case insensitive', {
     env : {
       HTTP_PROXY : s.url,


### PR DESCRIPTION
If one of the no-proxy item is exactly one character longer than the
request URL, it was considered as a valid match for no-proxy case
detection.

This patch handle the special (-1) value to close issue #1294.
