### PR TITLE
Adding handling for no auth method and null bearer

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -42,7 +42,7 @@ Auth.prototype.bearer = function (bearer, sendImmediately) {
     if (typeof bearer === 'function') {
       bearer = bearer()
     }
-    var authHeader = 'Bearer ' + bearer
+    var authHeader = 'Bearer ' + (bearer || '')
     self.sentAuth = true
     return authHeader
   }
@@ -114,7 +114,9 @@ Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
     , request = self.request
 
   var authHeader
-  if (bearer !== undefined) {
+  if (bearer === undefined && user === undefined) {
+    throw new Error('no auth mechanism defined')
+  } else if (bearer !== undefined) {
     authHeader = self.bearer(bearer, sendImmediately)
   } else {
     authHeader = self.basic(user, pass, sendImmediately)

--- a/tests/test-bearer-auth.js
+++ b/tests/test-bearer-auth.js
@@ -49,7 +49,7 @@ tape('setup', function(t) {
   })
 })
 
-tape('', function(t) {
+tape('bearer auth', function(t) {
   request({
     'method': 'GET',
     'uri': 'http://localhost:6767/test/',
@@ -64,7 +64,7 @@ tape('', function(t) {
   })
 })
 
-tape('', function(t) {
+tape('bearer auth with default sendImmediately', function(t) {
   // If we don't set sendImmediately = false, request will send bearer auth
   request({
     'method': 'GET',
@@ -95,7 +95,7 @@ tape('', function(t) {
   })
 })
 
-tape('', function(t) {
+tape('using .auth, sendImmediately = false', function(t) {
   request
     .get('http://localhost:6767/test/')
     .auth(null, null, false, 'theToken')
@@ -106,7 +106,7 @@ tape('', function(t) {
     })
 })
 
-tape('', function(t) {
+tape('using .auth, sendImmediately = true', function(t) {
   request
     .get('http://localhost:6767/test/')
     .auth(null, null, true, 'theToken')
@@ -117,7 +117,7 @@ tape('', function(t) {
     })
 })
 
-tape('', function(t) {
+tape('bearer is a function', function(t) {
   request({
     'method': 'GET',
     'uri': 'http://localhost:6767/test/',
@@ -132,7 +132,7 @@ tape('', function(t) {
   })
 })
 
-tape('', function(t) {
+tape('bearer is a function, path = test2', function(t) {
   // If we don't set sendImmediately = false, request will send bearer auth
   request({
     'method': 'GET',
@@ -143,6 +143,36 @@ tape('', function(t) {
   }, function(error, res, body) {
     t.equal(res.statusCode, 200)
     t.equal(numBearerRequests, 11)
+    t.end()
+  })
+})
+
+tape('no auth method', function(t) {
+  t.throws(function() {
+    request({
+      'method': 'GET',
+      'uri': 'http://localhost:6767/test2/',
+      'auth': {
+        'bearer': undefined
+      }
+    }, function(error, res, body) {
+      t.fail('Requests without a valid auth mechanism are not valid')
+      t.end()
+    })
+  }, /no auth mechanism defined/)
+  t.end()
+})
+
+tape('null bearer', function(t) {
+  request({
+    'method': 'GET',
+    'uri': 'http://localhost:6767/test2/',
+    'auth': {
+      'bearer': null
+    }
+  }, function(error, res, body) {
+    t.equal(res.statusCode, 401)
+    t.equal(numBearerRequests, 12)
     t.end()
   })
 })


### PR DESCRIPTION
I noticed a couple of scenarios the other day:

0.  When no authentication mechanism is defined, or bearer = undefined (I meant to send it, but it got set incorrectly) the error message is difficult to deciper
0.  When setting `bearer: null`, request does a string concat, which results in `'bearer null'`. Probably not the intended behavior

Also added explanations to the bearer tests