### PR TITLE
Webpack karma config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
     "har-validator": "^1.6.1"
   },
   "scripts": {
-    "test": "npm run lint && npm run test-ci && npm run test-browser",
+    "test": "npm run lint && npm run test-ci && npm run test-browserify && npm run test-webpack",
     "test-ci": "taper tests/test-*.js",
     "test-cov": "istanbul cover tape tests/test-*.js",
-    "test-browser": "node tests/browser/start.js",
+    "test-browserify": "TEST=browserify node tests/browser/start.js",
+    "test-webpack": "TEST=webpack node tests/browser/start.js",
     "lint": "eslint lib/ *.js tests/ && echo Lint passed."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "forever-agent": "~0.6.0",
     "form-data": "~1.0.0-rc1",
     "json-stringify-safe": "~5.0.0",
+    "karma-webpack": "^1.5.1",
     "mime-types": "~2.1.2",
     "node-uuid": "~1.4.0",
     "qs": "~4.0.0",

--- a/tests/browser/karma.browserify.js
+++ b/tests/browser/karma.browserify.js
@@ -1,0 +1,26 @@
+'use strict'
+var sharedConfig = require('./karma.conf.js')
+var istanbul = require('browserify-istanbul')
+
+module.exports = function(config) {
+  sharedConfig(config)
+  config.set({
+    frameworks: ['tap', 'browserify'],
+    preprocessors: {
+      'tests/browser/test.js': ['browserify'],
+      '*.js,!(tests)/**/*.js': ['coverage']
+    },
+    plugins: [
+      'karma-phantomjs-launcher',
+      'karma-coverage',
+      'karma-browserify',
+      'karma-tap'
+    ],
+    browserify: {
+      debug: true,
+      transform: [istanbul({
+        ignore: ['**/node_modules/**', '**/tests/**']
+      })]
+    }
+  })
+}

--- a/tests/browser/karma.conf.js
+++ b/tests/browser/karma.conf.js
@@ -1,14 +1,9 @@
 'use strict'
-var istanbul = require('browserify-istanbul')
 
 module.exports = function(config) {
   config.set({
     basePath: '../..',
-    frameworks: ['tap', 'browserify'],
-    preprocessors: {
-      'tests/browser/test.js': ['browserify'],
-      '*.js,!(tests)/**/*.js': ['coverage']
-    },
+
     files: [
       'tests/browser/test.js'
     ],
@@ -26,18 +21,6 @@ module.exports = function(config) {
 
     singleRun: true,
 
-    plugins: [
-      'karma-phantomjs-launcher',
-      'karma-coverage',
-      'karma-browserify',
-      'karma-tap'
-    ],
-    browserify: {
-      debug: true,
-      transform: [istanbul({
-        ignore: ['**/node_modules/**', '**/tests/**']
-      })]
-    },
     coverageReporter: {
       type: 'lcov',
       dir: 'coverage/'

--- a/tests/browser/karma.webpack.js
+++ b/tests/browser/karma.webpack.js
@@ -1,0 +1,41 @@
+'use strict'
+var sharedConfig = require('./karma.conf.js')
+
+module.exports = function(config) {
+  sharedConfig(config)
+  config.set({
+    frameworks: ['tap'],
+    preprocessors: {
+      'tests/browser/test.js': ['webpack'],
+      '*.js,!(tests)/**/*.js': ['coverage']
+    },
+    plugins: [
+      'karma-phantomjs-launcher',
+      'karma-coverage',
+      'karma-webpack',
+      'karma-tap'
+    ],
+    webpack: {
+      devtool: 'source-map',
+      resolve: {
+        modulesDirectories: [
+          'node_modules'
+        ]
+      },
+      module: {
+        loaders: [
+          {
+            test: /\.json$/,
+            loader: 'json'
+          }
+        ]
+      },
+      externals: {
+        fs: '{}',
+        tls: '{}',
+        net: '{}',
+        console: '{}'
+      }
+    }
+  })
+}

--- a/tests/browser/start.js
+++ b/tests/browser/start.js
@@ -23,7 +23,9 @@ server.listen(port, function() {
   // Spawn process for karma.
   var c = spawn('karma', [
     'start',
-    path.join(__dirname, '/karma.conf.js')
+    path.join(__dirname, '/karma.browserify.js')
+    // TODO: run webpack tests after browserify
+    // path.join(__dirname, '/karma.webpack.js')
   ])
   c.stdout.pipe(process.stdout)
   c.stderr.pipe(process.stderr)

--- a/tests/browser/start.js
+++ b/tests/browser/start.js
@@ -23,9 +23,7 @@ server.listen(port, function() {
   // Spawn process for karma.
   var c = spawn('karma', [
     'start',
-    path.join(__dirname, '/karma.browserify.js')
-    // TODO: run webpack tests after browserify
-    // path.join(__dirname, '/karma.webpack.js')
+    path.join(__dirname, '/karma.'+process.env.TEST+'.js')
   ])
   c.stdout.pipe(process.stdout)
   c.stderr.pipe(process.stderr)

--- a/tests/browser/start.js
+++ b/tests/browser/start.js
@@ -23,7 +23,7 @@ server.listen(port, function() {
   // Spawn process for karma.
   var c = spawn('karma', [
     'start',
-    path.join(__dirname, '/karma.'+process.env.TEST+'.js')
+    path.join(__dirname, '/karma.' + process.env.TEST + '.js')
   ])
   c.stdout.pipe(process.stdout)
   c.stderr.pipe(process.stderr)


### PR DESCRIPTION
This adds a configuration for Webpack as a reference to anyone using it over Browserify since it requires some special configuration to work. There is a TODO task here to make the tests run with both Webpack and Browserify configs in series, but that will take some work as the current test setup won't allow that easily. For now, having this example will help others to figure out how to get request working with Webpack.
