### PR TITLE
Update combined-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "hawk": "~2.3.0",
     "aws-sign2": "~0.5.0",
     "stringstream": "~0.0.4",
-    "combined-stream": "~0.0.5",
+    "combined-stream": "~1.0.1",
     "isstream": "~0.1.1",
     "har-validator": "^1.6.1"
   },


### PR DESCRIPTION
This updated combined-stream now uses an updated delayed-stream which no longer
uses the non-standard `__defineGetter__` syntax. By removing this, request can
now be loaded in IE10+ (which doesn't support `__defineGetter__`).