### PR TITLE
Providing the user defined headers to the form-data set headers method

### DIFF
--- a/request.js
+++ b/request.js
@@ -563,7 +563,7 @@ Request.prototype.init = function (options) {
 
     if (self._form && !self.hasHeader('content-length')) {
       // Before ending the request, we had to compute the length of the whole form, asyncly
-      self.setHeader(self._form.getHeaders())
+      self.setHeader(self._form.getHeaders(self.headers))
       self._form.getLength(function (err, length) {
         if (!err) {
           self.setHeader('content-length', length)


### PR DESCRIPTION
This change allows the user to override form-data's default content-type header by providing the headers object to the getHeaders function. 
