### PR TITLE
Use faster container-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ webhooks:
   on_success: change  # options: [always|never|change] default: always
   on_failure: always  # options: [always|never|change] default: always
   on_start: false     # default: false
+sudo: false


### PR DESCRIPTION
Travis has an option to run builds in Docker containers now, which makes the builds start and complete much faster.  See the [Travis blog post](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) for details.
