### PR TITLE
Allow explicitly disabling tunneling for proxied https destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ or other features, it is generally simpler to go with a
 straightforward HTTP proxy in this case.  However, if you would like
 to force a tunneling proxy, you may set the `tunnel` option to `true`.
 
+You can also make a standard proxied `http` request by explicitly setting
+`tunnel : false`, but **note that this will allow the proxy to see the traffic
+to/from the destination server**.
+
 If you are using a tunneling proxy, you may set the
 `proxyHeaderWhiteList` to share certain headers with the proxy.
 
@@ -609,10 +613,14 @@ The first argument can be either a `url` or an `options` object. The only requir
 * `httpSignature` - Options for the [HTTP Signature Scheme](https://github.com/joyent/node-http-signature/blob/master/http_signing.md) using [Joyent's library](https://github.com/joyent/node-http-signature). The `keyId` and `key` properties must be specified. See the docs for other options.
 * `localAddress` - Local interface to bind for network connections.
 * `gzip` - If `true`, add an `Accept-Encoding` header to request compressed content encodings from the server (if not already present) and decode supported content encodings in the response.  **Note:** Automatic decoding of the response content is performed on the body data returned through `request` (both through the `request` stream and passed to the callback function) but is not performed on the `response` stream (available from the `response` event) which is the unmodified `http.IncomingMessage` object which may contain compressed data. See example below.
-* `tunnel` - If `true`, then *always* use a tunneling proxy.  If
-  `false` (default), then tunneling will only be used if the
-  destination is `https`, or if a previous request in the redirect
-  chain used a tunneling proxy.
+* `tunnel` - controls the behavior of
+  [HTTP `CONNECT` tunneling](https://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_tunneling)
+  as follows:
+   * `undefined` (default) - `true` if the destination is `https` or a previous
+     request in the redirect chain used a tunneling proxy, `false` otherwise
+   * `true` - always tunnel to the destination by making a `CONNECT` request to
+     the proxy
+   * `false` - request the destination as a `GET` request.
 * `proxyHeaderWhiteList` - A whitelist of headers to send to a
   tunneling proxy.
 * `proxyHeaderExclusiveList` - A whitelist of headers to send

--- a/request.js
+++ b/request.js
@@ -159,7 +159,7 @@ function getTunnelOption(self, options) {
   return undefined
 }
 
-function construcTunnelOptions(request) {
+function constructTunnelOptions(request) {
   var proxy = request.proxy
 
   var tunnelOptions = {
@@ -311,7 +311,7 @@ Request.prototype.setupTunnel = function () {
   proxyHeaderExclusiveList.forEach(self.removeHeader, self)
 
   var tunnelFn = getTunnelFn(self)
-  var tunnelOptions = construcTunnelOptions(self)
+  var tunnelOptions = constructTunnelOptions(self)
 
   self.agent = tunnelFn(tunnelOptions)
   return true

--- a/request.js
+++ b/request.js
@@ -133,6 +133,32 @@ function constructProxyHeaderWhiteList(headers, proxyHeaderWhiteList) {
     }, {})
 }
 
+function getTunnelOption(self, options) {
+  // Tunnel HTTPS by default, or if a previous request in the redirect chain
+  // was tunneled.  Allow the user to override this setting.
+
+  // If self.tunnel is already set (because this is a redirect), use the
+  // existing value.
+  if (typeof self.tunnel !== 'undefined') {
+    return self.tunnel
+  }
+
+  // If options.tunnel is set (the user specified a value), use it.
+  if (typeof options.tunnel !== 'undefined') {
+    return options.tunnel
+  }
+
+  // If the destination is HTTPS, tunnel.
+  if (self.uri.protocol === 'https:') {
+    return true
+  }
+
+  // Otherwise, leave tunnel unset, because if a later request in the redirect
+  // chain is HTTPS then that request (and any subsequent ones) should be
+  // tunneled.
+  return undefined
+}
+
 function construcTunnelOptions(request) {
   var proxy = request.proxy
 
@@ -209,7 +235,6 @@ function rfc3986 (str) {
 }
 
 function Request (options) {
-  // if tunnel property of options was not given default to false
   // if given the method property in options, set property explicitMethod to true
 
   // extend the Request instance with any non-reserved properties
@@ -228,13 +253,9 @@ function Request (options) {
 
   self.readable = true
   self.writable = true
-  if (typeof options.tunnel === 'undefined') {
-    options.tunnel = false
-  }
   if (options.method) {
     self.explicitMethod = true
   }
-  self.canTunnel = options.tunnel !== false && tunnel
   self.init(options)
 }
 
@@ -263,7 +284,7 @@ Request.prototype.setupTunnel = function () {
     return false
   }
 
-  if (!self.tunnel && self.uri.protocol !== 'https:') {
+  if (!self.tunnel) {
     return false
   }
 
@@ -293,7 +314,6 @@ Request.prototype.setupTunnel = function () {
   var tunnelOptions = construcTunnelOptions(self)
 
   self.agent = tunnelFn(tunnelOptions)
-  self.tunnel = true
   return true
 }
 
@@ -383,8 +403,7 @@ Request.prototype.init = function (options) {
     self.proxy = getProxyFromURI(self.uri)
   }
 
-  // Pass in `tunnel:true` to *always* tunnel through proxies
-  self.tunnel = !!options.tunnel
+  self.tunnel = getTunnelOption(self, options)
   if (self.proxy) {
     self.setupTunnel()
   }


### PR DESCRIPTION
Before, tunneling would default to false for http destinations and be
forced to true for https destinations.

Now, allow specifying `tunnel : false` to perform a regular GET request
to HTTPS destinations.  This is insecure, so make a note accordingly.

Supersedes #1344 and fixes #1293.

Also add some more tests for proxy environment variables - it hasn't been easy to test proxying HTTPS URLs without tunneling until this change.