### PR TITLE
HTTP Archive 1.2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ request('http://www.google.com', function (error, response, body) {
 - [Proxies](#proxies)
 - [Unix Domain Sockets](#unix-domain-sockets)
 - [TLS/SSL Protocol](#tlsssl-protocol)
-- [Support for HAR 1.2](#support-for-har-1.2)
+- [Support for HAR 1.2](#support-for-har-12)
 - [**All Available Options**](#requestoptions-callback)
 
 Request also offers [convenience methods](#convenience-methods) like

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ request('http://www.google.com', function (error, response, body) {
 - [Proxies](#proxies)
 - [Unix Domain Sockets](#unix-domain-sockets)
 - [TLS/SSL Protocol](#tlsssl-protocol)
+- [Support for HAR 1.2](#support-for-har-1.2)
 - [**All Available Options**](#requestoptions-callback)
 
 Request also offers [convenience methods](#convenience-methods) like
@@ -633,6 +634,54 @@ request.get({
 
 ---
 
+## Support for HAR 1.2
+
+The `options.har` property will override the values: `url`, `method`, `qs`, `headers`, `form`, `formData`, `body`, `json`, as well as construct multipart data and read files from disk when `request.postData.params[].fileName` is present without a matching `value`.
+
+a validation step will check if the HAR Request format matches the latest spec (v1.2) and will skip parsing if not matching.
+
+```js
+  var request = require('request')
+  request({
+    // will be ignored
+    method: 'GET'
+    uri: 'http://www.google.com',
+
+    // HTTP Archive Request Object
+    har: {
+      url: 'http://www.mockbin.com/har'
+      method: 'POST',
+      headers: [
+        {
+          name: 'content-type',
+          value: 'application/x-www-form-urlencoded'
+        }
+      ],
+      postData: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {
+            name: 'foo',
+            value: 'bar'
+          },
+          {
+            name: 'hello',
+            value: 'world'
+          }
+        ]
+      }
+    }
+  })
+
+  // a POST request will be sent to http://www.mockbin.com
+  // with body an application/x-www-form-urlencoded body:
+  // foo=bar&hello=world
+```
+
+[back to top](#table-of-contents)
+
+
+---
 
 ## request(options, callback)
 
@@ -728,7 +777,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 ---
 
-- `har` - A [HAR 1.2 Request Object](http://www.softwareishard.com/blog/har-12-spec/#request), will be processed from HAR format into options overwriting matching values *(see example below for details)*
+- `har` - A [HAR 1.2 Request Object](http://www.softwareishard.com/blog/har-12-spec/#request), will be processed from HAR format into options overwriting matching values *(see the [HAR 1.2 section](#support-for-har-1.2) for details)*
 
 The callback argument gets 3 arguments:
 
@@ -740,50 +789,6 @@ The callback argument gets 3 arguments:
 
 
 ---
-
-## Support for HAR 1.2
-
-The `options.har` property will override the values: `url`, `method`, `qs`, `headers`, `form`, `formData`, `body`, `json`, as well as construct multipart data and read files from disk when `request.postData.params[].fileName` is present without a matching `value`.
-
-a validation step will check if the HAR Request format matches the latest spec (v1.2) and will skip parsing if not matching.
-
-```js
-  var request = require('request')
-  request({
-    // will be ignored
-    method: 'GET'
-    uri: 'http://www.google.com',
-
-    // HTTP Archive Request Object
-    har: {
-      url: 'http://www.mockbin.com/har'
-      method: 'POST',
-      headers: [
-        {
-          name: 'content-type',
-          value: 'application/x-www-form-urlencoded'
-        }
-      ],
-      postData: {
-        mimeType: 'application/x-www-form-urlencoded',
-        params: [
-          {
-            name: 'foo',
-            value: 'bar'
-          },
-          {
-            name: 'hello',
-            value: 'world'
-          }
-        ]
-      }
-    }
-  })
-
-  // a POST request will be sent to http://www.mockbin.com
-  // with body an application/x-www-form-urlencoded body:
-  // foo=bar&hello=world
-```
 
 ## Convenience methods
 

--- a/README.md
+++ b/README.md
@@ -726,6 +726,9 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 - `time` - If `true`, the request-response cycle (including all redirects) is timed at millisecond resolution, and the result provided on the response's `elapsedTime` property.
 
+---
+
+- `har` - A [HAR 1.2 Request Object](http://www.softwareishard.com/blog/har-12-spec/#request), will be processed from HAR format into options overwriting matching values *(see example below for details)*
 
 The callback argument gets 3 arguments:
 
@@ -738,6 +741,49 @@ The callback argument gets 3 arguments:
 
 ---
 
+## Support for HAR 1.2
+
+The `options.har` property will override the values: `url`, `method`, `qs`, `headers`, `form`, `formData`, `body`, `json`, as well as construct multipart data and read files from disk when `request.postData.params[].fileName` is present without a matching `value`.
+
+a validation step will check if the HAR Request format matches the latest spec (v1.2) and will skip parsing if not matching.
+
+```js
+  var request = require('request')
+  request({
+    // will be ignored
+    method: 'GET'
+    uri: 'http://www.google.com',
+
+    // HTTP Archive Request Object
+    har: {
+      url: 'http://www.mockbin.com/har'
+      method: 'POST',
+      headers: [
+        {
+          name: 'content-type',
+          value: 'application/x-www-form-urlencoded'
+        }
+      ],
+      postData: {
+        mimeType: 'application/x-www-form-urlencoded',
+        params: [
+          {
+            name: 'foo',
+            value: 'bar'
+          },
+          {
+            name: 'hello',
+            value: 'world'
+          }
+        ]
+      }
+    }
+  })
+
+  // a POST request will be sent to http://www.mockbin.com
+  // with body an application/x-www-form-urlencoded body:
+  // foo=bar&hello=world
+```
 
 ## Convenience methods
 

--- a/lib/har.js
+++ b/lib/har.js
@@ -1,0 +1,191 @@
+'use strict'
+
+var fs = require('fs')
+var path = require('path')
+var qs = require('querystring')
+var util = require('util')
+
+function Har (request) {
+  this.request = request
+}
+
+Har.prototype.reducer = function (obj, pair) {
+  // new property ?
+  if (obj[pair.name] === undefined) {
+    obj[pair.name] = pair.value
+    return obj
+  }
+
+  // existing? convert to array
+  var arr = [
+    obj[pair.name],
+    pair.value
+  ]
+
+  obj[pair.name] = arr
+
+  return obj
+}
+
+Har.prototype.prep = function (har) {
+  var data = util._extend({}, har)
+
+  // only process the first entry
+  if (data.log && data.log.entries) {
+    data = data.log.entries[0]
+  }
+
+  // construct utility properties
+  data.queryObj = {}
+  data.headersObj = {}
+  data.postData = data.postData ? data.postData : {}
+  data.postData.jsonObj = false
+  data.postData.paramsObj = false
+
+  // construct query objects
+  if (data.queryString && data.queryString.length) {
+    data.queryObj = data.queryString.reduce(this.reducer, {})
+  }
+
+  // construct headers objects
+  if (data.headers && data.headers.length) {
+    // loweCase header keys
+    data.headersObj = data.headers.reduceRight(function (headers, header) {
+      headers[header.name] = header.value
+      return headers
+    }, {})
+  }
+
+  // construct Cookie heade
+  if (data.cookies && data.cookies.length) {
+    var cookies = data.cookies.map(function (cookie) {
+      return cookie.name + '=' + cookie.value
+    })
+
+    if (cookies.length) {
+      data.headersObj.cookie = cookies.join('; ')
+    }
+  }
+
+  // prep body
+  switch (data.postData.mimeType) {
+    case 'multipart/mixed':
+    case 'multipart/related':
+    case 'multipart/form-data':
+    case 'multipart/alternative':
+      // reset values
+      data.postData.mimeType = 'multipart/form-data'
+      break
+
+    case 'application/x-www-form-urlencoded':
+      if (!data.postData.params) {
+        data.postData.text = ''
+      } else {
+        data.postData.paramsObj = data.postData.params.reduce(this.reducer, {})
+
+        // always overwrite
+        data.postData.text = qs.stringify(data.postData.paramsObj)
+      }
+      break
+
+    case 'text/json':
+    case 'text/x-json':
+    case 'application/json':
+    case 'application/x-json':
+      data.postData.mimeType = 'application/json'
+
+      if (data.postData.text) {
+        try {
+          data.postData.jsonObj = JSON.parse(data.postData.text)
+        } catch (e) {
+          this.request.debug(e)
+
+          // force back to text/plain
+          data.postData.mimeType = 'text/plain'
+        }
+      }
+      break
+  }
+
+  return data
+}
+
+Har.prototype.options = function (options) {
+  // skip if no har property defined
+  if (!options.har) {
+    return options
+  }
+
+  // clean up and get some utility properties
+  var req = this.prep(options.har)
+
+  // construct new options
+  if (req.url) {
+    options.url = req.url
+  }
+
+  if (req.method) {
+    options.method = req.method
+  }
+
+  if (Object.keys(req.queryObj).length) {
+    options.qs = req.queryObj
+  }
+
+  if (Object.keys(req.headersObj).length) {
+    options.headers = req.headersObj
+  }
+
+  switch (req.postData.mimeType) {
+    case 'application/x-www-form-urlencoded':
+      options.form = req.postData.paramsObj
+      break
+
+    case 'application/json':
+      if (req.postData.jsonObj) {
+        options.body = req.postData.jsonObj
+        options.json = true
+      }
+      break
+
+    case 'multipart/form-data':
+      options.formData = {}
+
+      req.postData.params.forEach(function (param) {
+        var attachement = {}
+
+        if (!param.fileName && !param.fileName && !param.contentType) {
+          options.formData[param.name] = param.value
+          return
+        }
+
+        // attempt to read from disk!
+        if (param.fileName && !param.value) {
+          attachement.value = fs.createReadStream(param.fileName)
+        } else if (param.value) {
+          attachement.value = param.value
+        }
+
+        if (param.fileName) {
+          var base = path.parse(param.fileName).base
+
+          attachement.options = {
+            filename: base.length ? base : 'filename',
+            contentType: param.contentType ? param.contentType : null
+          }
+        }
+
+        options.formData[param.name] = attachement
+      })
+      break
+
+    default:
+      if (req.postData.text) {
+        options.body = req.postData.text
+      }
+  }
+
+  return options
+}
+
+exports.Har = Har

--- a/lib/har.js
+++ b/lib/har.js
@@ -3,6 +3,7 @@
 var fs = require('fs')
 var path = require('path')
 var qs = require('querystring')
+var validate = require('har-validator')
 var util = require('util')
 
 function Har (request) {
@@ -27,18 +28,10 @@ Har.prototype.reducer = function (obj, pair) {
   return obj
 }
 
-Har.prototype.prep = function (har) {
-  var data = util._extend({}, har)
-
-  // only process the first entry
-  if (data.log && data.log.entries) {
-    data = data.log.entries[0]
-  }
-
+Har.prototype.prep = function (data) {
   // construct utility properties
   data.queryObj = {}
   data.headersObj = {}
-  data.postData = data.postData ? data.postData : {}
   data.postData.jsonObj = false
   data.postData.paramsObj = false
 
@@ -116,8 +109,32 @@ Har.prototype.options = function (options) {
     return options
   }
 
+  var har = util._extend({}, options.har)
+
+  // only process the first entry
+  if (har.log && har.log.entries) {
+    har = har.log.entries[0]
+  }
+
+  // add optional properties to make validation successful
+  har.url = har.url || options.url || options.uri || options.baseUrl || '/'
+  har.httpVersion = har.httpVersion || 'HTTP/1.1'
+  har.queryString = har.queryString || []
+  har.headers = har.headers || []
+  har.cookies = har.cookies || []
+  har.postData = har.postData || {}
+  har.postData.mimeType = har.postData.mimeType || 'application/octet-stream'
+
+  har.bodySize = 0
+  har.headersSize = 0
+  har.postData.size = 0
+
+  if (!validate.request(har)) {
+    return options
+  }
+
   // clean up and get some utility properties
-  var req = this.prep(options.har)
+  var req = this.prep(har)
 
   // construct new options
   if (req.url) {

--- a/lib/har.js
+++ b/lib/har.js
@@ -48,7 +48,7 @@ Har.prototype.prep = function (data) {
     }, {})
   }
 
-  // construct Cookie heade
+  // construct Cookie header
   if (data.cookies && data.cookies.length) {
     var cookies = data.cookies.map(function (cookie) {
       return cookie.name + '=' + cookie.value
@@ -168,7 +168,7 @@ Har.prototype.options = function (options) {
       options.formData = {}
 
       req.postData.params.forEach(function (param) {
-        var attachement = {}
+        var attachment = {}
 
         if (!param.fileName && !param.fileName && !param.contentType) {
           options.formData[param.name] = param.value
@@ -177,19 +177,19 @@ Har.prototype.options = function (options) {
 
         // attempt to read from disk!
         if (param.fileName && !param.value) {
-          attachement.value = fs.createReadStream(param.fileName)
+          attachment.value = fs.createReadStream(param.fileName)
         } else if (param.value) {
-          attachement.value = param.value
+          attachment.value = param.value
         }
 
         if (param.fileName) {
-          attachement.options = {
+          attachment.options = {
             filename: param.fileName,
             contentType: param.contentType ? param.contentType : null
           }
         }
 
-        options.formData[param.name] = attachement
+        options.formData[param.name] = attachment
       })
       break
 

--- a/lib/har.js
+++ b/lib/har.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var fs = require('fs')
-var path = require('path')
 var qs = require('querystring')
 var validate = require('har-validator')
 var util = require('util')
@@ -184,10 +183,8 @@ Har.prototype.options = function (options) {
         }
 
         if (param.fileName) {
-          var base = path.parse(param.fileName).base
-
           attachement.options = {
-            filename: base.length ? base : 'filename',
+            filename: param.fileName,
             contentType: param.contentType ? param.contentType : null
           }
         }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "aws-sign2": "~0.5.0",
     "stringstream": "~0.0.4",
     "combined-stream": "~0.0.5",
-    "isstream": "~0.1.1"
+    "isstream": "~0.1.1",
+    "har-validator": "^1.4.0"
   },
   "scripts": {
     "test": "npm run lint && node node_modules/.bin/taper tests/test-*.js && npm run test-browser",

--- a/request.js
+++ b/request.js
@@ -22,6 +22,7 @@ var http = require('http')
   , cookies = require('./lib/cookies')
   , copy = require('./lib/copy')
   , getProxyFromURI = require('./lib/getProxyFromURI')
+  , Har = require('./lib/har').Har
   , Auth = require('./lib/auth').Auth
   , OAuth = require('./lib/oauth').OAuth
   , Multipart = require('./lib/multipart').Multipart
@@ -244,6 +245,13 @@ function Request (options) {
   // call init
 
   var self = this
+
+  // start with HAR, then override with additional options
+  if (options.har) {
+    self._har = new Har(self)
+    options = self._har.options(options)
+  }
+
   stream.Stream.call(self)
   var reserved = Object.keys(Request.prototype)
   var nonReserved = filterForNonReserved(reserved, options)

--- a/tests/fixtures/har.json
+++ b/tests/fixtures/har.json
@@ -1,0 +1,158 @@
+{
+  "application-form-encoded": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "application/x-www-form-urlencoded"
+      }
+    ],
+    "postData": {
+      "mimeType": "application/x-www-form-urlencoded",
+      "params": [
+        {
+          "name": "foo",
+          "value": "bar"
+        },
+        {
+          "name": "hello",
+          "value": "world"
+        }
+      ]
+    }
+  },
+
+  "application-json": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "application/json"
+      }
+    ],
+    "postData": {
+      "mimeType": "application/json",
+      "text": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}]}"
+    }
+  },
+
+  "cookies": {
+    "method": "POST",
+    "cookies":  [
+      {
+        "name": "foo",
+        "value": "bar"
+      },
+      {
+        "name": "bar",
+        "value": "baz"
+      }
+    ]
+  },
+
+  "custom-method": {
+    "method": "PROPFIND"
+  },
+
+  "headers": {
+    "method": "GET",
+    "headers": [
+      {
+        "name": "x-foo",
+        "value": "Bar"
+      }
+    ]
+  },
+
+  "multipart-data": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "multipart/form-data"
+      }
+    ],
+    "postData": {
+      "mimeType": "multipart/form-data",
+      "params": [
+        {
+          "name": "foo",
+          "value": "Hello World",
+          "fileName": "hello.txt",
+          "contentType": "text/plain"
+        }
+      ]
+    }
+  },
+
+  "multipart-file": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "multipart/form-data"
+      }
+    ],
+    "postData": {
+      "mimeType": "multipart/form-data",
+      "params": [
+        {
+          "name": "foo",
+          "fileName": "../tests/unicycle.jpg",
+          "contentType": "image/jpeg"
+        }
+      ]
+    }
+  },
+
+  "multipart-form-data": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "multipart/form-data"
+      }
+    ],
+    "postData": {
+      "mimeType": "multipart/form-data",
+      "params": [
+        {
+          "name": "foo",
+          "value": "bar"
+        }
+      ]
+    }
+  },
+
+  "query": {
+    "method": "GET",
+    "queryString": [
+      {
+        "name": "foo",
+        "value": "bar"
+      },
+      {
+        "name": "foo",
+        "value": "baz"
+      },
+      {
+        "name": "baz",
+        "value": "abc"
+      }
+    ]
+  },
+
+  "text-plain": {
+    "method": "POST",
+    "headers": [
+      {
+        "name": "content-type",
+        "value": "text/plain"
+      }
+    ],
+    "postData": {
+      "mimeType": "text/plain",
+      "text": "Hello World"
+    }
+  }
+}

--- a/tests/server.js
+++ b/tests/server.js
@@ -21,6 +21,28 @@ exports.createServer = function (port) {
   return s
 }
 
+exports.createEchoServer = function (port) {
+  port = port || exports.port
+  var s = http.createServer(function (req, resp) {
+    var b = ''
+    req.on('data', function (chunk) {b += chunk})
+    req.on('end', function () {
+      resp.writeHead(200, {'content-type':'application/json'})
+      resp.write(JSON.stringify({
+        url: req.url,
+        method: req.method,
+        headers: req.headers,
+        body: b
+      }))
+      resp.end()
+    })
+  })
+  s.port = port
+  s.url = 'http://localhost:' + port
+  s.protocol = 'http'
+  return s
+}
+
 exports.createSSLServer = function(port, opts) {
   port = port || exports.portSSL
 

--- a/tests/test-har.js
+++ b/tests/test-har.js
@@ -1,0 +1,172 @@
+'use strict'
+
+var request = require('..')
+var tape = require('tape')
+var fixture = require('./fixtures/har.json')
+var server = require('./server')
+
+var s = server.createEchoServer()
+
+tape('setup', function (t) {
+  s.listen(s.port, function () {
+    t.end()
+  })
+})
+
+tape('application-form-encoded', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['application-form-encoded']
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.equal(json.body, 'foo=bar&hello=world')
+    t.end()
+  })
+})
+
+tape('application-json', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['application-json']
+  }
+
+  request(options, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body.body, fixture['application-json'].postData.text)
+    t.end()
+  })
+})
+
+tape('cookies', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture.cookies
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.equal(json.headers.cookie, 'foo=bar; bar=baz')
+    t.end()
+  })
+})
+
+tape('custom-method', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['custom-method']
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.equal(json.method, fixture['custom-method'].method)
+    t.end()
+  })
+})
+
+tape('headers', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture.headers
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.equal(json.headers['x-foo'], 'Bar')
+    t.end()
+  })
+})
+
+tape('multipart-data', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['multipart-data']
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.ok(~json.headers['content-type'].indexOf('multipart/form-data'))
+    t.ok(~json.body.indexOf('Content-Disposition: form-data; name="foo"; filename="hello.txt"\r\nContent-Type: text/plain\r\n\r\nHello World'))
+    t.end()
+  })
+})
+
+tape('multipart-file', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['multipart-file']
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.ok(~json.headers['content-type'].indexOf('multipart/form-data'))
+    t.ok(~json.body.indexOf('Content-Disposition: form-data; name="foo"; filename="unicycle.jpg"\r\nContent-Type: image/jpeg'))
+    t.end()
+  })
+})
+
+tape('multipart-form-data', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['multipart-form-data']
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.ok(~json.headers['content-type'].indexOf('multipart/form-data'))
+    t.ok(~json.body.indexOf('Content-Disposition: form-data; name="foo"'))
+    t.end()
+  })
+})
+
+tape('query', function (t) {
+  var options = {
+    url: s.url + '/?fff=sss',
+    har: fixture.query
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.equal(json.url, '/?fff=sss&foo%5B0%5D=bar&foo%5B1%5D=baz&baz=abc')
+    t.end()
+  })
+})
+
+tape('text/plain', function (t) {
+  var options = {
+    url: s.url,
+    har: fixture['text-plain']
+  }
+
+  request(options, function (err, res, body) {
+    var json = JSON.parse(body)
+
+    t.equal(err, null)
+    t.equal(json.headers['content-type'], 'text/plain')
+    t.equal(json.body, 'Hello World')
+    t.end()
+  })
+})
+
+tape('cleanup', function (t) {
+  s.close(function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
passing a [HAR Request 1.2](http://www.softwareishard.com/blog/har-12-spec/#request) in `options.har` will construct and set matching `options` values for use in the request.

this makes the library particularly useful when dealing with debug / performance data from many tools and proxies, especially to repeat requests from the browser's network panel.