### PR TITLE
Clean up readme badges, and add Travis and Coveralls badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Request — Simplified HTTP client
-[![NPM](https://nodei.co/npm/request.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/request/)
+[![npm package](https://nodei.co/npm/request.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/request/)
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/request/request?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build status](https://img.shields.io/travis/nylen/chronolog.svg?style=flat)](https://travis-ci.org/nylen/chronolog)
+[![Coverage](https://img.shields.io/coveralls/request/request.svg?style=flat)](https://coveralls.io/r/request/request)
+[![Gitter](https://img.shields.io/badge/gitter-join_chat-blue.svg?style=flat)](https://gitter.im/request/request?utm_source=badge)
 
 ## Super simple to use
 


### PR DESCRIPTION
Per discussion on Gitter and in #1277 we want to disable Coveralls PR
comments.  Add a Coveralls badge so that we still watch coverage stats.

While we're at it, add a Travis badge, and make all badges the same
style.