### PR TITLE
debug() when JSON.parse() on a response body fails

### DIFF
--- a/request.js
+++ b/request.js
@@ -1047,7 +1047,7 @@ Request.prototype.onRequestResponse = function (response) {
           try {
             response.body = JSON.parse(response.body, self._jsonReviver)
           } catch (e) {
-            // empty
+            debug('invalid JSON received', self.uri.href)
           }
         }
         debug('emitting complete', self.uri.href)


### PR DESCRIPTION
Previously JSON.parse() failures was silently ignored.

Although `response.body` would still contain the invalid JSON response body as a string, instead of a JS object, it's valueable to know the JSON was invalid while debugging.

I was tempted to `.emit('error', new Error('Invalid JSON received'))` but that might be a little harse.

Any thoughts?