### PR TITLE
Add clean script to remove test-browser.js after the tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "isstream": "~0.1.1"
   },
   "scripts": {
-    "test": "npm run lint && node node_modules/.bin/taper tests/test-*.js && npm run test-browser",
+    "test": "npm run lint && node node_modules/.bin/taper tests/test-*.js && npm run test-browser && npm run clean",
     "test-browser": "browserify tests/browser/test.js -o tests/browser/test-browser.js && karma start tests/browser/karma.conf.js",
-    "lint": "node node_modules/.bin/eslint lib/ *.js tests/ && echo Lint passed."
+    "lint": "node node_modules/.bin/eslint lib/ *.js tests/ && echo Lint passed.",
+    "clean": "rm tests/browser/test-browser.js || true"
   },
   "devDependencies": {
     "browserify": "~5.9.1",


### PR DESCRIPTION
Whenever you run `npm test` it would generate a file.
The location of the file would be `tests/browser/test-browser.js`
which is a directory that the linter will lint.
I tried making the linter ignore the file but it seems we're using
an older version of the linter which may not support ignoring paths.

I may be wrong but this was an alternative solution, safely delete
the file before running the linter.