### PR TITLE
WIP request-oauth as a separate module

### DIFF
--- a/request-oauth.js
+++ b/request-oauth.js
@@ -1,0 +1,117 @@
+'use strict'
+
+var querystring = require('querystring')
+var qs = require('qs')
+var caseless = require('caseless')
+var uuid = require('node-uuid')
+var oauth = require('oauth-sign')
+
+/*
+  var args = {
+    uri: {},
+    method: '',
+    headers: {},
+    body: {},
+    qsLib: {},
+    oauth: {}
+  }
+*/
+
+exports.oauth = function (args) {
+  if (!args.uri) {
+    throw new Error('request-oauth: missing url argument')
+  }
+  if (!args.method) {
+    throw new Error('request-oauth: missing method argument')
+  }
+
+  var uri = args.uri
+  var method = args.method
+  var headers = caseless(args.headers || {})
+  var body = args.body || ''
+  var qsLib = args.qsLib || qs
+  var _oauth = args.oauth || {}
+  
+
+  var form, query, contentType = '', formContentType = 'application/x-www-form-urlencoded'
+
+  if (headers.has('content-type') &&
+      headers.get('content-type').slice(0, formContentType.length) === formContentType) {
+    contentType = formContentType
+    form = body
+  }
+  if (uri.query) {
+    query = uri.query
+  }
+
+  var transport = _oauth.transport_method || 'header'
+  if (transport === 'body' && (
+      method !== 'POST' || contentType !== formContentType)) {
+
+    throw new Error('oauth.transport_method of \'body\' requires \'POST\' ' +
+      'and content-type \'' + formContentType + '\'')
+  }
+
+  delete _oauth.transport_method
+
+  var oa = {}
+  for (var i in _oauth) {
+    oa['oauth_' + i] = _oauth[i]
+  }
+  if ('oauth_realm' in oa) {
+    delete oa.oauth_realm
+  }
+  if (!oa.oauth_version) {
+    oa.oauth_version = '1.0'
+  }
+  if (!oa.oauth_timestamp) {
+    oa.oauth_timestamp = Math.floor( Date.now() / 1000 ).toString()
+  }
+  if (!oa.oauth_nonce) {
+    oa.oauth_nonce = uuid().replace(/-/g, '')
+  }
+  if (!oa.oauth_signature_method) {
+    oa.oauth_signature_method = 'HMAC-SHA1'
+  }
+
+  var consumer_secret_or_private_key = oa.oauth_consumer_secret || oa.oauth_private_key
+  delete oa.oauth_consumer_secret
+  delete oa.oauth_private_key
+  var token_secret = oa.oauth_token_secret
+  delete oa.oauth_token_secret
+
+  var baseurl = uri.protocol + '//' + uri.host + uri.pathname
+  var params = qsLib.parse([].concat(query, form, qsLib.stringify(oa)).join('&'))
+
+  var signature = oauth.sign(
+    oa.oauth_signature_method,
+    method,
+    baseurl,
+    params,
+    consumer_secret_or_private_key,
+    token_secret)
+
+  var buildSortedParams = function (sep, wrap) {
+    wrap = wrap || ''
+    return Object.keys(oa).sort().map(function (i) {
+      return i + '=' + wrap + oauth.rfc3986(oa[i]) + wrap
+    }).join(sep) + sep + 'oauth_signature=' + wrap + oauth.rfc3986(signature) + wrap
+  }
+
+  var data
+  if (transport === 'header') {
+    var realm = _oauth.realm ? 'realm="' + _oauth.realm + '",' : ''
+    data = 'OAuth ' + realm + buildSortedParams(',', '"')
+  }
+  else if (transport === 'query') {
+    data = (query ? '&' : '?') + buildSortedParams('&')
+  }
+  else if (transport === 'body') {
+    data = (form ? form + '&' : '') + buildSortedParams('&')
+  }
+  else {
+    throw new Error('request-oauth: oauth.transport_method invalid')
+  }
+
+  return {transport:transport, data:data}
+}

--- a/request.js
+++ b/request.js
@@ -10,7 +10,7 @@ var http = require('http')
   , zlib = require('zlib')
   , helpers = require('./lib/helpers')
   , bl = require('bl')
-  , oauth = require('oauth-sign')
+  , roauth = require('./request-oauth')
   , hawk = require('hawk')
   , aws = require('aws-sign2')
   , httpSignature = require('http-signature')
