### PR TITLE
Clarify the nature of setting `ca` in `agentOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,8 @@ request.get({
 
 It is possible to accept other certificates than those signed by generally allowed Certificate Authorities (CAs).
 This can be useful, for example,  when using self-signed certificates.
-To allow a different certificate, you can specify the signing CA by adding the contents of the CA's certificate file to the `agentOptions`:
+To require a different root certificate, you can specify the signing CA by adding the contents of the CA's certificate file to the `agentOptions`.
+The certificate the domain presents must be signed by the root certificate specified:
 
 ```js
 request.get({


### PR DESCRIPTION
The `ca` option in https://nodejs.org/api/tls.html#tls_tls_connect_options_callback indicates that the certificate presented must be signed by one of the certificates provided. The existing wording in request led me to believe that setting it augmented the list of acceptable certificates rather than replacing it.

This caused a problem when we switched from a testing environment which used a self-signed certificate to a staging environment which used a third-party signed certificate.