### PR TITLE
Do not create Buffer from Object in setContentLength(iojs v3.0 issue)

### DIFF
--- a/request.js
+++ b/request.js
@@ -432,7 +432,7 @@ Request.prototype.init = function (options) {
   }
 
   function setContentLength () {
-    if (!Buffer.isBuffer(self.body) && !Array.isArray(self.body)) {
+    if (!Buffer.isBuffer(self.body) && !Array.isArray(self.body) && typeof self.body !== 'object') {
       self.body = new Buffer(self.body)
     }
     if (!self.hasHeader('content-length')) {


### PR DESCRIPTION
Due to changes in io.js v3.0 creating Buffer from Object throws an Error. This PR just prevents this