### PR TITLE
Add ability to set a requester without setting default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,12 @@ request.cookie = function (str) {
 }
 
 request.defaults = function (options, requester) {
+
+  if (typeof options === 'function') {
+    requester = options
+    options = {}
+  }
+
   var self = this
   var wrap = function (method) {
     var headerlessOptions = function (options) {

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -266,6 +266,23 @@ tape('test custom request handler function', function(t) {
   })
 })
 
+tape('test custom request handler function without options', function(t) {
+  t.plan(1)
+
+  var customHandlerWithoutOptions = request.defaults(function(uri, options, callback) {
+    var params = request.initParams(uri, options, callback)
+    var headers = params.options.headers || {}
+    headers.x = 'y'
+    headers.foo = 'bar'
+    params.options.headers = headers
+    return request(params.uri, params.options, params.callback)
+  })
+
+  customHandlerWithoutOptions.get(s.url + '/get_custom', function(e, r, b) {
+    t.equal(e, null)
+  })
+})
+
 tape('test only setting undefined properties', function(t) {
   request.defaults({
     method: 'post',


### PR DESCRIPTION
This PR adds the ability to call `request.defaults()` and only pass in a `requester` function.

Right now if you want to use defaults to just pass in a custom `requester` function you need to pass in an empty options object, like this...  
`request.defaults({}, function(uri, options, callback){})`

This PR adds the ability to do...  
```
request.defaults(function(uri, options, callback){})
// note we left out the first param of `{}`
```