### PR TITLE
Fix baseUrl and redirections.

### DIFF
--- a/request.js
+++ b/request.js
@@ -386,6 +386,7 @@ Request.prototype.init = function (options) {
     } else {
       self.uri = self.baseUrl + '/' + self.uri
     }
+    delete self.baseUrl
   }
 
   // A URI is needed by this point, throw if we haven't been able to get one

--- a/tests/test-baseUrl.js
+++ b/tests/test-baseUrl.js
@@ -6,8 +6,14 @@ var http = require('http')
   , url = require('url')
 
 var s = http.createServer(function(req, res) {
-  res.statusCode = 200
-  res.setHeader('X-PATH', req.url)
+  if(req.url === '/redirect/') {
+    res.writeHead(302, {
+      location : '/'
+    })
+  } else {
+    res.statusCode = 200
+    res.setHeader('X-PATH', req.url)
+  }
   res.end('ok')
 })
 
@@ -34,6 +40,17 @@ tape('baseUrl defaults', function(t) {
   withDefaults('resource', function(err, resp, body) {
     t.equal(err, null)
     t.equal(body, 'ok')
+    t.end()
+  })
+})
+
+tape('baseUrl and redirects', function(t) {
+  request('/', {
+    baseUrl: 'http://localhost:6767/redirect'
+  }, function(err, resp, body) {
+    t.equal(err, null)
+    t.equal(body, 'ok')
+    t.equal(resp.headers['x-path'], '/')
     t.end()
   })
 })


### PR DESCRIPTION
I found a bug in new `baseUrl` feature, when used in combination with redirection.

This script produce absurdly error `[Error: options.uri must be a string when using options.baseUrl]`:

```javascript
var request = require('./node_modules/request');
var http = require('http');

var s = http.createServer(function(req, res) {
  if(req.url === '/redirect/') {
    res.writeHead(302, {
      location : '/'
    })
  } else  {
    res.statusCode = 200
  }
  res.end()
}).listen(6767);

request({
  url: '/',
  baseUrl: 'http://localhost:6767/redirect'

}, function (err, resp, body) {
  console.log(err);
  s.close();
});
```
This is due to the fact that first call changes URI to an object, and therefore in the second iteration (to redirected page) can be seen as a string. The solution is delete `baseUrl` immediately after use, because certainly no longer needed.

This pull request fixes this bug. Test included.