### PR TITLE
Require Colon in Basic Auth

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -26,7 +26,7 @@ Auth.prototype.basic = function (user, pass, sendImmediately) {
   self.user = user
   self.pass = pass
   self.hasAuth = true
-  var header = typeof pass !== 'undefined' ? user + ':' + pass : user
+  var header = user + ':' + (pass || '')
   if (sendImmediately || typeof sendImmediately === 'undefined') {
     var authHeader = 'Basic ' + toBase64(header)
     self.sentAuth = true

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -22,8 +22,6 @@ tape('setup', function(t) {
         ok = true
       } else if ( req.headers.authorization === 'Basic ' + new Buffer(':pass').toString('base64')) {
         ok = true
-      } else if ( req.headers.authorization === 'Basic ' + new Buffer('user').toString('base64')) {
-        ok = true
       } else {
         // Bad auth header, don't send back WWW-Authenticate header
         ok = false


### PR DESCRIPTION
Going by RFC 2617, it seems that a colon is required in the base64 encoded user-pass.
```
   To receive authorization, the client sends the userid and password,
   separated by a single colon (":") character, within a base64 [7]
   encoded string in the credentials.

      basic-credentials = base64-user-pass
      base64-user-pass  = <base64 [4] encoding of user-pass, except not limited to 76 char/line>
      user-pass   = userid ":" password
      userid      = *<TEXT excluding ":">
      password    = *TEXT
```
https://www.ietf.org/rfc/rfc2617.txt

Some servers handle the case of a missing colon, but others do not. For instance, the standard method in Golang for parsing basic auth requires a colon.
http://golang.org/src/net/http/request.go?s=16575:16641#L518

Rather than force users to specify an empty string, it would be preferable to treat an undefined password as an empty string.