### PR TITLE
initial support for oauth_body_hash on json payloads

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -4,6 +4,7 @@ var qs = require('qs')
   , caseless = require('caseless')
   , uuid = require('node-uuid')
   , oauth = require('oauth-sign')
+  , crypto = require('crypto')
 
 
 function OAuth (request) {
@@ -57,6 +58,21 @@ OAuth.prototype.buildParams = function (_oauth, uri, method, query, form, qsLib)
   return oa
 }
 
+OAuth.prototype.buildBodyHash = function(_oauth, body) {
+  var acceptedSignatureMethods = ['HMAC-SHA1', 'RSA-SHA1']
+  var index = acceptedSignatureMethods.indexOf(_oauth.signature_method)
+
+  if (!_oauth.signature_method || index > -1) {
+    var shasum = crypto.createHash('sha1')
+    shasum.update(body || '')
+    var sha1 = shasum.digest('hex')
+
+    return new Buffer(sha1).toString('base64')
+  } else {
+    throw new Error('oauth: ' + _oauth.signature_method + ' signature_method not supported with body_hash signing.')
+  }
+}
+
 OAuth.prototype.concatParams = function (oa, sep, wrap) {
   wrap = wrap || ''
 
@@ -100,6 +116,10 @@ OAuth.prototype.onRequest = function (_oauth) {
   if (transport === 'body' && (method !== 'POST' || contentType !== formContentType)) {
     throw new Error('oauth: transport_method of \'body\' requires \'POST\' ' +
       'and content-type \'' + formContentType + '\'')
+  }
+
+  if (!form && typeof _oauth.body_hash === 'boolean') {
+    _oauth.body_hash = this.buildBodyHash(_oauth, this.request.body.toString())
   }
 
   var oa = this.buildParams(_oauth, uri, method, query, form, qsLib)

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -59,18 +59,15 @@ OAuth.prototype.buildParams = function (_oauth, uri, method, query, form, qsLib)
 }
 
 OAuth.prototype.buildBodyHash = function(_oauth, body) {
-  var acceptedSignatureMethods = ['HMAC-SHA1', 'RSA-SHA1']
-  var index = acceptedSignatureMethods.indexOf(_oauth.signature_method)
-
-  if (!_oauth.signature_method || index > -1) {
-    var shasum = crypto.createHash('sha1')
-    shasum.update(body || '')
-    var sha1 = shasum.digest('hex')
-
-    return new Buffer(sha1).toString('base64')
-  } else {
+  if (['HMAC-SHA1', 'RSA-SHA1'].indexOf(_oauth.signature_method || 'HMAC-SHA1') < 0) {
     throw new Error('oauth: ' + _oauth.signature_method + ' signature_method not supported with body_hash signing.')
   }
+
+  var shasum = crypto.createHash('sha1')
+  shasum.update(body || '')
+  var sha1 = shasum.digest('hex')
+
+  return new Buffer(sha1).toString('base64')
 }
 
 OAuth.prototype.concatParams = function (oa, sep, wrap) {

--- a/request.js
+++ b/request.js
@@ -541,6 +541,7 @@ Request.prototype.init = function (options) {
     self.path = '/'
   }
 
+  // Auth must happen last in case signing is dependent on other headers
   if (options.aws) {
     self.aws(options.aws)
   }
@@ -625,7 +626,6 @@ Request.prototype.init = function (options) {
     }
   }
 
-  // Auth must happen last in case signing is dependent on other headers
   if (options.oauth) {
     self.oauth(options.oauth)
   }

--- a/request.js
+++ b/request.js
@@ -27,7 +27,6 @@ var http = require('http')
   , OAuth = require('./lib/oauth').OAuth
   , Multipart = require('./lib/multipart').Multipart
   , Redirect = require('./lib/redirect').Redirect
-  , crypto = require('crypto')
 
 var safeStringify = helpers.safeStringify
   , isReadStream = helpers.isReadStream
@@ -542,49 +541,6 @@ Request.prototype.init = function (options) {
     self.path = '/'
   }
 
-  // Add support for oauth_body_hash
-  // See https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html
-  // Only supports JSON payloads at the moment
-  // ====================
-
-  // Check for an explicit 'true' value, in case someone is already generating their own hash
-  if (options.oauth && typeof options.oauth.body_hash === 'boolean') {
-    // 4.1.1b: OAuth Consumers MUST NOT include an oauth_body_hash parameter on requests with form-encoded request bodies.
-    // --------------------
-    if (self.getHeader('content-type') === 'application/x-www-form-urlencoded') {
-      throw new Error('oauth_body_hash is not supported with form-encoded request bodies.')
-    }
-    else {
-      // 3.1a: If the OAuth signature method is HMAC-SHA1 or RSA-SHA1, SHA1 [RFC3174] MUST be used as the body hash algorithm.
-      // --------------------
-      var acceptedSignatureMethods = ['HMAC-SHA1', 'RSA-SHA1']
-      var index = acceptedSignatureMethods.indexOf(options.oauth.signature_method)
-
-      if (!options.oauth.signature_method || index > -1) {
-        // 3.2a: The body hash value is calculated by executing the selected hash algorithm over the request body. The request body is the entity body as defined in [RFC2616] section 7.2. If the request does not have an entity body, the hash should be taken over the empty string.
-        // --------------------
-        var shasum = crypto.createHash('sha1')
-        shasum.update(options.json.toString() || '')
-        var sha1 = shasum.digest('hex')
-
-        // 3.2b: The calculated body hash value is encoded using Base64 per [RFC4648].
-        // --------------------
-        // oauth_body_hash_base64 = new Buffer(sha1).toString('base64');
-        options.oauth.body_hash = new Buffer(sha1).toString('base64')
-      }
-      else {
-        // 3.1b: If the OAuth signature method is PLAINTEXT, use of this specification provides no security benefit and is NOT RECOMMENDED.
-        // --------------------
-        throw new Error(options.oauth.signature_method + ' signature_method not supported with body_hash signing.')
-      }
-    }
-  }
-
-  // Auth must happen last in case signing is dependent on other headers
-  if (options.oauth) {
-    self.oauth(options.oauth)
-  }
-
   if (options.aws) {
     self.aws(options.aws)
   }
@@ -667,6 +623,11 @@ Request.prototype.init = function (options) {
     } else {
       throw new Error('Argument error, options.body.')
     }
+  }
+
+  // Auth must happen last in case signing is dependent on other headers
+  if (options.oauth) {
+    self.oauth(options.oauth)
   }
 
   var protocol = self.proxy && !self.tunnel ? self.proxy.protocol : self.uri.protocol

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -574,7 +574,7 @@ tape('body_hash automatic built', function(t) {
 })
 
 tape('body_hash PLAINTEXT signature_method', function(t) {
-  try {
+  t.throws(function() {
     request.post(
     { url: 'http://example.com'
     , oauth:
@@ -583,11 +583,10 @@ tape('body_hash PLAINTEXT signature_method', function(t) {
       , signature_method: 'PLAINTEXT'
       }
     , json: {foo: 'bar'}
-    })
-  } catch(e) {
-    process.nextTick(function() {
-      t.equal(typeof e, 'object')
+    }, function () {
+      t.fail('body_hash is not allowed with PLAINTEXT signature_method')
       t.end()
     })
-  }
+  }, /oauth: PLAINTEXT signature_method not supported with body_hash signing/)
+  t.end()
 })

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -527,3 +527,30 @@ tape('body transport_method with prexisting body params', function(t) {
     t.end()
   })
 })
