### PR TITLE
ensure the latest version of har-validator is included

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stringstream": "~0.0.4",
     "combined-stream": "~0.0.5",
     "isstream": "~0.1.1",
-    "har-validator": "^1.4.0"
+    "har-validator": "^1.6.1"
   },
   "scripts": {
     "test": "npm run lint && node node_modules/.bin/taper tests/test-*.js && npm run test-browser",


### PR DESCRIPTION
seems like some folks have had issues when using request from source with `har-validator` dependency (see: https://github.com/ahmadnassri/har-validator/issues/6) `v1.6.1` of `har-validator` addresses these problems.