### PR TITLE
Upgrade form-data, add back browserify compability. Fixes #455.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bl": "~0.9.0",
     "caseless": "~0.8.0",
     "forever-agent": "~0.5.0",
-    "form-data": "~0.1.0",
+    "form-data": "~0.2.0",
     "json-stringify-safe": "~5.0.0",
     "mime-types": "~1.0.1",
     "node-uuid": "~1.4.0",


### PR DESCRIPTION
The form-data module now has moved to a "browserifiable" mime module, so request can again be built with browserify if we upgrade to the latest version of form-data.

This PR fixes that.

Just wondering. If I make a PR where I add a test suite for making sure request can be used with browserify, will that be considered being added into request?
