### PR TITLE
Always wait for server.close() callback in tests

### DIFF
--- a/tests/test-agentOptions.js
+++ b/tests/test-agentOptions.js
@@ -41,6 +41,7 @@ tape('with agentOptions should apply to new agent in pool', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -179,6 +179,7 @@ tape('', function(t) {
 })
 
 tape('cleanup', function(t) {
-  basicServer.close()
-  t.end()
+  basicServer.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-bearer-auth.js
+++ b/tests/test-bearer-auth.js
@@ -148,6 +148,7 @@ tape('', function(t) {
 })
 
 tape('cleanup', function(t) {
-  bearerServer.close()
-  t.end()
+  bearerServer.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -145,6 +145,7 @@ addTest('testPutMultipartPostambleCRLF', {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+   t.end()
+  })
 })

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -254,6 +254,7 @@ tape('test only setting undefined properties', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-digest-auth.js
+++ b/tests/test-digest-auth.js
@@ -157,6 +157,7 @@ tape('with different credentials', function(t) {
 })
 
 tape('cleanup', function(t) {
-  digestServer.close()
-  t.end()
+  digestServer.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-emptyBody.js
+++ b/tests/test-emptyBody.js
@@ -49,6 +49,7 @@ tape('empty JSON body', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-event-forwarding.js
+++ b/tests/test-event-forwarding.js
@@ -33,6 +33,7 @@ tape('should emit socket event', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -130,6 +130,7 @@ tape('upper-case Host header and redirect', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-https.js
+++ b/tests/test-https.js
@@ -109,8 +109,9 @@ function runAllTests(strict, s) {
   })
 
   tape(strictMsg + 'cleanup', function(t) {
-    s.close()
-    t.end()
+    s.close(function() {
+      t.end()
+    })
   })
 }
 

--- a/tests/test-isUrl.js
+++ b/tests/test-isUrl.js
@@ -95,6 +95,7 @@ tape('hostname and port 3', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-json-request.js
+++ b/tests/test-json-request.js
@@ -74,6 +74,7 @@ testJSONValueReviver('jsonReviver', -48269.592, function (k, v) {
 testJSONValueReviver('jsonReviverInvalid', -48269.592, 'invalid reviver', -48269.592)
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-node-debug.js
+++ b/tests/test-node-debug.js
@@ -79,6 +79,7 @@ tape('it should be possible to disable debugging at runtime', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-option-reuse.js
+++ b/tests/test-option-reuse.js
@@ -47,6 +47,7 @@ tape('options object is not mutated', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -96,6 +96,7 @@ runTest('testPutMultipart', {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-piped-redirect.js
+++ b/tests/test-piped-redirect.js
@@ -45,7 +45,9 @@ tape('piped redirect', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s1.close()
-  s2.close()
-  t.end()
+  s1.close(function() {
+    s2.close(function() {
+      t.end()
+    })
+  })
 })

--- a/tests/test-pipes.js
+++ b/tests/test-pipes.js
@@ -275,6 +275,7 @@ tape('request.pipefilter is called correctly', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-pool.js
+++ b/tests/test-pool.js
@@ -31,6 +31,7 @@ tape('pool', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-proxy-connect.js
+++ b/tests/test-proxy-connect.js
@@ -77,6 +77,7 @@ tape('proxy', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-proxy.js
+++ b/tests/test-proxy.js
@@ -238,6 +238,7 @@ if (process.env.TEST_PROXY_HARNESS) {
 
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-redirect-auth.js
+++ b/tests/test-redirect-auth.js
@@ -118,7 +118,9 @@ runTest('different host and protocol',
   false)
 
 tape('cleanup', function(t) {
-  s.close()
-  ss.close()
-  t.end()
+  s.close(function() {
+    ss.close(function() {
+      t.end()
+    })
+  })
 })

--- a/tests/test-redirect-complex.js
+++ b/tests/test-redirect-complex.js
@@ -79,7 +79,9 @@ tape('lots of redirects', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  ss.close()
-  t.end()
+  s.close(function() {
+    ss.close(function() {
+      t.end()
+    })
+  })
 })

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -313,7 +313,9 @@ tape('http to https redirect', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  ss.close()
-  t.end()
+  s.close(function() {
+    ss.close(function() {
+      t.end()
+    })
+  })
 })

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -112,7 +112,8 @@ if (process.env.TRAVIS === 'true') {
   })
 
   tape('cleanup', function(t) {
-    s.close()
-    t.end()
+    s.close(function() {
+      t.end()
+    })
   })
 }

--- a/tests/test-toJSON.js
+++ b/tests/test-toJSON.js
@@ -38,6 +38,7 @@ tape('request().toJSON()', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  t.end()
+  s.close(function() {
+    t.end()
+  })
 })

--- a/tests/test-unix.js
+++ b/tests/test-unix.js
@@ -36,7 +36,9 @@ tape('unix socket connection', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close()
-  fs.unlink(socket, function() { })
-  t.end()
+  s.close(function() {
+    fs.unlink(socket, function() {
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
Somehow I missed a whole bunch of these in #1327.  Maybe I was only searching for `server.close()` and not `s.close()`?

Ping @simov 