### PR TITLE
Throw error when making HEAD request with a body

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ function request (uri, options, callback) {
   options.callback = params.callback
   options.uri = params.uri
 
+  if (params.options.method === 'HEAD' && paramsHaveRequestBody(params)) {
+    throw new Error('HTTP HEAD requests MUST NOT include a request body.')
+  }
+
   return new request.Request(options)
 }
 
@@ -66,11 +70,6 @@ request.get = function (uri, options, callback) {
 request.head = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'HEAD'
-
-  if (paramsHaveRequestBody(params)) {
-    throw new Error('HTTP HEAD requests MUST NOT include a request body.')
-  }
-
   return requester(params)(params.uri || null, params.options, params.callback)
 }
 

--- a/tests/test-errors.js
+++ b/tests/test-errors.js
@@ -77,3 +77,22 @@ tape('multipart without body 2', function(t) {
   }, /^Error: Body attribute missing in multipart\.$/)
   t.end()
 })
+
+tape('head method with a body', function(t) {
+  t.throws(function() {
+    request(local, {
+      method: 'HEAD',
+      body: 'foo'
+    })
+  }, /HTTP HEAD requests MUST NOT include a request body/)
+  t.end()
+})
+
+tape('head method with a body 2', function(t) {
+  t.throws(function() {
+    request.head(local, {
+      body: 'foo'
+    })
+  }, /HTTP HEAD requests MUST NOT include a request body/)
+  t.end()
+})


### PR DESCRIPTION
Currently it only throws the error if you make the request using `request.head(uri)`

This PR updates to also throw the error when making the request by manually setting the method

```javascript
request({
  uri: uri,
  method: 'HEAD'
})
```