### PR TITLE
Fix defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,15 @@ request.defaults = function (options, requester) {
       var params = initParams(uri, opts, callback)
       params.options = extend(headerlessOptions(options), params.options)
 
+      if (typeof method === 'string') {
+        params.options.method = (method === 'del' ? 'DELETE' : method.toUpperCase())
+        method = request[method]
+      }
+
+      if (params.options.method === 'HEAD' && paramsHaveRequestBody(params)) {
+        throw new Error('HTTP HEAD requests MUST NOT include a request body.')
+      }
+
       if (options.headers) {
         params.options.headers = getHeaders(params, options)
       }
@@ -112,12 +121,12 @@ request.defaults = function (options, requester) {
   }
 
   var defaults      = wrap(self)
-  defaults.get      = wrap(self.get)
-  defaults.patch    = wrap(self.patch)
-  defaults.post     = wrap(self.post)
-  defaults.put      = wrap(self.put)
-  defaults.head     = wrap(self.head)
-  defaults.del      = wrap(self.del)
+  defaults.get      = wrap('get')
+  defaults.patch    = wrap('patch')
+  defaults.post     = wrap('post')
+  defaults.put      = wrap('put')
+  defaults.head     = wrap('head')
+  defaults.del      = wrap('del')
   defaults.cookie   = wrap(self.cookie)
   defaults.jar      = self.jar
   defaults.defaults = self.defaults

--- a/index.js
+++ b/index.js
@@ -112,13 +112,13 @@ request.defaults = function (options, requester) {
   }
 
   var defaults      = wrap(self)
-  defaults.get      = self.get
-  defaults.patch    = self.patch
-  defaults.post     = self.post
-  defaults.put      = self.put
-  defaults.head     = self.head
-  defaults.del      = self.del
-  defaults.cookie   = self.cookie
+  defaults.get      = wrap(self.get)
+  defaults.patch    = wrap(self.patch)
+  defaults.post     = wrap(self.post)
+  defaults.put      = wrap(self.put)
+  defaults.head     = wrap(self.head)
+  defaults.del      = wrap(self.del)
+  defaults.cookie   = wrap(self.cookie)
   defaults.jar      = self.jar
   defaults.defaults = self.defaults
   return defaults

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -314,6 +314,30 @@ tape('test only function', function(t) {
   })
 })
 
+tape('invoke defaults', function(t) {
+  var d = request.defaults({
+    uri: s.url + '/get',
+    headers: { foo: 'bar' }
+  })
+  d({}, function (e, r, b) {
+    t.equal(e, null)
+    t.equal(b, 'TESTING!')
+    t.end()
+  })
+})
+
+tape('invoke convenience method from defaults', function(t) {
+  var d = request.defaults({
+    uri: s.url + '/get',
+    headers: { foo: 'bar' }
+  })
+  d.get({}, function (e, r, b) {
+    t.equal(e, null)
+    t.equal(b, 'TESTING!')
+    t.end()
+  })
+})
+
 tape('cleanup', function(t) {
   s.close(function() {
     t.end()


### PR DESCRIPTION
Fixes https://github.com/request/request/issues/1509

Introduced in https://github.com/request/request/pull/1429 https://github.com/request/request/pull/1430 follow up https://github.com/request/request/pull/1435

Related to this bug as well https://github.com/request/request/pull/1515

Calling a convenience method from default object wasn't using the defaults properties, because the method was not wrapped, and therefore the extend logic wasn't called at all.

Then I'm temporarily passing a string to the wrap function so that I can make the head-body check before calling the requester just to satisfy the https://github.com/request/request/blob/master/tests/test-defaults.js#L265 test.

I'm going to improve the entire defaults related logic in index.js after this PR got merged in, because it's extremely hard to follow and obviously too error prone.