### PR TITLE
Improve `timeout` option description

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,9 +599,9 @@ The first argument can be either a `url` or an `options` object. The only requir
     with your pool options or create the pool object with the `maxSockets`
     property outside of the loop.
 * `timeout` - Integer containing the number of milliseconds to wait for a
-  request to respond before aborting the request.  Note that increasing the
-  timeout beyond the OS-wide TCP connection timeout will not work
-  ([the default in Linux is around 20 seconds](http://www.sekuda.com/overriding_the_default_linux_kernel_20_second_tcp_socket_connect_timeout)).
+  request to respond before aborting the request.  Note that if the underlying
+  TCP connection cannot be established, the OS-wide TCP connection timeout will
+  overrule the `timeout` option ([the default in Linux is around 20 seconds](http://www.sekuda.com/overriding_the_default_linux_kernel_20_second_tcp_socket_connect_timeout)).
 * `proxy` - An HTTP proxy to be used. Supports proxy Auth with Basic Auth, identical to support for the `url` parameter (by embedding the auth info in the `uri`)
 * `oauth` - Options for OAuth HMAC-SHA1 signing. See documentation above.
 * `hawk` - Options for [Hawk signing](https://github.com/hueniverse/hawk). The `credentials` key must contain the necessary signing info, [see hawk docs for details](https://github.com/hueniverse/hawk#usage-example).


### PR DESCRIPTION
Emphasise when the OS-wide TCP timeout overrules the `timeout` option. The previous explanation could leave the reader thinking that the OS-wide timeout would overrule a bigger `timeout` option even if the TCP connection was successfully established