### PR TITLE
Parameters encoded to base 64 should be decoded as UTF-8, not ASCII.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -74,7 +74,7 @@ function isReadStream (rs) {
 }
 
 function toBase64 (str) {
-  return (new Buffer(str || '', 'ascii')).toString('base64')
+  return (new Buffer(str || '', 'utf8')).toString('base64')
 }
 
 exports.isFunction            = isFunction

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -22,6 +22,8 @@ tape('setup', function(t) {
         ok = true
       } else if ( req.headers.authorization === 'Basic ' + new Buffer(':pass').toString('base64')) {
         ok = true
+      } else if ( req.headers.authorization === 'Basic ' + new Buffer('user:pâss').toString('base64')) {
+        ok = true
       } else {
         // Bad auth header, don't send back WWW-Authenticate header
         ok = false
@@ -155,6 +157,27 @@ tape('pass - undefined', function(t) {
   })
 })
 
+
+tape('pass - utf8', function(t) {
+  t.doesNotThrow( function() {
+    var r = request({
+      'method': 'GET',
+      'uri': 'http://localhost:6767/allow_undefined_password/',
+      'auth': {
+        'user': 'user',
+        'pass': 'pâss',
+        'sendImmediately': false
+      }
+    }, function(error, res, body ) {
+      t.equal(r._auth.user, 'user')
+      t.equal(r._auth.pass, 'pâss')
+      t.equal(res.statusCode, 200)
+      t.equal(numBasicRequests, 12)
+      t.end()
+    })
+  })
+})
+
 tape('auth method', function(t) {
   var r = request
     .get('http://localhost:6767/test/')
@@ -162,7 +185,7 @@ tape('auth method', function(t) {
     .on('response', function (res) {
       t.equal(r._auth.user, 'user')
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 12)
+      t.equal(numBasicRequests, 14)
       t.end()
     })
 })
@@ -179,7 +202,7 @@ tape('get method', function(t) {
       t.equal(r._auth.user, 'user')
       t.equal(err, null)
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 14)
+      t.equal(numBasicRequests, 16)
       t.end()
     })
 })


### PR DESCRIPTION
This fixes a bug that I have currently. Some users were created with special characters in password but could not authenticate through request.auth method afterward.