### PR TITLE
Fix memory leak caused by multiple redirect.

### DIFF
--- a/request.js
+++ b/request.js
@@ -956,7 +956,7 @@ Request.prototype.start = function () {
     self.emit('socket', socket)
   })
 
-  if (self._isInitEnd) {
+  if (!self._isInitEnd) {
     self._isInitEnd = true
     self.on('end', function() {
       if ( self.req.connection ) {

--- a/request.js
+++ b/request.js
@@ -651,35 +651,39 @@ Request.prototype.init = function (options) {
     self.agent = self.agent || self.getNewAgent()
   }
 
-  self.on('pipe', function (src) {
-    if (self.ntick && self._started) {
-      throw new Error('You cannot pipe to this stream after the outbound request has started.')
-    }
-    self.src = src
-    if (isReadStream(src)) {
-      if (!self.hasHeader('content-type')) {
-        self.setHeader('content-type', mime.lookup(src.path))
+  if (!self._isInitPipe) {
+    self._isInitPipe = true
+    self.on('pipe', function (src) {
+      if (self.ntick && self._started) {
+        throw new Error('You cannot pipe to this stream after the outbound request has started.')
       }
-    } else {
-      if (src.headers) {
-        for (var i in src.headers) {
-          if (!self.hasHeader(i)) {
-            self.setHeader(i, src.headers[i])
+      self.src = src
+      if (isReadStream(src)) {
+        if (!self.hasHeader('content-type')) {
+          self.setHeader('content-type', mime.lookup(src.path))
+        }
+      } else {
+        if (src.headers) {
+          for (var i in src.headers) {
+            if (!self.hasHeader(i)) {
+              self.setHeader(i, src.headers[i])
+            }
           }
         }
+        if (self._json && !self.hasHeader('content-type')) {
+          self.setHeader('content-type', 'application/json')
+        }
+        if (src.method && !self.explicitMethod) {
+          self.method = src.method
+        }
       }
-      if (self._json && !self.hasHeader('content-type')) {
-        self.setHeader('content-type', 'application/json')
-      }
-      if (src.method && !self.explicitMethod) {
-        self.method = src.method
-      }
-    }
 
-    // self.on('pipe', function () {
-    //   console.error('You have already piped to this stream. Pipeing twice is likely to break the request.')
-    // })
-  })
+      // self.on('pipe', function () {
+      //   console.error('You have already piped to this stream. Pipeing twice is likely to break the request.')
+      // })
+    })
+
+  }
 
   defer(function () {
     if (self._aborted) {
@@ -952,11 +956,14 @@ Request.prototype.start = function () {
     self.emit('socket', socket)
   })
 
-  self.on('end', function() {
-    if ( self.req.connection ) {
-      self.req.connection.removeListener('error', connectionErrorHandler)
-    }
-  })
+  if (self._isInitEnd) {
+    self._isInitEnd = true
+    self.on('end', function() {
+      if ( self.req.connection ) {
+        self.req.connection.removeListener('error', connectionErrorHandler)
+      }
+    })
+  }
   self.emit('request', self.req)
 }
 


### PR DESCRIPTION
When processing multiple redirects Request will init more than once.
the `end event` register every time when the `Request.prototype.start`, also
the same with `pipe event` on `Request.prototype.init`.

you'll see the test scripts here: https://github.com/belltoy/request-redirect-test 
