### PR TITLE
Add support for qs options via qsOptions key

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 * `uri` || `url` - fully qualified uri or a parsed url object from `url.parse()`
 * `qs` - object containing querystring values to be appended to the `uri`
+* `qsOptions` - object containing options to pass to the `qs` or `querystring` module
 * `useQuerystring` - If true, use `querystring` to stringify and parse
   querystrings, otherwise use `qs` (default: `false`).  Set this option to
   `true` if you need arrays to be serialized as `foo=bar&foo=baz` instead of the

--- a/README.md
+++ b/README.md
@@ -565,7 +565,8 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 * `uri` || `url` - fully qualified uri or a parsed url object from `url.parse()`
 * `qs` - object containing querystring values to be appended to the `uri`
-* `qsOptions` - object containing options to pass to the `qs` or `querystring` module
+* `qsParseOptions` - object containing options to pass to the [qs.parse](https://github.com/hapijs/qs#parsing-objects) method or [querystring.parse](https://nodejs.org/docs/v0.12.0/api/querystring.html#querystring_querystring_parse_str_sep_eq_options) method
+* `qsStringifyOptions` - object containing options to pass to the [qs.stringify](https://github.com/hapijs/qs#stringifying) method or to the [querystring.stringify](https://nodejs.org/docs/v0.12.0/api/querystring.html#querystring_querystring_stringify_obj_sep_eq_options) method. For example, to change the way arrays are converted to query strings pass the `arrayFormat` option with one of `indices|brackets|repeat`
 * `useQuerystring` - If true, use `querystring` to stringify and parse
   querystrings, otherwise use `qs` (default: `false`).  Set this option to
   `true` if you need arrays to be serialized as `foo=bar&foo=baz` instead of the

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "json-stringify-safe": "~5.0.0",
     "mime-types": "~2.0.1",
     "node-uuid": "~1.4.0",
-    "qs": "~2.3.1",
+    "qs": "~2.4.0",
     "tunnel-agent": "~0.4.0",
     "tough-cookie": ">=0.12.0",
     "http-signature": "~0.10.0",

--- a/request.js
+++ b/request.js
@@ -329,6 +329,9 @@ Request.prototype.init = function (options) {
   if (!self.qsLib) {
     self.qsLib = (options.useQuerystring ? querystring : qs)
   }
+  if (!self.qsOptions) {
+    self.qsOptions = options.qsOptions
+  }
 
   debug(options)
   if (!self.pool && self.pool !== false) {
@@ -1229,7 +1232,7 @@ Request.prototype.qs = function (q, clobber) {
   var self = this
   var base
   if (!clobber && self.uri.query) {
-    base = self.qsLib.parse(self.uri.query)
+    base = self.qsLib.parse(self.uri.query, self.qsOptions)
   } else {
     base = {}
   }
@@ -1238,11 +1241,11 @@ Request.prototype.qs = function (q, clobber) {
     base[i] = q[i]
   }
 
-  if (self.qsLib.stringify(base) === ''){
+  if (self.qsLib.stringify(base, self.qsOptions) === ''){
     return self
   }
 
-  var qs = self.qsLib.stringify(base)
+  var qs = self.qsLib.stringify(base, self.qsOptions)
 
   self.uri = url.parse(self.uri.href.split('?')[0] + '?' + rfc3986(qs))
   self.url = self.uri
@@ -1254,7 +1257,9 @@ Request.prototype.form = function (form) {
   var self = this
   if (form) {
     self.setHeader('content-type', 'application/x-www-form-urlencoded')
-    self.body = (typeof form === 'string') ? form.toString('utf8') : self.qsLib.stringify(form).toString('utf8')
+    self.body = (typeof form === 'string')
+      ? form.toString('utf8')
+      : self.qsLib.stringify(form, self.qsOptions).toString('utf8')
     self.body = rfc3986(self.body)
     return self
   }

--- a/request.js
+++ b/request.js
@@ -329,8 +329,11 @@ Request.prototype.init = function (options) {
   if (!self.qsLib) {
     self.qsLib = (options.useQuerystring ? querystring : qs)
   }
-  if (!self.qsOptions) {
-    self.qsOptions = options.qsOptions
+  if (!self.qsParseOptions) {
+    self.qsParseOptions = options.qsParseOptions
+  }
+  if (!self.qsStringifyOptions) {
+    self.qsStringifyOptions = options.qsStringifyOptions
   }
 
   debug(options)
@@ -1232,7 +1235,7 @@ Request.prototype.qs = function (q, clobber) {
   var self = this
   var base
   if (!clobber && self.uri.query) {
-    base = self.qsLib.parse(self.uri.query, self.qsOptions)
+    base = self.qsLib.parse(self.uri.query, self.qsParseOptions)
   } else {
     base = {}
   }
@@ -1241,11 +1244,11 @@ Request.prototype.qs = function (q, clobber) {
     base[i] = q[i]
   }
 
-  if (self.qsLib.stringify(base, self.qsOptions) === ''){
+  if (self.qsLib.stringify(base, self.qsStringifyOptions) === ''){
     return self
   }
 
-  var qs = self.qsLib.stringify(base, self.qsOptions)
+  var qs = self.qsLib.stringify(base, self.qsStringifyOptions)
 
   self.uri = url.parse(self.uri.href.split('?')[0] + '?' + rfc3986(qs))
   self.url = self.uri
@@ -1259,7 +1262,7 @@ Request.prototype.form = function (form) {
     self.setHeader('content-type', 'application/x-www-form-urlencoded')
     self.body = (typeof form === 'string')
       ? form.toString('utf8')
-      : self.qsLib.stringify(form, self.qsOptions).toString('utf8')
+      : self.qsLib.stringify(form, self.qsStringifyOptions).toString('utf8')
     self.body = rfc3986(self.body)
     return self
   }

--- a/tests/test-qs.js
+++ b/tests/test-qs.js
@@ -6,7 +6,8 @@ var request = require('../index')
 // Run a querystring test.  `options` can have the following keys:
 //   - suffix              : a string to be added to the URL
 //   - qs                  : an object to be passed to request's `qs` option
-//   - qsOptions           : an object to be passed to request's `qsOptions` option
+//   - qsParseOptions      : an object to be passed to request's `qsParseOptions` option
+//   - qsStringifyOptions  : an object to be passed to request's `qsStringifyOptions` option
 //   - afterRequest        : a function to execute after creating the request
 //   - expected            : the expected path of the request
 //   - expectedQuerystring : expected path when using the querystring library
@@ -14,7 +15,8 @@ function runTest(name, options) {
   var uri = 'http://www.google.com' + (options.suffix || '')
     , requestOptsQs = {
       uri : uri,
-      qsOptions: options.qsOptions
+      qsParseOptions: options.qsParseOptions,
+      qsStringifyOptions: options.qsStringifyOptions
     }
     , requestOptsQuerystring = {
       uri : uri,
@@ -104,9 +106,18 @@ runTest('a query with an array for a value', {
   expectedQuerystring : '/?order=bar&order=desc'
 })
 
-runTest('pass options to the qs module via the qsOptions key', {
+runTest('pass options to the qs module via the qsParseOptions key', {
+  suffix   : '?a=1;b=2',
+  qs: {},
+  qsParseOptions: { delimiter : ';' },
+  qsStringifyOptions: { delimiter : ';' },
+  expected : esc('/?a=1;b=2'),
+  expectedQuerystring : '/?a=1%3Bb%3D2'
+})
+
+runTest('pass options to the qs module via the qsStringifyOptions key', {
   qs       : { order : ['bar', 'desc'] },
-  qsOptions: { arrayFormat : 'brackets' },
+  qsStringifyOptions: { arrayFormat : 'brackets' },
   expected : esc('/?order[]=bar&order[]=desc'),
   expectedQuerystring : '/?order=bar&order=desc'
 })

--- a/tests/test-qs.js
+++ b/tests/test-qs.js
@@ -6,13 +6,15 @@ var request = require('../index')
 // Run a querystring test.  `options` can have the following keys:
 //   - suffix              : a string to be added to the URL
 //   - qs                  : an object to be passed to request's `qs` option
+//   - qsOptions           : an object to be passed to request's `qsOptions` option
 //   - afterRequest        : a function to execute after creating the request
 //   - expected            : the expected path of the request
 //   - expectedQuerystring : expected path when using the querystring library
 function runTest(name, options) {
   var uri = 'http://www.google.com' + (options.suffix || '')
     , requestOptsQs = {
-      uri : uri
+      uri : uri,
+      qsOptions: options.qsOptions
     }
     , requestOptsQuerystring = {
       uri : uri,
@@ -99,5 +101,12 @@ runTest('a query with an object for a value', {
 runTest('a query with an array for a value', {
   qs       : { order : ['bar', 'desc'] },
   expected : esc('/?order[0]=bar&order[1]=desc'),
+  expectedQuerystring : '/?order=bar&order=desc'
+})
+
+runTest('pass options to the qs module via the qsOptions key', {
+  qs       : { order : ['bar', 'desc'] },
+  qsOptions: { arrayFormat : 'brackets' },
+  expected : esc('/?order[]=bar&order[]=desc'),
   expectedQuerystring : '/?order=bar&order=desc'
 })


### PR DESCRIPTION
Closes https://github.com/request/request/issues/1473

The `qsOptions` key can be used to pass options to both the `parse` and the `stringify` methods of the `qs` and `querystring` modules.

The `arrayFormat` options was missing from the `qs` readme https://github.com/hapijs/qs/pull/72