### PR TITLE
Refactor multipart/related logic into separate module

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -1,0 +1,104 @@
+'use strict'
+
+var uuid = require('node-uuid')
+  , CombinedStream = require('combined-stream')
+  , isstream = require('isstream')
+
+
+function Multipart () {
+  this.boundary = uuid()
+  this.chunked = false
+  this.body = null
+}
+
+Multipart.prototype.isChunked = function (request, options) {
+  var chunked = false
+    , parts = options.data || options
+
+  if (!parts.forEach) {
+    throw new Error('Argument error, options.multipart.')
+  }
+
+  if (request.getHeader('transfer-encoding') === 'chunked') {
+    chunked = true
+  }
+
+  if (options.chunked !== undefined) {
+    chunked = options.chunked
+  }
+
+  if (!chunked) {
+    parts.forEach(function (part) {
+      if(typeof part.body === 'undefined') {
+        throw new Error('Body attribute missing in multipart.')
+      }
+      if (isstream(part.body)) {
+        chunked = true
+      }
+    })
+  }
+
+  return chunked
+}
+
+Multipart.prototype.setHeaders = function (request, chunked) {
+  var self = this
+
+  if (chunked && !request.hasHeader('transfer-encoding')) {
+    request.setHeader('transfer-encoding', 'chunked')
+  }
+
+  var header = request.getHeader('content-type')
+  var contentType = (!header || header.indexOf('multipart') === -1)
+    ? 'multipart/related'
+    : header.split(';')[0]
+
+  request.setHeader('content-type', contentType + '; boundary=' + self.boundary)
+}
+
+Multipart.prototype.build = function (request, parts, chunked) {
+  var self = this
+  var body = chunked ? new CombinedStream() : []
+
+  function add (part) {
+    return chunked ? body.append(part) : body.push(new Buffer(part))
+  }
+
+  if (request.preambleCRLF) {
+    add('\r\n')
+  }
+
+  parts.forEach(function (part) {
+    var preamble = '--' + self.boundary + '\r\n'
+    Object.keys(part).forEach(function (key) {
+      if (key === 'body') { return }
+      preamble += key + ': ' + part[key] + '\r\n'
+    })
+    preamble += '\r\n'
+    add(preamble)
+    add(part.body)
+    add('\r\n')
+  })
+  add('--' + self.boundary + '--')
+
+  if (request.postambleCRLF) {
+    add('\r\n')
+  }
+
+  return body
+}
+
+Multipart.prototype.related = function (request, options) {
+  var self = this
+
+  var chunked = self.isChunked(request, options)
+  self.setHeaders(request, chunked)
+
+  var parts = options.data || options
+  var body = self.build(request, parts, chunked)
+
+  self.chunked = chunked
+  self.body = body
+}
+
+exports.Multipart = Multipart

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -5,21 +5,23 @@ var uuid = require('node-uuid')
   , isstream = require('isstream')
 
 
-function Multipart () {
+function Multipart (request) {
+  this.request = request
   this.boundary = uuid()
   this.chunked = false
   this.body = null
 }
 
-Multipart.prototype.isChunked = function (request, options) {
-  var chunked = false
+Multipart.prototype.isChunked = function (options) {
+  var self = this
+    , chunked = false
     , parts = options.data || options
 
   if (!parts.forEach) {
     throw new Error('Argument error, options.multipart.')
   }
 
-  if (request.getHeader('transfer-encoding') === 'chunked') {
+  if (self.request.getHeader('transfer-encoding') === 'chunked') {
     chunked = true
   }
 
@@ -41,22 +43,22 @@ Multipart.prototype.isChunked = function (request, options) {
   return chunked
 }
 
-Multipart.prototype.setHeaders = function (request, chunked) {
+Multipart.prototype.setHeaders = function (chunked) {
   var self = this
 
-  if (chunked && !request.hasHeader('transfer-encoding')) {
-    request.setHeader('transfer-encoding', 'chunked')
+  if (chunked && !self.request.hasHeader('transfer-encoding')) {
+    self.request.setHeader('transfer-encoding', 'chunked')
   }
 
-  var header = request.getHeader('content-type')
+  var header = self.request.getHeader('content-type')
   var contentType = (!header || header.indexOf('multipart') === -1)
     ? 'multipart/related'
     : header.split(';')[0]
 
-  request.setHeader('content-type', contentType + '; boundary=' + self.boundary)
+  self.request.setHeader('content-type', contentType + '; boundary=' + self.boundary)
 }
 
-Multipart.prototype.build = function (request, parts, chunked) {
+Multipart.prototype.build = function (parts, chunked) {
   var self = this
   var body = chunked ? new CombinedStream() : []
 
@@ -64,7 +66,7 @@ Multipart.prototype.build = function (request, parts, chunked) {
     return chunked ? body.append(part) : body.push(new Buffer(part))
   }
 
-  if (request.preambleCRLF) {
+  if (self.request.preambleCRLF) {
     add('\r\n')
   }
 
@@ -81,24 +83,22 @@ Multipart.prototype.build = function (request, parts, chunked) {
   })
   add('--' + self.boundary + '--')
 
-  if (request.postambleCRLF) {
+  if (self.request.postambleCRLF) {
     add('\r\n')
   }
 
   return body
 }
 
-Multipart.prototype.related = function (request, options) {
+Multipart.prototype.related = function (options) {
   var self = this
 
-  var chunked = self.isChunked(request, options)
-  self.setHeaders(request, chunked)
+  var chunked = self.isChunked(options)
+    , parts = options.data || options
 
-  var parts = options.data || options
-  var body = self.build(request, parts, chunked)
-
+  self.setHeaders(chunked)
   self.chunked = chunked
-  self.body = body
+  self.body = self.build(parts, chunked)
 }
 
 exports.Multipart = Multipart

--- a/request.js
+++ b/request.js
@@ -13,7 +13,6 @@ var http = require('http')
   , hawk = require('hawk')
   , aws = require('aws-sign2')
   , httpSignature = require('http-signature')
-  , uuid = require('node-uuid')
   , mime = require('mime-types')
   , tunnel = require('tunnel-agent')
   , stringstream = require('stringstream')
@@ -553,7 +552,7 @@ Request.prototype.init = function (options) {
     self.json(options.json)
   }
   if (options.multipart) {
-    self._multipart = new Multipart()
+    self._multipart = new Multipart(self)
     self.multipart(options.multipart)
   }
 
@@ -1350,7 +1349,7 @@ Request.prototype.form = function (form) {
 Request.prototype.multipart = function (multipart) {
   var self = this
 
-  self._multipart.related(self, multipart)
+  self._multipart.related(multipart)
 
   if (!self._multipart.chunked) {
     self.body = self._multipart.body


### PR DESCRIPTION
I just refactored the behavior I proposed here https://github.com/request/request/pull/1283 

The `isChunked`, `setHeaders` and the `build` methods can be used outside of this class. The `related` method just wraps them up, but that logic can be put somewhere else.

The reason why I pass the `request` instance to each method individually is because I don't think it belongs to that class as a property. I even allow the `setHeaders` method to modify the instance, so I contradict myself here, I know, but it seemed more logical in this case.

Other than that I really want to see a few more modules out of request before I can decide on the best approach about the instance.

I moved the `boundary` field into the `multipart` instance, no idea what was the reason to have it attached on the `request` instance, since it wasn't used anywhere else.

The `related` method sets up the `self._multipart.chunked` and the `self._multipart.body` properties, and then use them to pipe with request if needed (not the most elegant code, but that will change I guess)

```js
if (self._multipart && self._multipart.chunked) {
  self._multipart.body.pipe(self)
}
```