### PR TITLE
Refactor OAuth into separate module

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -7,7 +7,7 @@ var querystring = require('querystring')
   , oauth = require('oauth-sign')
 
 
-function getParams (_oauth, uri, method, query, form, qsLib) {
+exports.buildParams = function (_oauth, uri, method, query, form, qsLib) {
   var oa = {}
   for (var i in _oauth) {
     oa['oauth_' + i] = _oauth[i]
@@ -49,7 +49,7 @@ function getParams (_oauth, uri, method, query, form, qsLib) {
   return oa
 }
 
-function concatParams (oa, sep, wrap) {
+exports.concatParams = function (oa, sep, wrap) {
   wrap = wrap || ''
   return Object.keys(oa).sort().map(function (i) {
     return i + '=' + wrap + oauth.rfc3986(oa[i]) + wrap
@@ -83,21 +83,21 @@ exports.oauth = function (args) {
       'and content-type \'' + formContentType + '\'')
   }
 
-  var oa = getParams(_oauth, uri, method, query, form, qsLib)
+  var oa = this.buildParams(_oauth, uri, method, query, form, qsLib)
 
   var data
   switch (transport) {
     case 'header':
       var realm = _oauth.realm ? 'realm="' + _oauth.realm + '",' : ''
-      data = 'OAuth ' + realm + concatParams(oa, ',', '"')
+      data = 'OAuth ' + realm + this.concatParams(oa, ',', '"')
       break
 
     case 'query':
-      data = (query ? '&' : '?') + concatParams(oa, '&')
+      data = (query ? '&' : '?') + this.concatParams(oa, '&')
       break
 
     case 'body':
-      data = (form ? form + '&' : '') + concatParams(oa, '&')
+      data = (form ? form + '&' : '') + this.concatParams(oa, '&')
       break
 
     default:

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,0 +1,108 @@
+'use strict'
+
+var querystring = require('querystring')
+  , qs = require('qs')
+  , caseless = require('caseless')
+  , uuid = require('node-uuid')
+  , oauth = require('oauth-sign')
+
+
+function getParams (_oauth, uri, method, query, form, qsLib) {
+  var oa = {}
+  for (var i in _oauth) {
+    oa['oauth_' + i] = _oauth[i]
+  }
+  if (!oa.oauth_version) {
+    oa.oauth_version = '1.0'
+  }
+  if (!oa.oauth_timestamp) {
+    oa.oauth_timestamp = Math.floor( Date.now() / 1000 ).toString()
+  }
+  if (!oa.oauth_nonce) {
+    oa.oauth_nonce = uuid().replace(/-/g, '')
+  }
+  if (!oa.oauth_signature_method) {
+    oa.oauth_signature_method = 'HMAC-SHA1'
+  }
+
+  var consumer_secret_or_private_key = oa.oauth_consumer_secret || oa.oauth_private_key
+  delete oa.oauth_consumer_secret
+  delete oa.oauth_private_key
+
+  var token_secret = oa.oauth_token_secret
+  delete oa.oauth_token_secret
+
+  delete oa.oauth_realm
+  delete oa.oauth_transport_method
+
+  var baseurl = uri.protocol + '//' + uri.host + uri.pathname
+  var params = qsLib.parse([].concat(query, form, qsLib.stringify(oa)).join('&'))
+
+  oa.oauth_signature = oauth.sign(
+    oa.oauth_signature_method,
+    method,
+    baseurl,
+    params,
+    consumer_secret_or_private_key,
+    token_secret)
+
+  return oa
+}
+
+function concatParams (oa, sep, wrap) {
+  wrap = wrap || ''
+  return Object.keys(oa).sort().map(function (i) {
+    return i + '=' + wrap + oauth.rfc3986(oa[i]) + wrap
+  // }).join(sep) + sep + 'oauth_signature=' + wrap + oauth.rfc3986(signature) + wrap
+  }).join(sep)
+}
+
+exports.oauth = function (args) {
+  var uri = args.uri || {}
+    , method = args.method || ''
+    , headers = caseless(args.headers)
+    , body = args.body || ''
+    , _oauth = args.oauth || {}
+    , qsLib = args.qsLib || qs
+
+  var form
+    , query
+    , contentType = headers.get('content-type') || ''
+    , formContentType = 'application/x-www-form-urlencoded'
+    , transport = _oauth.transport_method || 'header'
+
+  if (contentType.slice(0, formContentType.length) === formContentType) {
+    contentType = formContentType
+    form = body
+  }
+  if (uri.query) {
+    query = uri.query
+  }
+  if (transport === 'body' && (method !== 'POST' || contentType !== formContentType)) {
+    throw new Error('oauth: transport_method of \'body\' requires \'POST\' ' +
+      'and content-type \'' + formContentType + '\'')
+  }
+
+  var oa = getParams(_oauth, uri, method, query, form, qsLib)
+
+  var data
+  switch (transport) {
+    case 'header':
+      var realm = _oauth.realm ? 'realm="' + _oauth.realm + '",' : ''
+      data = 'OAuth ' + realm + concatParams(oa, ',', '"')
+      break
+
+    case 'query':
+      data = (query ? '&' : '?') + concatParams(oa, '&')
+      break
+
+    case 'body':
+      data = (form ? form + '&' : '') + concatParams(oa, '&')
+      break
+
+    default:
+      throw new Error('oauth: transport_method invalid')
+  }
+
+  return {oauth:data, transport:transport}
+}

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -32,6 +32,7 @@ exports.buildParams = function (_oauth, uri, method, query, form, qsLib) {
   var token_secret = oa.oauth_token_secret
   delete oa.oauth_token_secret
 
+  var realm = oa.oauth_realm
   delete oa.oauth_realm
   delete oa.oauth_transport_method
 
@@ -46,14 +47,27 @@ exports.buildParams = function (_oauth, uri, method, query, form, qsLib) {
     consumer_secret_or_private_key,
     token_secret)
 
+  if (realm) {
+    oa.realm = realm
+  }
+
   return oa
 }
 
 exports.concatParams = function (oa, sep, wrap) {
   wrap = wrap || ''
-  return Object.keys(oa).sort().map(function (i) {
+
+  var params = Object.keys(oa).filter(function (i) {
+    return i !== 'realm' && i !== 'oauth_signature'
+  }).sort()
+
+  if (oa.realm) {
+    params.splice(0, 1, 'realm')
+  }
+  params.push('oauth_signature')
+
+  return params.map(function (i) {
     return i + '=' + wrap + oauth.rfc3986(oa[i]) + wrap
-  // }).join(sep) + sep + 'oauth_signature=' + wrap + oauth.rfc3986(signature) + wrap
   }).join(sep)
 }
 
@@ -88,8 +102,7 @@ exports.oauth = function (args) {
   var data
   switch (transport) {
     case 'header':
-      var realm = _oauth.realm ? 'realm="' + _oauth.realm + '",' : ''
-      data = 'OAuth ' + realm + this.concatParams(oa, ',', '"')
+      data = 'OAuth ' + this.concatParams(oa, ',', '"')
       break
 
     case 'query':

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -451,20 +451,20 @@ tape('query transport_method with qs parameter and existing query string in url'
     t.notOk(r.headers.Authorization, 'oauth Authorization header should not be present with transport_method \'query\'')
     t.notOk(r.path.match(/\?&/), 'there should be no ampersand at the beginning of the query')
     t.equal('OB33pYjWAnf+xtOHN4Gmbdil168=', qs.parse(r.path).oauth_signature)
-    var matches = r.path.match(/\?(.*?)&(oauth.*$)/)
-    t.ok(matches, 'regex to split oauth parameters from qs parameters matched successfully')
-    var qsParams = qs.parse(matches[1])
-    var oauthParams = qs.parse(matches[2])
+    
+    var params = qs.parse(r.path.split('?')[1])
+      , keys = Object.keys(params)
 
-    var i, paramNames = ['a2', 'a3[0]', 'a3[1]', 'c@', 'b5', 'c2']
-    for (i = 0; i < paramNames.length; i++) {
-      t.ok(qsParams.hasOwnProperty(paramNames[i]), 'Non-oauth query params should be first in query string: ' + paramNames[i])
-    }
+    var paramNames = [
+      'a2', 'b5', 'a3[0]', 'a3[1]', 'c@', 'c2',
+      'realm', 'oauth_nonce', 'oauth_signature_method', 'oauth_timestamp',
+      'oauth_token', 'oauth_version', 'oauth_signature'
+    ]
 
-    paramNames = ['consumer_key', 'nonce', 'timestamp', 'version', 'signature', 'token', 'signature_method']
-    for (i = 0; i < paramNames.length; i++) {
-      var paramName = 'oauth_' + paramNames[i]
-      t.ok(oauthParams[paramName], 'OAuth query params should be included after request specific parameters: ' + paramName)
+    for (var i = 0; i < keys.length; i++) {
+      t.ok(keys[i] === paramNames[i],
+        'Non-oauth query params should be first, ' +
+        'OAuth query params should be second in query string')
     }
 
     r.abort()


### PR DESCRIPTION

This is a follow up to my previous PR https://github.com/request/request/pull/1350 Also it might be related to this one https://github.com/request/request/pull/1360

The `getParams` function is about the generation of OAuth parameters. I think it's pretty straightforward to understand which parameters have defaults, which are excluded, and what parameters are required for the OAuth signature.

The `concatParams` function is the old `buildSortedParams` but I though it deserves it's own function, I mean the `oa` parameter was used from the outer scope, so it was not exactly a function in that sense.

One change in `concatParams` is that the signature is no longer appended to the end of the string, but that can be changed if it not confront to the spec in some way.

The `oauth` function is pretty much what's left from the original one, but I think now it's more compact and easy to follow, it even fits on my screen. The `getParams` and `concatParams` are called from there, there is only one level of indirection so again it's very easy to follow.

All of the available input `args` parameters are listed on top of the `oauth` function. Also right now in Request this module is called like `var result = oauth.oauth` which is a bit silly, but I couldn't come up with something more reasonable.

At first I thought that returning of a map is not a good idea for the `oauth` method, but then I liked how it feels, I mean `result.transport` and `result.oauth` sounds good to me.

That's all I could think of at the moment.
