### PR TITLE
Discovered tests that weren't properly running

### DIFF
--- a/tests/server.js
+++ b/tests/server.js
@@ -94,7 +94,7 @@ exports.createPostValidator = function (text, reqContentType) {
         assert.ok(~req.headers['content-type'].indexOf(reqContentType))
       }
       resp.writeHead(200, {'content-type':'text/plain'})
-      resp.write('OK')
+      resp.write(r)
       resp.end()
     })
   }

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -20,6 +20,11 @@ function addTest(name, data) {
       t.equal(err, null)
       if (data.expectBody && Buffer.isBuffer(data.expectBody)) {
         t.deepEqual(data.expectBody.toString(), body.toString())
+      } else if (data.expectBody) {
+        t.deepEqual(data.expectBody, body)
+      } else {
+        // not sure what to test when we dont have expectBody
+        console.log('untested code')
       }
       t.end()
     })

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -22,9 +22,6 @@ function addTest(name, data) {
         t.deepEqual(data.expectBody.toString(), body.toString())
       } else if (data.expectBody) {
         t.deepEqual(data.expectBody, body)
-      } else {
-        // not sure what to test when we dont have expectBody
-        console.log('untested code')
       }
       t.end()
     })

--- a/tests/test-pipes.js
+++ b/tests/test-pipes.js
@@ -80,7 +80,7 @@ tape('piping to a request object', function(t) {
   }, function(err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
-    t.equal(body, 'OK')
+    t.equal(body, 'mydata')
     t.end()
   })
   mydata.pipe(r1)
@@ -90,8 +90,9 @@ tape('piping to a request object', function(t) {
 })
 
 tape('piping to a request object with a json body', function(t) {
-  s.once('/push-json', server.createPostValidator('{"foo":"bar"}', 'application/json'))
-
+  var obj = {foo: 'bar'}
+  var json = JSON.stringify(obj)
+  s.once('/push-json', server.createPostValidator(json, 'application/json'))
   var mybodydata = new stream.Stream()
   mybodydata.readable = true
 
@@ -101,7 +102,7 @@ tape('piping to a request object with a json body', function(t) {
   }, function(err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
-    t.equal(body, 'OK')
+    t.deepEqual(body, obj)
     t.end()
   })
   mybodydata.pipe(r2)


### PR DESCRIPTION
I came across some tests in the test-body.js that didn't seem to be actually asserting anything.
It seems that assertions are only being done if there is an expectBody property and if the value of the expectBody property is a Buffer, otherwise it won't run an assertion and just pass. To make matters even more complicated some of the tests don't give an expectBody property, so I'm not completely sure how to fix those tests. Just wanted to bring this to our attention.