### PR TITLE
Fix errors generating coverage reports.

### DIFF
--- a/tests/test-cookies.js
+++ b/tests/test-cookies.js
@@ -91,6 +91,7 @@ tape('custom store', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-follow-all-303.js
+++ b/tests/test-follow-all-303.js
@@ -38,6 +38,7 @@ tape('followAllRedirects with 303', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-follow-all.js
+++ b/tests/test-follow-all.js
@@ -50,6 +50,7 @@ tape('followAllRedirects', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -97,8 +97,9 @@ function runTest(t, json) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.deepEqual(body, json ? {status: 'done'} : 'done')
-      server.close()
-      t.end()
+      server.close(function() {
+        t.end()
+      })
     })
 
   })

--- a/tests/test-form-urlencoded.js
+++ b/tests/test-form-urlencoded.js
@@ -27,14 +27,15 @@ function runTest (t, options) {
     })
   })
 
-  server.listen(8080, function() {
+  server.listen(6767, function() {
 
-    request.post('http://localhost:8080', options, function(err, res, body) {
+    request.post('http://localhost:6767', options, function(err, res, body) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.equal(body, 'done')
-      server.close()
-      t.end()
+      server.close(function() {
+        t.end()
+      })
     })
   })
 }

--- a/tests/test-form.js
+++ b/tests/test-form.js
@@ -65,7 +65,6 @@ tape('multipart form append', function(t) {
       res.end('done')
 
       t.equal(FIELDS.length, 0)
-      t.end()
     })
   })
 
@@ -82,7 +81,9 @@ tape('multipart form append', function(t) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.equal(body, 'done')
-      server.close()
+      server.close(function() {
+        t.end()
+      })
     })
     var form = req.form()
 

--- a/tests/test-gzip.js
+++ b/tests/test-gzip.js
@@ -140,6 +140,7 @@ tape('transparently supports gzip error to pipes', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-hawk.js
+++ b/tests/test-hawk.js
@@ -48,6 +48,7 @@ tape('hawk', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-http-signature.js
+++ b/tests/test-http-signature.js
@@ -103,6 +103,7 @@ tape('incorrect key', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-httpModule.js
+++ b/tests/test-httpModule.js
@@ -100,7 +100,9 @@ run_tests('https only', { 'https:': faux_https })
 run_tests('http and https', { 'http:': faux_http, 'https:': faux_https })
 
 tape('cleanup', function(t) {
-  plain_server.close()
-  https_server.close()
-  t.end()
+  plain_server.close(function() {
+    https_server.close(function() {
+      t.end()
+    })
+  })
 })

--- a/tests/test-multipart.js
+++ b/tests/test-multipart.js
@@ -107,8 +107,9 @@ function runTest(t, a) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.deepEqual(body, a.json ? {status: 'done'} : 'done')
-      server.close()
-      t.end()
+      server.close(function() {
+        t.end()
+      })
     })
 
   })

--- a/tests/test-onelineproxy.js
+++ b/tests/test-onelineproxy.js
@@ -54,6 +54,7 @@ tape('chained one-line proxying', function(t) {
 })
 
 tape('cleanup', function(t) {
-  server.close()
-  t.end()
+  server.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-rfc3986.js
+++ b/tests/test-rfc3986.js
@@ -44,8 +44,9 @@ function runTest (t, options) {
 
     request.post('http://localhost:8080', options, function(err, res, body) {
       t.equal(err, null)
-      server.close()
-      t.end()
+      server.close(function() {
+        t.end()
+      })
     })
   })
 }


### PR DESCRIPTION
server.close() is async, so treat it as such:

http://nodejs.org/api/net.html#net_server_close_callback

This doesn't seem to matter when test files are run in separate
processes using `npm test`, but it does when they are run in the same
process for the coverage report.

@simov fyi (hopefully this is the only issue with our coverage reporting)