### PR TITLE
More eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,9 @@
     // eslint can't handle this, so the check is disabled.
     "key-spacing": 0,
     // Allow shadowing vars in outer scope (needs discussion)
-    "no-shadow": 0
+    "no-shadow": 0,
+    // Use if () { }
+    //       ^ space
+    "space-after-keywords": [2, "always"]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,9 @@
     "no-shadow": 0,
     // Use if () { }
     //       ^ space
-    "space-after-keywords": [2, "always"]
+    "space-after-keywords": [2, "always"],
+    // Use if () { }
+    //          ^ space
+    "space-before-blocks": [2, "always"]
   }
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,7 +4,7 @@ var jsonSafeStringify = require('json-stringify-safe')
   , crypto = require('crypto')
 
 function deferMethod() {
-  if(typeof setImmediate === 'undefined') {
+  if (typeof setImmediate === 'undefined') {
     return process.nextTick
   }
 

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -31,7 +31,7 @@ Multipart.prototype.isChunked = function (options) {
 
   if (!chunked) {
     parts.forEach(function (part) {
-      if(typeof part.body === 'undefined') {
+      if (typeof part.body === 'undefined') {
         throw new Error('Body attribute missing in multipart.')
       }
       if (isstream(part.body)) {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "browserify": "~5.9.1",
     "browserify-istanbul": "~0.1.3",
     "coveralls": "~2.11.2",
-    "eslint": "0.17.1",
+    "eslint": "0.18.0",
     "function-bind": "~1.0.0",
     "istanbul": "~0.3.2",
     "karma": "~0.12.21",

--- a/request.js
+++ b/request.js
@@ -579,12 +579,12 @@ Request.prototype.init = function (options) {
   }
 
   if (self.uri.auth && !self.hasHeader('authorization')) {
-    var uriAuthPieces = self.uri.auth.split(':').map(function(item){ return querystring.unescape(item) })
+    var uriAuthPieces = self.uri.auth.split(':').map(function(item) { return querystring.unescape(item) })
     self.auth(uriAuthPieces[0], uriAuthPieces.slice(1).join(':'), true)
   }
 
   if (!self.tunnel && self.proxy && self.proxy.auth && !self.hasHeader('proxy-authorization')) {
-    var proxyAuthPieces = self.proxy.auth.split(':').map(function(item){
+    var proxyAuthPieces = self.proxy.auth.split(':').map(function(item) {
       return querystring.unescape(item)
     })
     var authHeader = 'Basic ' + toBase64(proxyAuthPieces.join(':'))
@@ -1299,7 +1299,7 @@ Request.prototype.qs = function (q, clobber) {
     base[i] = q[i]
   }
 
-  if (self.qsLib.stringify(base, self.qsStringifyOptions) === ''){
+  if (self.qsLib.stringify(base, self.qsStringifyOptions) === '') {
     return self
   }
 

--- a/request.js
+++ b/request.js
@@ -415,7 +415,7 @@ Request.prototype.init = function (options) {
   }
 
   // If a string URI/URL was given, parse it into a URL object
-  if(typeof self.uri === 'string') {
+  if (typeof self.uri === 'string') {
     self.uri = url.parse(self.uri)
   }
 
@@ -425,7 +425,7 @@ Request.prototype.init = function (options) {
   }
 
   // Support Unix Sockets
-  if(self.uri.host === 'unix') {
+  if (self.uri.host === 'unix') {
     // Get the socket & request paths from the URL
     var unixParts = self.uri.path.split(':')
       , host = unixParts[0]
@@ -443,7 +443,7 @@ Request.prototype.init = function (options) {
     self.rejectUnauthorized = false
   }
 
-  if(!self.hasOwnProperty('proxy')) {
+  if (!self.hasOwnProperty('proxy')) {
     self.proxy = getProxyFromURI(self.uri)
   }
 
@@ -1213,14 +1213,14 @@ Request.prototype.onRequestResponse = function (response) {
           } catch (e) {}
         }
         debug('emitting complete', self.uri.href)
-        if(typeof response.body === 'undefined' && !self._json) {
+        if (typeof response.body === 'undefined' && !self._json) {
           response.body = self.encoding === null ? new Buffer(0) : ''
         }
         self.emit('complete', response, response.body)
       })
     }
     //if no callback
-    else{
+    else {
       self.on('end', function () {
         if (self._aborted) {
           debug('aborted', self.uri.href)

--- a/request.js
+++ b/request.js
@@ -1210,7 +1210,9 @@ Request.prototype.onRequestResponse = function (response) {
         if (self._json) {
           try {
             response.body = JSON.parse(response.body, self._jsonReviver)
-          } catch (e) {}
+          } catch (e) {
+            // empty
+          }
         }
         debug('emitting complete', self.uri.href)
         if (typeof response.body === 'undefined' && !self._json) {

--- a/tests/test-baseUrl.js
+++ b/tests/test-baseUrl.js
@@ -6,7 +6,7 @@ var http = require('http')
   , url = require('url')
 
 var s = http.createServer(function(req, res) {
-  if(req.url === '/redirect/') {
+  if (req.url === '/redirect/') {
     res.writeHead(302, {
       location : '/'
     })


### PR DESCRIPTION
I updated eslint to 0.18.0 and added a couple rules for style consistency.

```
    // Use if () { }
    //       ^ space
    "space-after-keywords": [2, "always"],
```

There were only a few instances of `if()` and `else{` in the code, so this was clear.

```
    // Use if () { }
    //          ^ space
    "space-before-blocks": [2, "always"],
```

There were only a few instances of `if (){` in the code, so this was also clear.

```
    // Use function test() { }
    //                 ^^ no space
    "space-before-function-paren": [2, "never"]
```

This one was harder.  There were tons of `function ()`s and `function name ()`s in the code, including `function Request ()`.  But there were way more `function()`s and `function name()`s.  Introducing with `"always"` created 739 errors, vs `"never"` creating 245.

One additional change (1ffc50d53511eb1b81d64da816adad3aa687e6b0): eslint complained about an empty block statement, so I added the comment `// empty` to explicitly mark it as empty.