### PR TITLE
Fix OAuth query transport_method

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,6 +1,7 @@
 'use strict'
 
-var qs = require('qs')
+var url = require('url')
+  , qs = require('qs')
   , caseless = require('caseless')
   , uuid = require('node-uuid')
   , oauth = require('oauth-sign')
@@ -129,7 +130,9 @@ OAuth.prototype.onRequest = function (_oauth) {
       break
 
     case 'query':
-      self.request.path = (query ? '&' : '?') + self.concatParams(oa, '&')
+      var href = self.request.uri.href += (query ? '&' : '?') + self.concatParams(oa, '&')
+      self.request.uri = url.parse(href)
+      self.request.path = self.request.uri.path
       break
 
     case 'body':

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -327,16 +327,6 @@ tape('invalid transport_method', function(t) {
       request.post(
       { url: 'http://example.com/'
       , oauth:
-        { transport_method: 'some random string'
-        }
-      })
-    }, /transport_method invalid/)
-
-  t.throws(
-    function () {
-      request.post(
-      { url: 'http://example.com/'
-      , oauth:
         { transport_method: 'headerquery'
         }
       })
@@ -372,7 +362,7 @@ tape('invalid content-type while using transport_method \'body\'', function(t) {
   t.end()
 })
 
-tape('query transport_method simple url', function(t) {
+tape('query transport_method', function(t) {
   var r = request.post(
     { url: 'https://api.twitter.com/oauth/access_token'
     , oauth:
@@ -391,14 +381,23 @@ tape('query transport_method simple url', function(t) {
 
   process.nextTick(function() {
     t.notOk(r.headers.Authorization, 'oauth Authorization header should not be present with transport_method \'query\'')
-    t.equal(accsign, qs.parse(r.path).oauth_signature)
-    t.notOk(r.path.match(/\?&/), 'there should be no ampersand at the beginning of the query')
+    t.equal(r.uri.path, r.path, 'r.uri.path should equal r.path')
+    t.ok(r.path.match(/^\/oauth\/access_token\?/), 'path should contain path + query')
+    t.deepEqual(qs.parse(r.uri.query),
+      { oauth_consumer_key: 'GDdmIQH6jhtmLUypg82g',
+        oauth_nonce: '9zWH6qe0qG7Lc1telCn7FhUbLyVdjEaL3MO5uHxn8',
+        oauth_signature_method: 'HMAC-SHA1',
+        oauth_timestamp: '1272323047',
+        oauth_token: '8ldIZyxQeVrFZXFOZH5tAwj6vzJYuLQpl0WUEYtWc',
+        oauth_verifier: 'pDNg57prOHapMbhv25RNf75lVRd6JDsni1AJJIDYoTY',
+        oauth_version: '1.0',
+        oauth_signature: accsign })
     r.abort()
     t.end()
   })
 })
 
-tape('query transport_method with prexisting url params', function(t) {
+tape('query transport_method + form option + url params', function(t) {
   var r = request.post(
     { url: 'http://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b'
     , oauth:
@@ -420,14 +419,26 @@ tape('query transport_method with prexisting url params', function(t) {
 
   process.nextTick(function() {
     t.notOk(r.headers.Authorization, 'oauth Authorization header should not be present with transport_method \'query\'')
-    t.notOk(r.path.match(/\?&/), 'there should be no ampersand at the beginning of the query')
-    t.equal('OB33pYjWAnf+xtOHN4Gmbdil168=', qs.parse(r.path).oauth_signature)
+    t.equal(r.uri.path, r.path, 'r.uri.path should equal r.path')
+    t.ok(r.path.match(/^\/request\?/), 'path should contain path + query')
+    t.deepEqual(qs.parse(r.uri.query),
+      { b5: '=%3D',
+        a3: 'a',
+        'c@': '',
+        a2: 'r b',
+        realm: 'Example',
+        oauth_nonce: '7d8f3e4a',
+        oauth_signature_method: 'HMAC-SHA1',
+        oauth_timestamp: '137131201',
+        oauth_token: 'kkk9d7dh3k39sjv7',
+        oauth_version: '1.0',
+        oauth_signature: 'OB33pYjWAnf+xtOHN4Gmbdil168=' })
     r.abort()
     t.end()
   })
 })
 
-tape('query transport_method with qs parameter and existing query string in url', function(t) {
+tape('query transport_method + qs option + url params', function(t) {
   var r = request.post(
     { url: 'http://example.com/request?a2=r%20b'
     , oauth:
@@ -451,30 +462,28 @@ tape('query transport_method with qs parameter and existing query string in url'
 
   process.nextTick(function() {
     t.notOk(r.headers.Authorization, 'oauth Authorization header should not be present with transport_method \'query\'')
-    t.notOk(r.path.match(/\?&/), 'there should be no ampersand at the beginning of the query')
-    t.equal('OB33pYjWAnf+xtOHN4Gmbdil168=', qs.parse(r.path).oauth_signature)
-
-    var params = qs.parse(r.path.split('?')[1])
-      , keys = Object.keys(params)
-
-    var paramNames = [
-      'a2', 'b5', 'a3[0]', 'a3[1]', 'c@', 'c2',
-      'realm', 'oauth_nonce', 'oauth_signature_method', 'oauth_timestamp',
-      'oauth_token', 'oauth_version', 'oauth_signature'
-    ]
-
-    for (var i = 0; i < keys.length; i++) {
-      t.ok(keys[i] === paramNames[i],
-        'Non-oauth query params should be first, ' +
-        'OAuth query params should be second in query string')
-    }
-
+    t.equal(r.uri.path, r.path, 'r.uri.path should equal r.path')
+    t.ok(r.path.match(/^\/request\?/), 'path should contain path + query')
+    t.deepEqual(qs.parse(r.uri.query),
+      { a2: 'r b',
+        b5: '=%3D',
+        'a3[0]': 'a',
+        'a3[1]': '2 q',
+        'c@': '',
+        c2: '',
+        realm: 'Example',
+        oauth_nonce: '7d8f3e4a',
+        oauth_signature_method: 'HMAC-SHA1',
+        oauth_timestamp: '137131201',
+        oauth_token: 'kkk9d7dh3k39sjv7',
+        oauth_version: '1.0',
+        oauth_signature: 'OB33pYjWAnf+xtOHN4Gmbdil168=' })
     r.abort()
     t.end()
   })
 })
 
-tape('body transport_method empty body', function(t) {
+tape('body transport_method', function(t) {
   var r = request.post(
     { url: 'https://api.twitter.com/oauth/access_token'
     , headers: { 'content-type': 'application/x-www-form-urlencoded; charset=UTF-8' }
@@ -494,14 +503,21 @@ tape('body transport_method empty body', function(t) {
 
   process.nextTick(function() {
     t.notOk(r.headers.Authorization, 'oauth Authorization header should not be present with transport_method \'body\'')
-    t.equal(accsign, qs.parse(r.body.toString()).oauth_signature)
-    t.notOk(r.body.toString().match(/^&/), 'there should be no ampersand at the beginning of the body')
+    t.deepEqual(qs.parse(r.body),
+      { oauth_consumer_key: 'GDdmIQH6jhtmLUypg82g',
+        oauth_nonce: '9zWH6qe0qG7Lc1telCn7FhUbLyVdjEaL3MO5uHxn8',
+        oauth_signature_method: 'HMAC-SHA1',
+        oauth_timestamp: '1272323047',
+        oauth_token: '8ldIZyxQeVrFZXFOZH5tAwj6vzJYuLQpl0WUEYtWc',
+        oauth_verifier: 'pDNg57prOHapMbhv25RNf75lVRd6JDsni1AJJIDYoTY',
+        oauth_version: '1.0',
+        oauth_signature: accsign })
     r.abort()
     t.end()
   })
 })
 
-tape('body transport_method with prexisting body params', function(t) {
+tape('body transport_method + form option + url params', function(t) {
   var r = request.post(
     { url: 'http://example.com/request?b5=%3D%253D&a3=a&c%40=&a2=r%20b'
     , oauth:
@@ -523,8 +539,16 @@ tape('body transport_method with prexisting body params', function(t) {
 
   process.nextTick(function() {
     t.notOk(r.headers.Authorization, 'oauth Authorization header should not be present with transport_method \'body\'')
-    t.notOk(r.body.toString().match(/^&/), 'there should be no ampersand at the beginning of the body')
-    t.equal('OB33pYjWAnf+xtOHN4Gmbdil168=', qs.parse(r.body.toString()).oauth_signature)
+    t.deepEqual(qs.parse(r.body),
+      { c2: '',
+        a3: '2 q',
+        realm: 'Example',
+        oauth_nonce: '7d8f3e4a',
+        oauth_signature_method: 'HMAC-SHA1',
+        oauth_timestamp: '137131201',
+        oauth_token: 'kkk9d7dh3k39sjv7',
+        oauth_version: '1.0',
+        oauth_signature: 'OB33pYjWAnf+xtOHN4Gmbdil168=' })
     r.abort()
     t.end()
   })


### PR DESCRIPTION
I broke it here https://github.com/simov/request/commit/41319044e602af69cdfad9a92dc0c4fd4d30db0a#diff-84fad1d3b3913ec86805e857580c5d54R114 because the OAuth parameters were appended here https://github.com/simov/request/commit/41319044e602af69cdfad9a92dc0c4fd4d30db0a#diff-ccc0734f65dd7a299409ff07d35be095L1398 instead of replaced.

Additionally now `request.uri` is constructed properly when using OAuth `transport_method:query`, so when using `request-debug` the correct `uri` is dumped containing all of the query parameters.

Lastly I greatly improved the OAuth transport_method related tests, because they were a bit loose and the cause of this bug in the first place.