### PR TITLE
Return empty buffer upon empty response body and encoding is set to null

### DIFF
--- a/request.js
+++ b/request.js
@@ -1321,7 +1321,7 @@ Request.prototype.onRequestResponse = function (response) {
         }
         debug('emitting complete', self.uri.href)
         if(typeof response.body === 'undefined' && !self._json) {
-          response.body = ''
+          response.body = self.encoding === null ? new Buffer(0) : ''
         }
         self.emit('complete', response, response.body)
       })

--- a/tests/test-emptyBody.js
+++ b/tests/test-emptyBody.js
@@ -15,11 +15,23 @@ tape('setup', function(t) {
   })
 })
 
-tape('empty body', function(t) {
+tape('empty body with encoding', function(t) {
   request('http://localhost:6767', function(err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
     t.equal(body, '')
+    t.end()
+  })
+})
+
+tape('empty body without encoding', function(t) {
+  request({
+    url: 'http://localhost:6767',
+    encoding: null
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.same(body, new Buffer(0))
     t.end()
   })
 })


### PR DESCRIPTION
Instead of returning an empty string, an empty buffer will now be
returned when the encoding is set to null.

This is a PR to finish the work started #1286
Credit to @ramonsnir

@nylen @FredKSchott Review? 
