### PR TITLE
Reuse agentClass on redirect

### DIFF
--- a/request.js
+++ b/request.js
@@ -585,11 +585,11 @@ Request.prototype.init = function (options) {
     self.ca = options.ca
   }
 
-  if (!self.agent) {
-    if (options.agentOptions) {
-      self.agentOptions = options.agentOptions
-    }
+  if (!self.agent && options.agentOptions) {
+    self.agentOptions = options.agentOptions
+  }
 
+  if (!self.agent && !self.agentClass) {
     if (options.agentClass) {
       self.agentClass = options.agentClass
     } else if (options.forever) {


### PR DESCRIPTION
Fixes #1304

As no options are passed to `init()` on redirect, Request fell back to the default agent. This fixes changes the behaviour so that the default is not used if `self.agentClass` is already specified.

Includes a test case.