### PR TITLE
Fix caseless bug - content-type not being set for multipart/form-data

### DIFF
--- a/request.js
+++ b/request.js
@@ -573,7 +573,7 @@ Request.prototype.init = function (options) {
 
     if (self._form && !self.hasHeader('content-length')) {
       // Before ending the request, we had to compute the length of the whole form, asyncly
-      self.setHeader(self._form.getHeaders())
+      self.setHeader(self._form.getHeaders(), true)
       self._form.getLength(function (err, length) {
         if (!err) {
           self.setHeader('content-length', length)

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -29,6 +29,9 @@ function runTest(t, options) {
       }
     }
 
+    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+      .test(req.headers['content-type']))
+
     // temp workaround
     var data = ''
     req.setEncoding('utf8')

--- a/tests/test-form.js
+++ b/tests/test-form.js
@@ -21,6 +21,9 @@ tape('multipart form append', function(t) {
       return
     }
 
+    t.ok(/multipart\/form-data; boundary=--------------------------\d+/
+      .test(req.headers['content-type']))
+
     // temp workaround
     var data = ''
     req.setEncoding('utf8')


### PR DESCRIPTION
Fixes https://github.com/request/request/issues/1684
Fixes https://github.com/request/request/issues/1685
Closes https://github.com/request/request/pull/1686

As it [turned out](https://github.com/request/request/issues/1684#issuecomment-122978907) a change in  *caseless* caused `multipart/form-data` related headers to not being set.

Thanks for the feedback everyone, and especially @garymathews for fixing it up (your commit is in this PR).

I added the missing check for the `content-type` headers in the tests.