### PR TITLE
Emit FormData error events as Request error events

### DIFF
--- a/request.js
+++ b/request.js
@@ -1429,7 +1429,9 @@ Request.prototype.form = function (form) {
   // create form-data object
   self._form = new FormData()
   self._form.on('error',function(err) {
-    self.emit('error',err)
+    err.message = 'form-data: ' + err.message
+    self.emit('error', err)
+    self.abort()
   })
   return self._form
 }

--- a/request.js
+++ b/request.js
@@ -1428,6 +1428,9 @@ Request.prototype.form = function (form) {
   }
   // create form-data object
   self._form = new FormData()
+  self._form.on('error',function(err) {
+    self.emit('error',err);
+  });
   return self._form
 }
 Request.prototype.multipart = function (multipart) {

--- a/request.js
+++ b/request.js
@@ -1429,8 +1429,8 @@ Request.prototype.form = function (form) {
   // create form-data object
   self._form = new FormData()
   self._form.on('error',function(err) {
-    self.emit('error',err);
-  });
+    self.emit('error',err)
+  })
   return self._form
 }
 Request.prototype.multipart = function (multipart) {

--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -7,7 +7,7 @@ function runTest(t) {
   var req
     , form
     , reqOptions = {
-      url: 'http://localhost:8080/',
+      url: 'http://localhost:8080/'
     }
 
     req = request.post(reqOptions, function (err, res, body) {

--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -1,0 +1,25 @@
+'use strict'
+
+var request = require('../index')
+  , tape = require('tape')
+
+function runTest(t) {
+  var req
+    , form
+    , reqOptions = {
+      url: 'http://localhost:8080/',
+    }
+
+    req = request.post(reqOptions, function (err, res, body) {
+      t.equal(err.message,'Arrays are not supported.')
+      t.end()
+    })
+
+    form = req.form()
+    form.append('field',['value1','value2'])
+}
+
+
+tape('re-emit formData errors', function(t) {
+  runTest(t)
+})


### PR DESCRIPTION
As per #1336 created a clean request which passes tests.

Below is a stack trace (from 1st October 2014 sorry it's old!) caused by uploading an image to the Facebook API using request. The trace is caught by a node domain otherwise it'd be ignored.

```
Error: write ECONNRESET Error: write ECONNRESET
at errnoException (net.js:904:11)
at afterWrite (net.js:720:19)
 ---------------------------------------------
at Readable.on (_stream_readable.js:707:33)
at pipe (tls.js:1455:10)
at exports.connect (tls.js:1352:19)
at Agent.createConnection (https.js:79:14)
at Agent.createSocket (http.js:1293:16)
at Agent.addRequest (http.js:1269:23)
at new ClientRequest (http.js:1416:16)
at exports.request (https.js:123:10)
 ---------------------------------------------
at Stream.pipe (stream.js:57:10)
at CombinedStream.pipe (/node_modules/request/node_modules/form-data/node_modules/combined-stream/lib/combined_stream.js:63:25)
at end (/node_modules/request/request.js:415:22)
at /node_modules/request/request.js:444:11
at /node_modules/request/node_modules/form-data/lib/form_data.js:273:5
at /node_modules/request/node_modules/form-data/node_modules/async/lib/async.js:254:17
at done (/node_modules/request/node_modules/form-data/node_modules/async/lib/async.js:135:19)
at /node_modules/request/node_modules/form-data/node_modules/async/lib/async.js:32:16
```
As you can see there is an ECONNRESET in combined_stream which is passed up to the form-data module, however this error is not then passed up to request, unless domains are in place it is just lost.

This change will pass the error up to request so users can act on the 'error' event, in my case I'd retry the request. The only impact this should have on existing applications is they emit error events more often if the application uses form-data instead of ignoring it. 

The alternative option would be to in the application would be to listen to the 'error' event on the form object created from request.form() which I'm happy to do but I thought since it's used by request it'd be good if it could be sent to the callback.

I would write a test case for it but I've no idea how to trigger an ECONNRESET in combine_stream intentionally, if anyone knows how I'll gladly write a test case!