### PR TITLE
Refresh the oauth_nonce on redirect (#1573)

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -9,6 +9,7 @@ var qs = require('qs')
 
 function OAuth (request) {
   this.request = request
+  this.params = null
 }
 
 OAuth.prototype.buildParams = function (_oauth, uri, method, query, form, qsLib) {
@@ -90,6 +91,7 @@ OAuth.prototype.concatParams = function (oa, sep, wrap) {
 
 OAuth.prototype.onRequest = function (_oauth) {
   var self = this
+  self.params = _oauth
 
   var uri = self.request.uri || {}
     , method = self.request.method || ''

--- a/request.js
+++ b/request.js
@@ -628,6 +628,8 @@ Request.prototype.init = function (options) {
 
   if (options.oauth) {
     self.oauth(options.oauth)
+  } else if (self._oauth.params) {
+    self.oauth(self._oauth.params)
   }
 
   var protocol = self.proxy && !self.tunnel ? self.proxy.protocol : self.uri.protocol

--- a/request.js
+++ b/request.js
@@ -628,7 +628,7 @@ Request.prototype.init = function (options) {
 
   if (options.oauth) {
     self.oauth(options.oauth)
-  } else if (self._oauth.params) {
+  } else if (self._oauth.params && self.hasHeader('authorization')) {
     self.oauth(self._oauth.params)
   }
 

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -620,3 +620,35 @@ tape('refresh oauth_nonce on redirect', function(t) {
       })
   })
 })
+
+tape('no credentials on external redirect', function(t) {
+  var s1 = http.createServer(function (req, res) {
+    res.writeHead(302, {location:'http://127.0.0.1:6768'})
+    res.end()
+  })
+  var s2 = http.createServer(function (req, res) {
+    res.writeHead(200, {'content-type':'text/plain'})
+    res.end()
+  })
+  s1.listen(6767, function () {
+    s2.listen(6768, function () {
+      request.get(
+        { url: 'http://localhost:6767'
+        , oauth:
+          { consumer_key: 'consumer_key'
+          , consumer_secret: 'consumer_secret'
+          , token: 'token'
+          , token_secret: 'token_secret'
+          }
+        }, function (err, res, body) {
+          t.equal(err, null)
+          t.equal(res.request.headers.Authorization, undefined)
+          s1.close(function () {
+            s2.close(function () {
+              t.end()
+            })
+          })
+        })
+    })
+  })
+})

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -7,6 +7,7 @@ var oauth = require('oauth-sign')
   , request = require('../index')
   , tape = require('tape')
   , crypto = require('crypto')
+  , http = require('http')
 
 function getSignature(r) {
   var sign
@@ -586,4 +587,36 @@ tape('body_hash PLAINTEXT signature_method', function(t) {
     })
   }, /oauth: PLAINTEXT signature_method not supported with body_hash signing/)
   t.end()
+})
+
+tape('refresh oauth_nonce on redirect', function(t) {
+  var oauth_nonce1, oauth_nonce2
+  var s = http.createServer(function (req, res) {
+    if (req.url === '/redirect') {
+      oauth_nonce1 = req.headers.authorization.replace(/.*oauth_nonce="([^"]+)".*/, '$1')
+      res.writeHead(302, {location:'http://localhost:6767/response'})
+      res.end()
+    } else if (req.url === '/response') {
+      oauth_nonce2 = req.headers.authorization.replace(/.*oauth_nonce="([^"]+)".*/, '$1')
+      res.writeHead(200, {'content-type':'text/plain'})
+      res.end()
+    }
+  })
+  s.listen(6767, function () {
+    request.get(
+      { url: 'http://localhost:6767/redirect'
+      , oauth:
+        { consumer_key: 'consumer_key'
+        , consumer_secret: 'consumer_secret'
+        , token: 'token'
+        , token_secret: 'token_secret'
+        }
+      }, function (err, res, body) {
+        t.equal(err, null)
+        t.notEqual(oauth_nonce1, oauth_nonce2)
+        s.close(function () {
+          t.end()
+        })
+      })
+  })
 })


### PR DESCRIPTION
- Cache the initial oauth options passed to request in _oauth.params
- On subsequent calls to init() use the cached _oauth.params
  to invoke the oauth params generation logic again

Fixes #1573