### PR TITLE
Refactor defaults

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -17,10 +17,10 @@ function isFunction(value) {
 
 function paramsHaveRequestBody(params) {
   return (
-    params.options.body ||
-    params.options.requestBodyStream ||
-    (params.options.json && typeof params.options.json !== 'boolean') ||
-    params.options.multipart
+    params.body ||
+    params.requestBodyStream ||
+    (params.json && typeof params.json !== 'boolean') ||
+    params.multipart
   )
 }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,6 @@
 'use strict'
 
-var extend = require('util')._extend
-  , jsonSafeStringify = require('json-stringify-safe')
+var jsonSafeStringify = require('json-stringify-safe')
   , crypto = require('crypto')
 
 function deferMethod() {
@@ -12,38 +11,8 @@ function deferMethod() {
   return setImmediate
 }
 
-function constructObject(initialObject) {
-  initialObject = initialObject || {}
-
-  return {
-    extend: function (object) {
-      return constructObject(extend(initialObject, object))
-    },
-    done: function () {
-      return initialObject
-    }
-  }
-}
-
-function constructOptionsFrom(uri, options) {
-  var params = constructObject()
-  if (typeof options === 'object') {
-    params.extend(options).extend({uri: uri})
-  } else if (typeof uri === 'string') {
-    params.extend({uri: uri})
-  } else {
-    params.extend(uri)
-  }
-  return params.done()
-}
-
 function isFunction(value) {
   return typeof value === 'function'
-}
-
-function filterForCallback(values) {
-  var callbacks = values.filter(isFunction)
-  return callbacks[0]
 }
 
 function paramsHaveRequestBody(params) {
@@ -78,9 +47,6 @@ function toBase64 (str) {
 }
 
 exports.isFunction            = isFunction
-exports.constructObject       = constructObject
-exports.constructOptionsFrom  = constructOptionsFrom
-exports.filterForCallback     = filterForCallback
 exports.paramsHaveRequestBody = paramsHaveRequestBody
 exports.safeStringify         = safeStringify
 exports.md5                   = md5

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -255,9 +255,8 @@ tape('test custom request handler function', function(t) {
     body: 'TESTING!'
   }, function(uri, options, callback) {
     var params = request.initParams(uri, options, callback)
-    options = params.options
-    options.headers.x = 'y'
-    return request(params.uri, params.options, params.callback)
+    params.headers.x = 'y'
+    return request(params.uri, params, params.callback)
   })
 
   t.throws(function() {
@@ -276,11 +275,11 @@ tape('test custom request handler function without options', function(t) {
 
   var customHandlerWithoutOptions = request.defaults(function(uri, options, callback) {
     var params = request.initParams(uri, options, callback)
-    var headers = params.options.headers || {}
+    var headers = params.headers || {}
     headers.x = 'y'
     headers.foo = 'bar'
-    params.options.headers = headers
-    return request(params.uri, params.options, params.callback)
+    params.headers = headers
+    return request(params.uri, params, params.callback)
   })
 
   customHandlerWithoutOptions.get(s.url + '/get_custom', function(e, r, b) {


### PR DESCRIPTION
This is a follow up to https://github.com/request/request/pull/1518

Much more simplified defaults and params initialization in index.js. Basically flattened the logic, also moved the `wrap` closure outside of the `defaults` method and I left it in index.js because I think it's very closely related to the `request` method, and the convenience http verb methods. Also completely dropped all of the object extend closures, as I don't think they add any substantial value to that piece of code.

/cc @nylen @FredKSchott @mikeal 