### PR TITLE
Add promise tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "rimraf": "~2.2.8",
     "server-destroy": "~1.0.0",
     "tape": "~3.0.0",
-    "taper": "~0.4.0"
+    "taper": "~0.4.0",
+    "bluebird": "~2.9.21"
   }
 }

--- a/tests/test-promise.js
+++ b/tests/test-promise.js
@@ -1,0 +1,52 @@
+'use strict'
+
+var http = require('http')
+  , request = require('../index')
+  , tape = require('tape')
+  , Promise = require('bluebird')
+
+var s = http.createServer(function(req, res) {
+  res.writeHead(200, {})
+  res.end('ok')
+})
+
+tape('setup', function(t) {
+  s.listen(6767, function() {
+    t.end()
+  })
+})
+
+tape('promisify convenience method', function(t) {
+  var get = request.get
+  var p = Promise.promisify(get)
+  p('http://localhost:6767')
+    .then(function (results) {
+      var res = results[0]
+      t.equal(res.statusCode, 200)
+      t.end()
+    })
+})
+
+tape('promisify request function', function(t) {
+  var p = Promise.promisify(request)
+  p('http://localhost:6767')
+    .spread(function (res, body) {
+      t.equal(res.statusCode, 200)
+      t.end()
+    })
+})
+
+tape('promisify all methods', function(t) {
+  Promise.promisifyAll(request)
+  request.getAsync('http://localhost:6767')
+    .spread(function (res, body) {
+      t.equal(res.statusCode, 200)
+      t.end()
+    })
+})
+
+tape('cleanup', function(t) {
+  s.close(function() {
+    t.end()
+  })
+})


### PR DESCRIPTION
A few promise tests using [bluebird](https://github.com/petkaantonov/bluebird) as it seems to be the most popular promise solution atm, plus it's used by [request-promise](https://github.com/tyabonil/request-promise) internally.

This is in attempt to make the promise support first class citizen in request, as it turns out that a lot of people are using promises with request. Also these tests should cover the bugs found in https://github.com/request/request/issues/1506 and https://github.com/request/request/issues/1509

@kytwb @noseglid @ericlu88 @carsy @neverfox let me know if there is anything else that can be added as test cases here.