### PR TITLE
localAddress or proxy config is lost when redirecting

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -138,9 +138,9 @@ Redirect.prototype.onResponse = function (response) {
 
   request.emit('redirect')
 
-  request.init({
-      localAddress:self.localAddress,
-      proxy:self.proxy
+    request.init({
+      localAddress:request.localAddress,
+      proxy:request.proxy
   })
 
   return true

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -138,7 +138,10 @@ Redirect.prototype.onResponse = function (response) {
 
   request.emit('redirect')
 
-  request.init()
+  request.init({
+      localAddress:self.localAddress,
+      proxy:self.proxy
+  })
 
   return true
 }

--- a/tests/test-localAddress.js
+++ b/tests/test-localAddress.js
@@ -43,8 +43,6 @@ tape('bind to local address on redirect', function (t) {
         localAddress: localIPS[0]
     }, function (err, res) {
         t.equal(err, null)
-        res.body = "";
-        console.log(res.request.method);
         t.equal(res.request.localAddress, localIPS[0])
         t.end()
     })

--- a/tests/test-localAddress.js
+++ b/tests/test-localAddress.js
@@ -1,27 +1,51 @@
 'use strict'
-
 var request = require('../index')
-  , tape = require('tape')
+    , tape = require('tape')
 
-tape('bind to invalid address', function(t) {
-  request.get({
-    uri: 'http://www.google.com',
-    localAddress: '1.2.3.4'
-  }, function(err, res) {
-    t.notEqual(err, null)
-    t.equal(err.message, 'bind EADDRNOTAVAIL')
-    t.equal(res, undefined)
-    t.end()
-  })
+tape('bind to invalid address', function (t) {
+    request.get({
+        uri: 'http://www.google.com',
+        localAddress: '1.2.3.4'
+    }, function (err, res) {
+        t.notEqual(err, null)
+        t.equal(err.message, 'bind EADDRNOTAVAIL')
+        t.equal(res, undefined)
+        t.end()
+    })
 })
 
-tape('bind to local address', function(t) {
-  request.get({
-    uri: 'http://www.google.com',
-    localAddress: '127.0.0.1'
-  }, function(err, res) {
-    t.notEqual(err, null)
-    t.equal(res, undefined)
-    t.end()
-  })
+tape('bind to local address', function (t) {
+    request.get({
+        uri: 'http://www.google.com',
+        localAddress: '127.0.0.1'
+    }, function (err, res) {
+        t.notEqual(err, null)
+        t.equal(res, undefined)
+        t.end()
+    })
+})
+
+tape('bind to local address on redirect', function (t) {
+    var os = require('os')
+    var localInterfaces = os.networkInterfaces()
+    var localIPS=[]
+    Object.keys(localInterfaces).forEach(function (ifname) {
+        localInterfaces[ifname].forEach(function (iface) {
+            if ('IPv4' !== iface.family || iface.internal !== false) {
+                // skip over internal (i.e. 127.0.0.1) and non-ipv4 addresses
+                return;
+            }
+                localIPS.push(iface.address);
+        });
+    });
+    request.get({
+        uri: 'http://google.com', //redirects to 'http://google.com'
+        localAddress: localIPS[0]
+    }, function (err, res) {
+        t.equal(err, null)
+        res.body = "";
+        console.log(res.request.method);
+        t.equal(res.request.localAddress, localIPS[0])
+        t.end()
+    })
 })

--- a/tests/test-localAddress.js
+++ b/tests/test-localAddress.js
@@ -28,16 +28,16 @@ tape('bind to local address', function (t) {
 tape('bind to local address on redirect', function (t) {
     var os = require('os')
     var localInterfaces = os.networkInterfaces()
-    var localIPS=[]
+    var localIPS = []
     Object.keys(localInterfaces).forEach(function (ifname) {
         localInterfaces[ifname].forEach(function (iface) {
-            if ('IPv4' !== iface.family || iface.internal !== false) {
+            if (iface.family !== 'IPv4' || iface.internal !== false) {
                 // skip over internal (i.e. 127.0.0.1) and non-ipv4 addresses
-                return;
+                return
             }
-                localIPS.push(iface.address);
-        });
-    });
+                localIPS.push(iface.address)
+        })
+    })
     request.get({
         uri: 'http://google.com', //redirects to 'http://google.com'
         localAddress: localIPS[0]


### PR DESCRIPTION
the localAddress or proxy configuration is lost when redirecting because the request object is initialized with an empty configuration instead of inheriting the one that made the initial request