### PR TITLE
Migrate to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "0.10"
 sudo: false
 
-after_script: "npm run test-cov && cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"
+after_script: "npm run test-cov && cat ./coverage/lcov.info | codecov && cat ./coverage/lcov.info | coveralls"
 
 webhooks:
   urls: https://webhooks.gitter.im/e/237280ed4796c19cc626

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ node_js:
   - "io.js"
   - "0.12"
   - "0.10"
-after_script: ./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape tests/test-*.js --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js --verbose
+sudo: false
+
+after_script: "npm run test-cov && cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js"
+
 webhooks:
   urls: https://webhooks.gitter.im/e/237280ed4796c19cc626
   on_success: change  # options: [always|never|change] default: always
   on_failure: always  # options: [always|never|change] default: always
   on_start: false     # default: false
-sudo: false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm package](https://nodei.co/npm/request.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/request/)
 
 [![Build status](https://img.shields.io/travis/request/request.svg?style=flat-square)](https://travis-ci.org/request/request)
-[![Coverage](https://img.shields.io/coveralls/request/request.svg?style=flat-square)](https://coveralls.io/r/request/request)
+[![Coverage](https://img.shields.io/codecov/c/github/request/request.svg?style=flat-square)](https://codecov.io/github/request/request)
 [![Dependency Status](https://img.shields.io/david/request/request.svg?style=flat-square)](https://david-dm.org/request/request)
 [![Gitter](https://img.shields.io/badge/gitter-join_chat-blue.svg?style=flat-square)](https://gitter.im/request/request?utm_source=badge)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![npm package](https://nodei.co/npm/request.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/request/)
 
 [![Build status](https://img.shields.io/travis/request/request.svg?style=flat-square)](https://travis-ci.org/request/request)
-[![Coverage](https://img.shields.io/codecov/c/github/request/request.svg?style=flat-square)](https://codecov.io/github/request/request)
+[![Coverage](https://img.shields.io/codecov/c/github/request/request.svg?style=flat-square)](https://codecov.io/github/request/request?branch=master)
+[![Coverage](https://img.shields.io/coveralls/request/request.svg?style=flat-square)](https://coveralls.io/r/request/request)
 [![Dependency Status](https://img.shields.io/david/request/request.svg?style=flat-square)](https://david-dm.org/request/request)
 [![Gitter](https://img.shields.io/badge/gitter-join_chat-blue.svg?style=flat-square)](https://gitter.im/request/request?utm_source=badge)
 

--- a/package.json
+++ b/package.json
@@ -43,16 +43,17 @@
   },
   "scripts": {
     "test": "npm run lint && npm run test-ci && npm run test-browser",
-    "test-ci": "node node_modules/.bin/taper tests/test-*.js",
-    "test-cov": "node node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape tests/test-*.js",
+    "test-ci": "taper tests/test-*.js",
+    "test-cov": "istanbul cover tape tests/test-*.js",
     "test-browser": "node tests/browser/start.js",
-    "lint": "node node_modules/.bin/eslint lib/ *.js tests/ && echo Lint passed."
+    "lint": "eslint lib/ *.js tests/ && echo Lint passed."
   },
   "devDependencies": {
     "browserify": "~5.9.1",
     "browserify-istanbul": "~0.1.3",
     "buffer-equal": "0.0.1",
     "codecov.io": "~0.1.2",
+    "coveralls": "~2.11.2",
     "eslint": "0.18.0",
     "function-bind": "~1.0.0",
     "istanbul": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "har-validator": "^1.6.1"
   },
   "scripts": {
-    "test": "npm run lint && node node_modules/.bin/taper tests/test-*.js && npm run test-browser",
+    "test": "npm run lint && npm run test-ci && npm run test-browser",
+    "test-ci": "node node_modules/.bin/taper tests/test-*.js",
+    "test-cov": "node node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape tests/test-*.js",
     "test-browser": "node tests/browser/start.js",
     "lint": "node node_modules/.bin/eslint lib/ *.js tests/ && echo Lint passed."
   },
@@ -50,7 +52,7 @@
     "browserify": "~5.9.1",
     "browserify-istanbul": "~0.1.3",
     "buffer-equal": "0.0.1",
-    "coveralls": "~2.11.2",
+    "codecov.io": "~0.1.2",
     "eslint": "0.18.0",
     "function-bind": "~1.0.0",
     "istanbul": "~0.3.2",


### PR DESCRIPTION
Fixes #1577 (hopefully)

 From what I'm reading coveralls no longer works with the public token for some reason. Codeclimate, codeship and now coveralls requires full read/write access to all of your public/private repos + the org ones = which is insane IMO.

Codecov on the other hand requires minimal set of permissions for public projects + it seems that they support reporting via the GitHub status API.