### PR TITLE
A few minor fixes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 - `followRedirect` - follow HTTP 3xx responses as redirects (default: `true`). This property can also be implemented as function which gets `response` object as a single argument and should return `true` if redirects should continue or `false` otherwise.
 - `followAllRedirects` - follow non-GET HTTP 3xx responses as redirects (default: `false`)
 - `maxRedirects` - the maximum number of redirects to follow (default: `10`)
+- `removeRefererHeader` - removes the referer header when a redirect happens (default: `false`).
 
 ---
 
@@ -797,7 +798,6 @@ The first argument can be either a `url` or an `options` object. The only requir
   tunneling proxy.
 - `proxyHeaderExclusiveList` - A whitelist of headers to send
   exclusively to a tunneling proxy and not to destination.
-- `removeRefererHeader` - removes the referer header when a redirect happens (default: `false`).
 
 ---
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -136,7 +136,7 @@ Auth.prototype.onResponse = function (response) {
 
   var authHeader = c.get('www-authenticate')
   var authVerb = authHeader && authHeader.split(' ')[0].toLowerCase()
-  // debug('reauth', authVerb)
+  request.debug('reauth', authVerb)
 
   switch (authVerb) {
     case 'basic':

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -15,27 +15,26 @@ function Redirect (request) {
   this.removeRefererHeader = false
 }
 
-Redirect.prototype.onRequest = function () {
+Redirect.prototype.onRequest = function (options) {
   var self = this
-    , request = self.request
 
-  if (request.maxRedirects !== undefined) {
-    self.maxRedirects = request.maxRedirects
+  if (options.maxRedirects !== undefined) {
+    self.maxRedirects = options.maxRedirects
   }
-  if (typeof request.followRedirect === 'function') {
-    self.allowRedirect = request.followRedirect
+  if (typeof options.followRedirect === 'function') {
+    self.allowRedirect = options.followRedirect
   }
-  if (request.followRedirect !== undefined) {
-    self.followRedirects = !!request.followRedirect
+  if (options.followRedirect !== undefined) {
+    self.followRedirects = !!options.followRedirect
   }
-  if (request.followAllRedirects !== undefined) {
-    self.followAllRedirects = request.followAllRedirects
+  if (options.followAllRedirects !== undefined) {
+    self.followAllRedirects = options.followAllRedirects
   }
   if (self.followRedirects || self.followAllRedirects) {
     self.redirects = self.redirects || []
   }
-  if (request.removeRefererHeader !== undefined) {
-    self.removeRefererHeader = request.removeRefererHeader
+  if (options.removeRefererHeader !== undefined) {
+    self.removeRefererHeader = options.removeRefererHeader
   }
 }
 
@@ -46,7 +45,7 @@ Redirect.prototype.redirectTo = function (response) {
   var redirectTo = null
   if (response.statusCode >= 300 && response.statusCode < 400 && response.caseless.has('location')) {
     var location = response.caseless.get('location')
-    // debug('redirect', location)
+    request.debug('redirect', location)
 
     if (self.followAllRedirects) {
       redirectTo = location
@@ -82,8 +81,7 @@ Redirect.prototype.onResponse = function (response) {
     return false
   }
 
-
-  // debug('redirect to', redirectTo)
+  request.debug('redirect to', redirectTo)
 
   // ignore any potential response body.  it cannot possibly be useful
   // to us at this point.

--- a/request.js
+++ b/request.js
@@ -281,6 +281,7 @@ function debug() {
     console.error('REQUEST %s', util.format.apply(util, arguments))
   }
 }
+Request.prototype.debug = debug
 
 Request.prototype.setupTunnel = function () {
   var self = this
@@ -469,7 +470,7 @@ Request.prototype.init = function (options) {
     return self.emit('error', new Error(message))
   }
 
-  self._redirect.onRequest()
+  self._redirect.onRequest(options)
 
   self.setHost = false
   if (!self.hasHeader('host')) {


### PR DESCRIPTION
- Moved `removeRefererHeader` to the appropriate section of the options docs
- Pass `options` to the redirect's module `onRequest` method, as it makes it more obvious from where these options are coming from (the extending of the request object in the ctor is a bit unexpected to say the least)
- Attached the `debug` function to the request's prototype to make it accessible to the modules through the request instance<br>
This also fixes the `request.debug` call in the `har` module, which obviously is not covered by the tests atm, or rather it should be obvious if coveralls was actually working ..