### PR TITLE
Emit error instead of throw

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -21,7 +21,7 @@ function Auth (request) {
 Auth.prototype.basic = function (user, pass, sendImmediately) {
   var self = this
   if (typeof user !== 'string' || (pass !== undefined && typeof pass !== 'string')) {
-    throw new Error('auth() received invalid user or password')
+    self.request.emit('error', new Error('auth() received invalid user or password'))
   }
   self.user = user
   self.pass = pass
@@ -115,7 +115,7 @@ Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
 
   var authHeader
   if (bearer === undefined && user === undefined) {
-    throw new Error('no auth mechanism defined')
+    self.request.emit('error', new Error('no auth mechanism defined'))
   } else if (bearer !== undefined) {
     authHeader = self.bearer(bearer, sendImmediately)
   } else {

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -18,7 +18,7 @@ Multipart.prototype.isChunked = function (options) {
     , parts = options.data || options
 
   if (!parts.forEach) {
-    throw new Error('Argument error, options.multipart.')
+    self.request.emit('error', new Error('Argument error, options.multipart.'))
   }
 
   if (options.chunked !== undefined) {
@@ -32,7 +32,7 @@ Multipart.prototype.isChunked = function (options) {
   if (!chunked) {
     parts.forEach(function (part) {
       if (typeof part.body === 'undefined') {
-        throw new Error('Body attribute missing in multipart.')
+        self.request.emit('error', new Error('Body attribute missing in multipart.'))
       }
       if (isstream(part.body)) {
         chunked = true

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -60,7 +60,8 @@ OAuth.prototype.buildParams = function (_oauth, uri, method, query, form, qsLib)
 
 OAuth.prototype.buildBodyHash = function(_oauth, body) {
   if (['HMAC-SHA1', 'RSA-SHA1'].indexOf(_oauth.signature_method || 'HMAC-SHA1') < 0) {
-    throw new Error('oauth: ' + _oauth.signature_method + ' signature_method not supported with body_hash signing.')
+    this.request.emit('error', new Error('oauth: ' + _oauth.signature_method +
+      ' signature_method not supported with body_hash signing.'))
   }
 
   var shasum = crypto.createHash('sha1')
@@ -89,13 +90,12 @@ OAuth.prototype.concatParams = function (oa, sep, wrap) {
 
 OAuth.prototype.onRequest = function (_oauth) {
   var self = this
-    , request = self.request
 
-  var uri = request.uri || {}
-    , method = request.method || ''
-    , headers = caseless(request.headers)
-    , body = request.body || ''
-    , qsLib = request.qsLib || qs
+  var uri = self.request.uri || {}
+    , method = self.request.method || ''
+    , headers = caseless(self.request.headers)
+    , body = self.request.body || ''
+    , qsLib = self.request.qsLib || qs
 
   var form
     , query
@@ -111,31 +111,31 @@ OAuth.prototype.onRequest = function (_oauth) {
     query = uri.query
   }
   if (transport === 'body' && (method !== 'POST' || contentType !== formContentType)) {
-    throw new Error('oauth: transport_method of \'body\' requires \'POST\' ' +
-      'and content-type \'' + formContentType + '\'')
+    self.request.emit('error', new Error('oauth: transport_method of body requires POST ' +
+      'and content-type ' + formContentType))
   }
 
   if (!form && typeof _oauth.body_hash === 'boolean') {
-    _oauth.body_hash = this.buildBodyHash(_oauth, this.request.body.toString())
+    _oauth.body_hash = self.buildBodyHash(_oauth, self.request.body.toString())
   }
 
-  var oa = this.buildParams(_oauth, uri, method, query, form, qsLib)
+  var oa = self.buildParams(_oauth, uri, method, query, form, qsLib)
 
   switch (transport) {
     case 'header':
-      request.setHeader('Authorization', 'OAuth ' + this.concatParams(oa, ',', '"'))
+      self.request.setHeader('Authorization', 'OAuth ' + self.concatParams(oa, ',', '"'))
       break
 
     case 'query':
-      request.path = (query ? '&' : '?') + this.concatParams(oa, '&')
+      self.request.path = (query ? '&' : '?') + self.concatParams(oa, '&')
       break
 
     case 'body':
-      request.body = (form ? form + '&' : '') + this.concatParams(oa, '&')
+      self.request.body = (form ? form + '&' : '') + self.concatParams(oa, '&')
       break
 
     default:
-      throw new Error('oauth: transport_method invalid')
+      self.request.emit('error', new Error('oauth: transport_method invalid'))
   }
 }
 

--- a/request.js
+++ b/request.js
@@ -409,7 +409,7 @@ Request.prototype.init = function (options) {
     delete self.baseUrl
   }
 
-  // A URI is needed by this point, throw if we haven't been able to get one
+  // A URI is needed by this point, emit error if we haven't been able to get one
   if (!self.uri) {
     return self.emit('error', new Error('options.uri is a required argument'))
   }
@@ -622,7 +622,7 @@ Request.prototype.init = function (options) {
         self.setHeader('content-length', length)
       }
     } else {
-      throw new Error('Argument error, options.body.')
+      self.emit('error', new Error('Argument error, options.body.'))
     }
   }
 
@@ -666,7 +666,7 @@ Request.prototype.init = function (options) {
 
   self.on('pipe', function (src) {
     if (self.ntick && self._started) {
-      throw new Error('You cannot pipe to this stream after the outbound request has started.')
+      self.emit('error', new Error('You cannot pipe to this stream after the outbound request has started.'))
     }
     self.src = src
     if (isReadStream(src)) {
@@ -1503,9 +1503,9 @@ Request.prototype.pipe = function (dest, opts) {
 
   if (self.response) {
     if (self._destdata) {
-      throw new Error('You cannot pipe after data has been emitted from the response.')
+      self.emit('error', new Error('You cannot pipe after data has been emitted from the response.'))
     } else if (self._ended) {
-      throw new Error('You cannot pipe after the response has been ended.')
+      self.emit('error', new Error('You cannot pipe after the response has been ended.'))
     } else {
       stream.Stream.prototype.pipe.call(self, dest, opts)
       self.pipeDest(dest)

--- a/tests/test-bearer-auth.js
+++ b/tests/test-bearer-auth.js
@@ -148,19 +148,16 @@ tape('bearer is a function, path = test2', function(t) {
 })
 
 tape('no auth method', function(t) {
-  t.throws(function() {
-    request({
-      'method': 'GET',
-      'uri': 'http://localhost:6767/test2/',
-      'auth': {
-        'bearer': undefined
-      }
-    }, function(error, res, body) {
-      t.fail('Requests without a valid auth mechanism are not valid')
-      t.end()
-    })
-  }, /no auth mechanism defined/)
-  t.end()
+  request({
+    'method': 'GET',
+    'uri': 'http://localhost:6767/test2/',
+    'auth': {
+      'bearer': undefined
+    }
+  }, function(error, res, body) {
+    t.equal(error.message, 'no auth mechanism defined')
+    t.end()
+  })
 })
 
 tape('null bearer', function(t) {
@@ -172,7 +169,7 @@ tape('null bearer', function(t) {
     }
   }, function(error, res, body) {
     t.equal(res.statusCode, 401)
-    t.equal(numBearerRequests, 12)
+    t.equal(numBearerRequests, 13)
     t.end()
   })
 })

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -353,7 +353,7 @@ tape('invalid method while using transport_method \'body\'', function(t) {
         { transport_method: 'body'
         }
       })
-    }, /requires 'POST'/)
+    }, /requires POST/)
   t.end()
 })
 
@@ -367,7 +367,7 @@ tape('invalid content-type while using transport_method \'body\'', function(t) {
         { transport_method: 'body'
         }
       })
-    }, /requires 'POST'/)
+    }, /requires POST/)
   t.end()
 })
 
@@ -583,9 +583,6 @@ tape('body_hash PLAINTEXT signature_method', function(t) {
       , signature_method: 'PLAINTEXT'
       }
     , json: {foo: 'bar'}
-    }, function () {
-      t.fail('body_hash is not allowed with PLAINTEXT signature_method')
-      t.end()
     })
   }, /oauth: PLAINTEXT signature_method not supported with body_hash signing/)
   t.end()


### PR DESCRIPTION
Related to this https://github.com/request/request/issues/1318#issuecomment-97374120 onward 

### Breaking change

Any code that previously relied on catching the errors in the `catch` block will now receive them in the `callback` as errors if a `callback` is specified

```js
request({uri:'...'}, function (err, res, body) {
  if (err) {
    // all errors are received here
  }
}).on('error', function (err) {
  // that's being called before being registered
})
```

### No callback during initialization

This repository still have two error cases that throws in index.js But if the callback is missing, any error will be thrown anyway

```js
try {
  request({uri:'...'}).on('error', function (err) {
    // that's being called before being registered
  })
} catch (err) {
  // EventEmitter throws the error if the event is unhandled
}
```

### After successful initialization

```js
request({uri:'...'}, function (err, res, body) {
  if (err) {
    // all errors are received here
  }
}).on('error', function (err) {
  // after successful initialization this is being registered
})
```

---

One possible way to receive the errors during initialization in the `on('error')` event handler, is to use this hack

```js
setTimeout(self.emit.bind(self, 'error', new Error('...')), 0)
// instead of
self.emit('error', new Error('...'))
```
But it's unreliable and I'm not going to use it.

// cc @mikeal @nylen @FredKSchott @saper