### PR TITLE
Use the `extend` module to deep extend when using the defaults method

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 
 'use strict'
 
-var extend                = require('util')._extend
+var extend                = require('extend')
   , cookies               = require('./lib/cookies')
   , helpers               = require('./lib/helpers')
 
@@ -30,12 +30,11 @@ function initParams(uri, options, callback) {
 
   var params = {}
   if (typeof options === 'object') {
-    params = extend({}, options)
-    params = extend(params, {uri: uri})
+    extend(params, options, {uri: uri})
   } else if (typeof uri === 'string') {
-    params = extend({}, {uri: uri})
+    extend(params, {uri: uri})
   } else {
-    params = extend({}, uri)
+    extend(params, uri)
   }
 
   params.callback = callback
@@ -86,24 +85,18 @@ function wrapRequestMethod (method, options, requester, verb) {
   return function (uri, opts, callback) {
     var params = initParams(uri, opts, callback)
 
-    var headerlessOptions = extend({}, options)
-    delete headerlessOptions.headers
-    params = extend(headerlessOptions, params)
-
-    if (options.headers) {
-      var headers = extend({}, options.headers)
-      params.headers = extend(headers, params.headers)
-    }
+    var target = {}
+    extend(true, target, options, params)
 
     if (verb) {
-      params.method = (verb === 'del' ? 'DELETE' : verb.toUpperCase())
+      target.method = (verb === 'del' ? 'DELETE' : verb.toUpperCase())
     }
 
     if (isFunction(requester)) {
       method = requester
     }
 
-    return method(params, params.callback)
+    return method(target, target.callback)
   }
 }
 
@@ -131,7 +124,7 @@ request.defaults = function (options, requester) {
 request.forever = function (agentOptions, optionsArg) {
   var options = {}
   if (optionsArg) {
-    options = extend({}, optionsArg)
+    extend(options, optionsArg)
   }
   if (agentOptions) {
     options.agentOptions = agentOptions

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "bl": "~0.9.0",
     "caseless": "~0.10.0",
+    "extend": "~2.0.1",
     "forever-agent": "~0.6.0",
     "form-data": "~0.2.0",
     "json-stringify-safe": "~5.0.0",

--- a/tests/server.js
+++ b/tests/server.js
@@ -13,7 +13,7 @@ exports.portSSL = 16167
 exports.createServer = function (port) {
   port = port || exports.port
   var s = http.createServer(function (req, resp) {
-    s.emit(req.url, req, resp)
+    s.emit(req.url.replace(/(\?.*)/, ''), req, resp)
   })
   s.port = port
   s.url = 'http://localhost:' + port


### PR DESCRIPTION
@mikeal @nylen I'm introducing the [extend](https://www.npmjs.com/package/extend) module into core. This fixes the flat extend behavior when using `util._extend` in `defaults` for any other object key that the `headers`.

Let me know what do you think.