### PR TITLE
Make sure we return on errored browser requests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "index.js",
   "dependencies": {
     "bl": "~0.9.0",
-    "caseless": "~0.8.0",
+    "caseless": "~0.9.0",
     "forever-agent": "~0.5.0",
     "form-data": "~0.2.0",
     "json-stringify-safe": "~5.0.0",

--- a/tests/browser/test.js
+++ b/tests/browser/test.js
@@ -13,7 +13,18 @@ var assert = require('assert')
   , tape = require('tape')
   , request = require('../../index')
 
-tape('Request browser test', function(t) {
+tape('returns on error', function(t) {
+  t.plan(1)
+  request({
+    uri: 'https://stupid.nonexistent.path:port123/\\<-great-idea',
+    withCredentials: false
+  }, function (error, response) {
+    t.equal(response.statusCode, 0)
+    t.end()
+  })
+})
+
+tape('succeeds on valid URLs (with https and CORS)', function(t) {
   t.plan(1)
   request({
     uri: 'https://localhost:6767',


### PR DESCRIPTION
Turns out that if browser requests are erroring out on an early stage (this could be error on DNS, cross-domain security cancellation or user has no internet connection), request will fail when trying the method `caseless.has`, because this will invoke Object.keys on undefined. So just wrapping the check here in a check for headers fixes the issue.

I also added a browesr test for this. The test proves the problem: it will fail if request.js is not updated (for example with this code).

I realize I could have also sent a PR to caseless to avoid calling Object keys on an undefined object, but seems to me that we should not even invoke caseless when we have no headers to work with. 

Please let me know if you feel this should be solved in another way

Have a great week!