### PR TITLE
Fix pause before response arrives

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -87,7 +87,8 @@ Redirect.prototype.onResponse = function (response) {
 
   // ignore any potential response body.  it cannot possibly be useful
   // to us at this point.
-  if (request._paused) {
+  // response.resume should be defined, but check anyway before calling. Workaround for browserify.
+  if (response.resume) {
     response.resume()
   }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "browserify": "~5.9.1",
     "browserify-istanbul": "~0.1.3",
+    "buffer-equal": "0.0.1",
     "coveralls": "~2.11.2",
     "eslint": "0.18.0",
     "function-bind": "~1.0.0",

--- a/request.js
+++ b/request.js
@@ -1047,12 +1047,6 @@ Request.prototype.onRequestResponse = function (response) {
     response.resume()
     return
   }
-  if (self._paused) {
-    response.pause()
-  } else if (response.resume) {
-    // response.resume should be defined, but check anyway before calling. Workaround for browserify.
-    response.resume()
-  }
 
   self.response = response
   response.request = self
@@ -1151,6 +1145,10 @@ Request.prototype.onRequestResponse = function (response) {
         // If/When support for 0.9.4 is dropped, this should be unnecessary.
         responseContent = responseContent.pipe(stringstream(self.encoding))
       }
+    }
+
+    if (self._paused) {
+      responseContent.pause()
     }
 
     self.responseContent = responseContent


### PR DESCRIPTION
This PR fixes a bit of fallout due to overlooking the pause behavior before the response arrives in #1568 last night.  I added some additional tests which should help catch similar issues in the future.  

If anyone has ideas for how to avoid the arbitrary `setTimeout`s when testing `pause`/`resume`, that would be great (currently it waits a bit between sending chunks to allow pausing and waits a bit more after calling `pause` to confirm no more data arrives).  Also, if there is a better location for the tests, I'm open to moving them around too.

Due to #1568, we now propagate pause and resume to the response content stream, rather than the response stream.  However, when pause is called before the response arrives, the pause is still being applied to the response object directly.  Fix this by applying it to the response content stream in both cases.  This avoids the issue that if pause is called on a gzip request before the response arrives, it pauses the response then resumes the response content, meaning the response can not be resumed.

Also add tests of the pause/resume behavior for both the gzip and non-gzip case both before and after the response has arrived.

This commit also makes the ancillary change that resume is now called unconditionally (when defined) in `Redirect`, since we always want to dump the response data (and it was previously called unconditionally in `onRequestResponse`).