### PR TITLE
Prevent crash with authorization and followRedirects of false

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -105,11 +105,13 @@ Redirect.prototype.onResponse = function (response) {
     request._updateProtocol()
   }
 
-  self.redirects.push(
-    { statusCode : response.statusCode
-    , redirectUri: redirectTo
-    }
-  )
+  if (self.redirects) {
+    self.redirects.push(
+      { statusCode : response.statusCode
+      , redirectUri: redirectTo
+      }
+    )
+  }
   if (self.followAllRedirects && response.statusCode !== 401 && response.statusCode !== 307) {
     request.method = 'GET'
   }


### PR DESCRIPTION
Currently turning followRedirects to false while passing in authorization information causes a crash.

self.redirects is only set if followRedirects or followAllRedirects is set:
https://github.com/request/request/blob/2f5f5e1913cad4b83fc379b1f96ac0f2f0fe1c7b/lib/redirect.js#L34

redirectTo is set to a value here if you are using authorization:
https://github.com/request/request/blob/2f5f5e1913cad4b83fc379b1f96ac0f2f0fe1c7b/lib/redirect.js#L66

I found this working with 2.27.0, but it seems to have been transferred to the latest code.