### PR TITLE
Replace '.client' with '.socket' as the former was deprecated in 2.2.0.

### DIFF
--- a/request.js
+++ b/request.js
@@ -1040,10 +1040,10 @@ Request.prototype.onRequestResponse = function (response) {
 
   // XXX This is different on 0.10, because SSL is strict by default
   if (self.httpModule === https &&
-      self.strictSSL && (!response.hasOwnProperty('client') ||
-      !response.client.authorized)) {
+      self.strictSSL && (!response.hasOwnProperty('socket') ||
+      !response.socket.authorized)) {
     debug('strict ssl error', self.uri.href)
-    var sslErr = response.hasOwnProperty('client') ? response.client.authorizationError : self.uri.href + ' does not support SSL'
+    var sslErr = response.hasOwnProperty('socket') ? response.socket.authorizationError : self.uri.href + ' does not support SSL'
     self.emit('error', new Error('SSL Error: ' + sslErr))
     return
   }

--- a/tests/ssl/ca/localhost.js
+++ b/tests/ssl/ca/localhost.js
@@ -21,9 +21,9 @@ https.request({ host: 'localhost'
               , agent: agent
               , ca: [ ca ]
               , path: '/' }, function (res) {
-  if (res.client.authorized) {
+  if (res.socket.authorized) {
     console.log('node test: OK')
   } else {
-    throw new Error(res.client.authorizationError)
+    throw new Error(res.socket.authorizationError)
   }
 }).end()

--- a/tests/ssl/ca/server.js
+++ b/tests/ssl/ca/server.js
@@ -22,9 +22,9 @@ https.request({ host: 'localhost'
               , agent: agent
               , ca: [ ca ]
               , path: '/' }, function (res) {
-  if (res.client.authorized) {
+  if (res.socket.authorized) {
     console.log('node test: OK')
   } else {
-    throw new Error(res.client.authorizationError)
+    throw new Error(res.socket.authorizationError)
   }
 }).end()


### PR DESCRIPTION
Actually, it's not only deprecated, checking it with `.hasOwnProperty('client')` is broken in 2.2.0, but that's going to be fixed in 2.2.1.

See https://github.com/nodejs/io.js/pull/1572 https://github.com/nodejs/io.js/issues/1850 [nodejs/io.js#1852/files](https://github.com/nodejs/io.js/pull/1852/files)