### PR TITLE
Fix recursive requester

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,47 +54,40 @@ function request (uri, options, callback) {
   return new request.Request(options)
 }
 
-function requester(params) {
-  if(typeof params.options._requester === 'function') {
-    return params.options._requester
-  }
-  return request
-}
-
 request.get = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'GET'
-  return requester(params)(params.uri || null, params.options, params.callback)
+  return this(params.uri || null, params.options, params.callback)
 }
 
 request.head = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'HEAD'
-  return requester(params)(params.uri || null, params.options, params.callback)
+  return this(params.uri || null, params.options, params.callback)
 }
 
 request.post = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'POST'
-  return requester(params)(params.uri || null, params.options, params.callback)
+  return this(params.uri || null, params.options, params.callback)
 }
 
 request.put = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PUT'
-  return requester(params)(params.uri || null, params.options, params.callback)
+  return this(params.uri || null, params.options, params.callback)
 }
 
 request.patch = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'PATCH'
-  return requester(params)(params.uri || null, params.options, params.callback)
+  return this(params.uri || null, params.options, params.callback)
 }
 
 request.del = function (uri, options, callback) {
   var params = initParams(uri, options, callback)
   params.options.method = 'DELETE'
-  return requester(params)(params.uri || null, params.options, params.callback)
+  return this(params.uri || null, params.options, params.callback)
 }
 
 request.jar = function (store) {
@@ -130,11 +123,7 @@ request.defaults = function (options, requester) {
       }
 
       if (isFunction(requester)) {
-        if (method === self) {
-          method = requester
-        } else {
-          params.options._requester = requester
-        }
+        method = requester
       }
 
       return method(params.options, params.callback)
@@ -142,13 +131,13 @@ request.defaults = function (options, requester) {
   }
 
   var defaults      = wrap(self)
-  defaults.get      = wrap(self.get)
-  defaults.patch    = wrap(self.patch)
-  defaults.post     = wrap(self.post)
-  defaults.put      = wrap(self.put)
-  defaults.head     = wrap(self.head)
-  defaults.del      = wrap(self.del)
-  defaults.cookie   = wrap(self.cookie)
+  defaults.get      = self.get
+  defaults.patch    = self.patch
+  defaults.post     = self.post
+  defaults.put      = self.put
+  defaults.head     = self.head
+  defaults.del      = self.del
+  defaults.cookie   = self.cookie
   defaults.jar      = self.jar
   defaults.defaults = self.defaults
   return defaults

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -213,6 +213,35 @@ tape('recursive defaults', function(t) {
   })
 })
 
+tape('recursive defaults requester', function(t) {
+  t.plan(4)
+
+  var defaultsOne = request.defaults({}, function(options, callback) {
+      var headers = options.headers || {}
+      headers.foo = 'bar1'
+      options.headers = headers
+
+      request(options, callback)
+    })
+    , defaultsTwo = defaultsOne.defaults({}, function(options, callback) {
+      var headers = options.headers || {}
+      headers.baz = 'bar2'
+      options.headers = headers
+
+      defaultsOne(options, callback)
+    })
+
+  defaultsOne.get(s.url + '/get_recursive1', function (e, r, b) {
+    t.equal(e, null)
+    t.equal(b, 'TESTING!')
+  })
+
+  defaultsTwo.get(s.url + '/get_recursive2', function (e, r, b) {
+    t.equal(e, null)
+    t.equal(b, 'TESTING!')
+  })
+})
+
 tape('test custom request handler function', function(t) {
   t.plan(2)
 


### PR DESCRIPTION
Right now if you set a `requester` function in `request.defaults` it will override all further defined `requester` functions when using `request.METHOD` to make a request. For example

```javascript
var request1 = request.defaults({}, function(uri, options, callback){
	console.log('I AM THE FIRST REQUESTER FUNCTION');
	request(uri, options, callback);
})

var request2 = request1.defaults({}, function(uri, options, callback){
	console.log('I AM THE SECOND REQUESTER FUNCTION');
	console.log('I WILL NEVER GET CALLED BY request2.METHOD');
	request1(uri, options, callback);
})

// currently using request.METHOD will only hit the first requester
request2.get(url)
// I AM THE FIRST REQUESTER FUNCTION

// using request directly will hit the both requesters
request({
  uri: url,
  method: 'GET'
})
// I AM THE SECOND REQUESTER FUNCTION
// I WILL NEVER GET CALLED BY request2.METHOD
// I AM THE FIRST REQUESTER FUNCTION
```

This PR fixes `request.defaults` so that recursive `requester` functions will get called by both `request()` and `request.METHOD()`