### PR TITLE
Refactor test-default tests (according to comments in #1430)

### DIFF
--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var server = require('./server')
-  , assert = require('assert')
   , request = require('../index')
   , tape = require('tape')
 
@@ -9,113 +8,27 @@ var s = server.createServer()
 
 tape('setup', function(t) {
   s.listen(s.port, function() {
-    s.on('/get', function(req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.method, 'GET')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end('TESTING!')
+    s.on('/', function (req, res) {
+      res.writeHead(200, {'content-type': 'application/json'})
+      res.end(JSON.stringify({method: req.method, headers: req.headers}))
     })
 
-    s.on('/merge-headers', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.headers.merged, 'yes')
-      resp.writeHead(200)
-      resp.end()
+    s.on('/head', function (req, res) {
+      res.writeHead(200, {'x-data':
+        JSON.stringify({method: req.method, headers: req.headers})})
+      res.end()
     })
 
-    s.on('/foo-no-test', function(req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal('test' in req.headers, false)
-      assert.equal(req.method, 'GET')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end('TESTING!')
-    })
-
-    s.on('/post', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.headers['content-type'], null)
-      assert.equal(req.method, 'POST')
-      resp.writeHead(200, {'Content-Type': 'application/json'})
-      resp.end(JSON.stringify({foo:'bar'}))
-    })
-
-    s.on('/patch', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.headers['content-type'], null)
-      assert.equal(req.method, 'PATCH')
-      resp.writeHead(200, {'Content-Type': 'application/json'})
-      resp.end(JSON.stringify({foo:'bar'}))
-    })
-
-    s.on('/post-body', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.headers['content-type'], 'application/json')
-      assert.equal(req.method, 'POST')
-      resp.writeHead(200, {'Content-Type': 'application/json'})
-      resp.end(JSON.stringify({foo:'bar'}))
-    })
-
-    s.on('/del', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.method, 'DELETE')
-      resp.writeHead(200, {'Content-Type': 'application/json'})
-      resp.end(JSON.stringify({foo:'bar'}))
-    })
-
-    s.on('/head', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.method, 'HEAD')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end()
-    })
-
-    s.on('/get_recursive1', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar1')
-      assert.equal(req.method, 'GET')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end('TESTING!')
-    })
-
-    s.on('/get_recursive2', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar1')
-      assert.equal(req.headers.baz, 'bar2')
-      assert.equal(req.method, 'GET')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end('TESTING!')
-    })
-
-    s.on('/get_recursive3', function (req, resp) {
-      assert.equal(req.headers.foo, 'bar3')
-      assert.equal(req.headers.baz, 'bar2')
-      assert.equal(req.method, 'GET')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end('TESTING!')
-    })
-
-    s.on('/get_custom', function(req, resp) {
-      assert.equal(req.headers.foo, 'bar')
-      assert.equal(req.headers.x, 'y')
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end()
-    })
-
-    s.on('/set-undefined', function (req, resp) {
-      assert.equal(req.method, 'POST')
-      assert.equal(req.headers['content-type'], 'application/json')
-      assert.equal(req.headers['x-foo'], 'baz')
+    s.on('/set-undefined', function (req, res) {
       var data = ''
       req.on('data', function(d) {
         data += d
       })
       req.on('end', function() {
-        resp.writeHead(200, {'Content-Type': 'application/json'})
-        resp.end(data)
+        res.writeHead(200, {'Content-Type': 'application/json'})
+        res.end(JSON.stringify({
+          method: req.method, headers: req.headers, data: JSON.parse(data)}))
       })
-    })
-
-    s.on('/function', function(req, resp) {
-      resp.writeHead(200, {'Content-Type': 'text/plain'})
-      resp.end()
     })
 
     t.end()
@@ -125,9 +38,10 @@ tape('setup', function(t) {
 tape('get(string, function)', function(t) {
   request.defaults({
     headers: { foo: 'bar' }
-  })(s.url + '/get', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  })(s.url + '/', function (e, r, b) {
+    b = JSON.parse(b)
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar')
     t.end()
   })
 })
@@ -135,21 +49,22 @@ tape('get(string, function)', function(t) {
 tape('merge headers', function(t) {
   request.defaults({
     headers: { foo: 'bar', merged: 'no' }
-  })(s.url + '/merge-headers', {
-    headers: { merged: 'yes' }
+  })(s.url + '/', {
+    headers: { merged: 'yes' }, json: true
   }, function (e, r, b) {
-    t.equal(e, null)
-    t.equal(r.statusCode, 200)
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers.merged, 'yes')
     t.end()
   })
 })
 
 tape('default undefined header', function(t) {
   request.defaults({
-    headers: { foo: 'bar', test: undefined }
-  })(s.url + '/foo-no-test', function(e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+    headers: { foo: 'bar', test: undefined }, json: true
+  })(s.url + '/', function(e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers.test, undefined)
     t.end()
   })
 })
@@ -157,9 +72,10 @@ tape('default undefined header', function(t) {
 tape('post(string, object, function)', function(t) {
   request.defaults({
     headers: { foo: 'bar' }
-  }).post(s.url + '/post', { json: true }, function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b.foo, 'bar')
+  }).post(s.url + '/', { json: true }, function (e, r, b) {
+    t.equal(b.method, 'POST')
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers['content-type'], undefined)
     t.end()
   })
 })
@@ -167,9 +83,10 @@ tape('post(string, object, function)', function(t) {
 tape('patch(string, object, function)', function(t) {
   request.defaults({
     headers: { foo: 'bar' }
-  }).patch(s.url + '/patch', { json: true }, function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b.foo, 'bar')
+  }).patch(s.url + '/', { json: true }, function (e, r, b) {
+    t.equal(b.method, 'PATCH')
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers['content-type'], undefined)
     t.end()
   })
 })
@@ -177,12 +94,13 @@ tape('patch(string, object, function)', function(t) {
 tape('post(string, object, function) with body', function(t) {
   request.defaults({
     headers: { foo: 'bar' }
-  }).post(s.url + '/post-body', {
+  }).post(s.url + '/', {
     json: true,
     body: { bar: 'baz' }
   }, function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b.foo, 'bar')
+    t.equal(b.method, 'POST')
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers['content-type'], 'application/json')
     t.end()
   })
 })
