### PR TITLE
Fix form method

### DIFF
--- a/tests/test-form-urlencoded.js
+++ b/tests/test-form-urlencoded.js
@@ -9,11 +9,12 @@ function runTest (t, options, index) {
 
   var server = http.createServer(function(req, res) {
 
-    if (index === 0) {
+    if (index === 0 || index === 3) {
       t.equal(req.headers['content-type'], 'application/x-www-form-urlencoded')
     } else {
       t.equal(req.headers['content-type'], 'application/x-www-form-urlencoded; charset=UTF-8')
     }
+    t.equal(req.headers['content-length'], '21')
     t.equal(req.headers.accept, 'application/json')
 
     var data = ''
@@ -33,7 +34,7 @@ function runTest (t, options, index) {
 
   server.listen(6767, function() {
 
-    request.post('http://localhost:6767', options, function(err, res, body) {
+    var r = request.post('http://localhost:6767', options, function(err, res, body) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.equal(body, 'done')
@@ -41,6 +42,9 @@ function runTest (t, options, index) {
         t.end()
       })
     })
+    if (!options.form && !options.body) {
+      r.form({some: 'url', encoded: 'data'})
+    }
   })
 }
 
@@ -57,6 +61,10 @@ var cases = [
   {
     headers: {'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'},
     body: 'some=url&encoded=data',
+    json: true
+  },
+  {
+    // body set via .form() method
     json: true
   }
 ]


### PR DESCRIPTION
Fixes https://github.com/request/request/issues/1630

It turned out that when the body is set via the `.form()` method the `content-length` is not being set, and therefore the request is sent as `transfer-encoding:'chunked'` which may cause problems with some servers.

So I refactored out the logic responsible for setting up the `content-length`:

```js
function setContentLength () {
  if (!Buffer.isBuffer(self.body) && !Array.isArray(self.body)) {
    self.body = new Buffer(self.body)
  }
  if (!self.hasHeader('content-length')) {
    var length = (Array.isArray(self.body))
      ? self.body.reduce(function (a, b) {return a + b.length}, 0)
      : self.body.length
    if (length) {
      self.setHeader('content-length', length)
    } else {
      self.emit('error', new Error('Argument error, options.body.'))
    }
  }
}
```

Much sexier than it was before, plus that conditional structure allows it to be called again inside the `defer` method. Now for the function name and declaration position it's just there for now, I couldn't figure out a better place to put it, but then again it's visible inside the `defer` function.

Lastly the `test-form-urlencoded` tests now checks if the `content-length` header is present as well.