### PR TITLE
Cast timeout to a number.

### DIFF
--- a/request.js
+++ b/request.js
@@ -914,6 +914,8 @@ Request.prototype.start = function () {
   self.req = self.httpModule.request(reqOptions)
 
   if (self.timeout && !self.timeoutTimer) {
+    self.timeout *= 1;
+    
     self.timeoutTimer = setTimeout(function () {
       self.abort()
       var e = new Error('ETIMEDOUT')


### PR DESCRIPTION
This creates consistency in the timeout feature.

The `setTimeout` implementation in node will correctly cast any strings passed in to a number using `*= 1`

This means that 

```js
request({
  uri: '/foo',
  timeout: '5000'
}, cb);
```

will work as expected.

**HOWEVER** the `req.setTimeout` method does not cast strings to number. It instead defaults to no timeout when passed a string. 

To guard against this bug in node core we manually cast the string to a number in `request/request` itself so that it is consistent.