@@ -191,9 +109,9 @@ tape('del(string, function)', function(t) {
   request.defaults({
     headers: {foo: 'bar'},
     json: true
-  }).del(s.url + '/del', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b.foo, 'bar')
+  }).del(s.url + '/', function (e, r, b) {
+    t.equal(b.method, 'DELETE')
+    t.equal(b.headers.foo, 'bar')
     t.end()
   })
 })
@@ -202,13 +120,15 @@ tape('head(object, function)', function(t) {
   request.defaults({
     headers: { foo: 'bar' }
   }).head({ uri: s.url + '/head' }, function (e, r, b) {
-    t.equal(e, null)
+    b = JSON.parse(r.headers['x-data'])
+    t.equal(b.method, 'HEAD')
+    t.equal(b.headers.foo, 'bar')
     t.end()
   })
 })
 
 tape('recursive defaults', function(t) {
-  t.plan(8)
+  t.plan(11)
 
   var defaultsOne = request.defaults({ headers: { foo: 'bar1' } })
     , defaultsTwo = defaultsOne.defaults({ headers: { baz: 'bar2' } })
@@ -219,30 +139,33 @@ tape('recursive defaults', function(t) {
       defaultsTwo(options, callback)
     })
 
-  defaultsOne(s.url + '/get_recursive1', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  defaultsOne(s.url + '/', {json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar1')
   })
 
-  defaultsTwo(s.url + '/get_recursive2', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  defaultsTwo(s.url + '/', {json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar1')
+    t.equal(b.headers.baz, 'bar2')
   })
 
   // requester function on recursive defaults
-  defaultsThree(s.url + '/get_recursive3', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  defaultsThree(s.url + '/', {json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar3')
+    t.equal(b.headers.baz, 'bar2')
   })
 
-  defaultsTwo.get(s.url + '/get_recursive2', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  defaultsTwo.get(s.url + '/', {json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar1')
+    t.equal(b.headers.baz, 'bar2')
   })
 })
 
 tape('recursive defaults requester', function(t) {
-  t.plan(4)
+  t.plan(5)
 
   var defaultsOne = request.defaults({}, function(options, callback) {
       var headers = options.headers || {}
@@ -259,19 +182,20 @@ tape('recursive defaults requester', function(t) {
       defaultsOne(options, callback)
     })
 
-  defaultsOne.get(s.url + '/get_recursive1', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  defaultsOne.get(s.url + '/', {json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar1')
   })
 
-  defaultsTwo.get(s.url + '/get_recursive2', function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  defaultsTwo.get(s.url + '/', {json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar1')
+    t.equal(b.headers.baz, 'bar2')
   })
 })
 
 tape('test custom request handler function', function(t) {
-  t.plan(2)
+  t.plan(3)
 
   var requestWithCustomHandler = request.defaults({
     headers: { foo: 'bar' },
@@ -283,18 +207,20 @@ tape('test custom request handler function', function(t) {
   })
 
   t.throws(function() {
-    requestWithCustomHandler.head(s.url + '/get_custom', function(e, r, b) {
+    requestWithCustomHandler.head(s.url + '/', function(e, r, b) {
       throw new Error('We should never get here')
     })
   }, /HTTP HEAD requests MUST NOT include a request body/)
 
-  requestWithCustomHandler.get(s.url + '/get_custom', function(e, r, b) {
-    t.equal(e, null)
+  requestWithCustomHandler.get(s.url + '/', function(e, r, b) {
+    b = JSON.parse(b)
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers.x, 'y')
   })
 })
 
 tape('test custom request handler function without options', function(t) {
-  t.plan(1)
+  t.plan(2)
 
   var customHandlerWithoutOptions = request.defaults(function(uri, options, callback) {
     var params = request.initParams(uri, options, callback)
@@ -305,8 +231,10 @@ tape('test custom request handler function without options', function(t) {
     return request(params.uri, params, params.callback)
   })
 
-  customHandlerWithoutOptions.get(s.url + '/get_custom', function(e, r, b) {
-    t.equal(e, null)
+  customHandlerWithoutOptions.get(s.url + '/', function(e, r, b) {
+    b = JSON.parse(b)
+    t.equal(b.headers.foo, 'bar')
+    t.equal(b.headers.x, 'y')
   })
 })
 
@@ -320,8 +248,10 @@ tape('test only setting undefined properties', function(t) {
     json: {foo: 'bar'},
     headers: {'x-foo': 'baz'}
   }, function (e, r, b) {
-    t.equal(e, null)
-    t.deepEqual(b, { foo: 'bar' })
+    t.equal(b.method, 'POST')
+    t.equal(b.headers['content-type'], 'application/json')
+    t.equal(b.headers['x-foo'], 'baz')
+    t.deepEqual(b.data, { foo: 'bar' })
     t.end()
   })
 })
@@ -329,7 +259,7 @@ tape('test only setting undefined properties', function(t) {
 tape('test only function', function(t) {
   var post = request.post
   t.doesNotThrow(function () {
-    post(s.url + '/function', function (e, r, b) {
+    post(s.url + '/', function (e, r, b) {
       t.equal(r.statusCode, 200)
       t.end()
     })
@@ -338,24 +268,24 @@ tape('test only function', function(t) {
 
 tape('invoke defaults', function(t) {
   var d = request.defaults({
-    uri: s.url + '/get',
+    uri: s.url + '/',
     headers: { foo: 'bar' }
   })
-  d({}, function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  d({json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar')
     t.end()
   })
 })
 
 tape('invoke convenience method from defaults', function(t) {
   var d = request.defaults({
-    uri: s.url + '/get',
+    uri: s.url + '/',
     headers: { foo: 'bar' }
   })
-  d.get({}, function (e, r, b) {
-    t.equal(e, null)
-    t.equal(b, 'TESTING!')
+  d.get({json: true}, function (e, r, b) {
+    t.equal(b.method, 'GET')
+    t.equal(b.headers.foo, 'bar')
     t.end()
   })
 })


### PR DESCRIPTION
Hopefully this will make the maintenance of these tests a bit easier, because even with all functions folded is hard to constantly jump back and forth just to follow a single test. Also the tests are actually using tape now instead of assert and some dummy assertion in the request's callback.

Comments here #1430 and in subsequent PRs as well.