### PR TITLE
Upgrade mime-types package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "forever-agent": "~0.5.0",
     "form-data": "~0.2.0",
     "json-stringify-safe": "~5.0.0",
-    "mime-types": "~1.0.1",
+    "mime-types": "~2.0.1",
     "node-uuid": "~1.4.0",
     "qs": "~2.3.1",
     "tunnel-agent": "~0.4.0",


### PR DESCRIPTION
the dependency 
``form-data`` is using ``"mime-types": "~2.0.3"``
https://github.com/felixge/node-form-data/blob/master/package.json#L20

but in ``request`` we are using ``~1.0.1`` which causes multiple version of copy being download whenever we require ``request``