+
+tape('body_hash integrity check', function(t) {
+  function getBodyHash(r) {
+    var body_hash
+    r.headers.Authorization.slice('OAuth '.length).replace(/,\ /g, ',').split(',').forEach(function(v) {
+      if (v.slice(0, 'oauth_body_hash="'.length) === 'oauth_body_hash="') {
+        body_hash = v.slice('oauth_body_hash="'.length, -1)
+      }
+    })
+    return body_hash
+  }
+
+  var body_hash = request.post(
+    { url: 'http://example.com'
+    , oauth:
+      { consumer_secret: 'consumer_secret'
+      , body_hash: true
+      }
+    , json: {foo: 'bar'}
+    })
+
+  process.nextTick(function() {
+    t.equal('YTVlNzQ0ZDAxNjQ1NDBkMzNiMWQ3ZWE2MTZjMjhmMmZhOTdlNzU0YQ%3D%3D', getBodyHash(body_hash))
+    body_hash.abort()
+    t.end()
+  })
+})

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -572,3 +572,22 @@ tape('body_hash automatic built', function(t) {
     t.end()
   })
 })
+
+tape('body_hash PLAINTEXT signature_method', function(t) {
+  try {
+    request.post(
+    { url: 'http://example.com'
+    , oauth:
+      { consumer_secret: 'consumer_secret'
+      , body_hash: true
+      , signature_method: 'PLAINTEXT'
+      }
+    , json: {foo: 'bar'}
+    })
+  } catch(e) {
+    process.nextTick(function() {
+      t.equal(typeof e, 'object')
+      t.end()
+    })
+  }
+})

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -529,17 +529,7 @@ tape('body transport_method with prexisting body params', function(t) {
 })
 
 tape('body_hash integrity check', function(t) {
-  function getBodyHash(r) {
-    var body_hash
-    r.headers.Authorization.slice('OAuth '.length).replace(/,\ /g, ',').split(',').forEach(function(v) {
-      if (v.slice(0, 'oauth_body_hash="'.length) === 'oauth_body_hash="') {
-        body_hash = v.slice('oauth_body_hash="'.length, -1)
-      }
-    })
-    return body_hash
-  }
-
-  var body_hash = request.post(
+  var r = request.post(
     { url: 'http://example.com'
     , oauth:
       { consumer_secret: 'consumer_secret'
@@ -549,8 +539,9 @@ tape('body_hash integrity check', function(t) {
     })
 
   process.nextTick(function() {
-    t.equal('YTVlNzQ0ZDAxNjQ1NDBkMzNiMWQ3ZWE2MTZjMjhmMmZhOTdlNzU0YQ%3D%3D', getBodyHash(body_hash))
-    body_hash.abort()
+    var body_hash = r.headers.Authorization.replace(/.*oauth_body_hash="([^"]+)".*/, '$1')
+    t.equal('YTVlNzQ0ZDAxNjQ1NDBkMzNiMWQ3ZWE2MTZjMjhmMmZhOTdlNzU0YQ%3D%3D', body_hash)
+    r.abort()
     t.end()
   })
 })


### PR DESCRIPTION
[Original thread](https://github.com/request/oauth-sign/issues/15) to add [oauth_body_hash signing](https://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html).

This isn't quite ready. Just looking for feedback to see if things look right so far.

Still needs tests and also support for body payloads other than json

cc: @simov 