@@ -1640,87 +1640,29 @@ Request.prototype.hawk = function (opts) {
 
 Request.prototype.oauth = function (_oauth) {
   var self = this
-  var form, query, contentType = '', formContentType = 'application/x-www-form-urlencoded'
 
-  if (self.hasHeader('content-type') &&
-      self.getHeader('content-type').slice(0, formContentType.length) === formContentType) {
-    contentType = formContentType
-    form = self.body
-  }
-  if (self.uri.query) {
-    query = self.uri.query
-  }
+  var result = roauth.oauth({
+    uri: self.uri,
+    method: self.method,
+    headers: self.headers,
+    body: self.body,
+    qsLib: self.qsLib,
+    oauth: _oauth
+  })
 
-  var transport = _oauth.transport_method || 'header'
-  if (transport === 'body' && (
-      self.method !== 'POST' || contentType !== formContentType)) {
-
-    throw new Error('oauth.transport_method of \'body\' requires \'POST\' ' +
-      'and content-type \'' + formContentType + '\'')
+  if (result.transport === 'header') {
+    self.setHeader('Authorization', result.data)
   }
-
-  delete _oauth.transport_method
-
-  var oa = {}
-  for (var i in _oauth) {
-    oa['oauth_' + i] = _oauth[i]
+  else if (result.transport === 'query') {
+    self.path += result.data
   }
-  if ('oauth_realm' in oa) {
-    delete oa.oauth_realm
-  }
-  if (!oa.oauth_version) {
-    oa.oauth_version = '1.0'
-  }
-  if (!oa.oauth_timestamp) {
-    oa.oauth_timestamp = Math.floor( Date.now() / 1000 ).toString()
-  }
-  if (!oa.oauth_nonce) {
-    oa.oauth_nonce = uuid().replace(/-/g, '')
-  }
-  if (!oa.oauth_signature_method) {
-    oa.oauth_signature_method = 'HMAC-SHA1'
-  }
-
-  var consumer_secret_or_private_key = oa.oauth_consumer_secret || oa.oauth_private_key
-  delete oa.oauth_consumer_secret
-  delete oa.oauth_private_key
-  var token_secret = oa.oauth_token_secret
-  delete oa.oauth_token_secret
-
-  var baseurl = self.uri.protocol + '//' + self.uri.host + self.uri.pathname
-  var params = self.qsLib.parse([].concat(query, form, self.qsLib.stringify(oa)).join('&'))
-
-  var signature = oauth.sign(
-    oa.oauth_signature_method,
-    self.method,
-    baseurl,
-    params,
-    consumer_secret_or_private_key,
-    token_secret)
-
-  var buildSortedParams = function (sep, wrap) {
-    wrap = wrap || ''
-    return Object.keys(oa).sort().map(function (i) {
-      return i + '=' + wrap + oauth.rfc3986(oa[i]) + wrap
-    }).join(sep) + sep + 'oauth_signature=' + wrap + oauth.rfc3986(signature) + wrap
-  }
-
-  if (transport === 'header') {
-    var realm = _oauth.realm ? 'realm="' + _oauth.realm + '",' : ''
-    self.setHeader('Authorization', 'OAuth ' + realm + buildSortedParams(',', '"'))
-  }
-  else if (transport === 'query') {
-    self.path += (query ? '&' : '?') + buildSortedParams('&')
-  }
-  else if (transport === 'body') {
-    self.body = (form ? form + '&' : '') + buildSortedParams('&')
-  }
-  else {
-    throw new Error('oauth.transport_method invalid')
+  else if (result.transport === 'body') {
+    self.body = result.data
   }
 
   return self
 }
+
 Request.prototype.jar = function (jar) {
   var self = this
   var cookies


### PR DESCRIPTION
**Not an actual PR**

I got inspired lately from some other refactoring PRs, so I just moved the `oauth` method into a separate _module_. The `oauth` method in request now looks like this:

```js
Request.prototype.oauth = function (_oauth) {
  var self = this

  var result = roauth.oauth({
    uri: self.uri,
    method: self.method,
    headers: self.headers,
    body: self.body,
    qsLib: self.qsLib,
    oauth: _oauth
  })

  if (result.transport === 'header') {
    self.setHeader('Authorization', result.data)
  }
  else if (result.transport === 'query') {
    self.path += result.data
  }
  else if (result.transport === 'body') {
    self.body = result.data
  }

  return self
}
```

My idea is for a separate module in the request org called `request-oauth` currently this is a [single file](https://github.com/simov/request/blob/1bd0ca14b538e0afa3a8066f5f6f5049655461fe/request-oauth.js) with only minor changes in it.

So if @mikeal @nylen @tbuchok @seanstrom and everyone else give it a green light, I would do the following:

1. Create documentation
2. Write unit tests
3. Make some minor changes to the code (right now it's really just copy/pasted)