### PR TITLE
Reuse request agent on redirect

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -120,7 +120,6 @@ Redirect.prototype.onResponse = function (response) {
   // request.method = 'GET' // Force all redirects to use GET || commented out fixes #215
   delete request.src
   delete request.req
-  delete request.agent
   delete request._started
   if (response.statusCode !== 401 && response.statusCode !== 307) {
     // Remove parameters from the previous response, unless this is the second request

--- a/request.js
+++ b/request.js
@@ -111,6 +111,8 @@ function Request (options) {
   // call init
 
   var self = this
+  self.options = self.options || options//joshux
+  self.options = self.options || {}//joshux
 
   // start with HAR, then override with additional options
   if (options.har) {
@@ -471,13 +473,13 @@ Request.prototype.init = function (options) {
   }
 
   if (!self.agent) {
-    if (options.agentOptions) {
-      self.agentOptions = options.agentOptions
+    if (self.options.agentOptions) {
+      self.agentOptions = self.options.agentOptions
     }
 
-    if (options.agentClass) {
-      self.agentClass = options.agentClass
-    } else if (options.forever) {
+    if (self.options.agentClass) {
+      self.agentClass = self.options.agentClass
+    } else if (self.options.forever) {
       var v = version()
       // use ForeverAgent in node 0.10- only
       if (v.major === 0 && v.minor <= 10) {
@@ -593,56 +595,7 @@ Request.prototype.init = function (options) {
 // httpModule, Tunneling agent, and/or Forever Agent in use.
 Request.prototype._updateProtocol = function () {
   var self = this
-  var protocol = self.uri.protocol
-
-  if (protocol === 'https:' || self.tunnel) {
-    // previously was doing http, now doing https
-    // if it's https, then we might need to tunnel now.
-    if (self.proxy) {
-      if (self._tunnel.setup()) {
-        return
-      }
-    }
-
-    self.httpModule = https
-    switch (self.agentClass) {
-      case ForeverAgent:
-        self.agentClass = ForeverAgent.SSL
-        break
-      case http.Agent:
-        self.agentClass = https.Agent
-        break
-      default:
-        // nothing we can do.  Just hope for the best.
-        return
-    }
-
-    // if there's an agent, we need to get a new one.
-    if (self.agent) {
-      self.agent = self.getNewAgent()
-    }
-
-  } else {
-    // previously was doing https, now doing http
-    self.httpModule = http
-    switch (self.agentClass) {
-      case ForeverAgent.SSL:
-        self.agentClass = ForeverAgent
-        break
-      case https.Agent:
-        self.agentClass = http.Agent
-        break
-      default:
-        // nothing we can do.  just hope for the best
-        return
-    }
-
-    // if there's an agent, then get a new one.
-    if (self.agent) {
-      self.agent = null
-      self.agent = self.getNewAgent()
-    }
-  }
+  delete self.agent
 }
 
 Request.prototype.getNewAgent = function () {

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -4,6 +4,7 @@ var server = require('./server')
   , assert = require('assert')
   , request = require('../index')
   , tape = require('tape')
+  , http = require('http')
 
 var s = server.createServer()
   , ss = server.createSSLServer()
@@ -362,6 +363,42 @@ tape('should not have a referer when removeRefererHeader is true', function(t) {
   })
   .on('redirect', function() {
     t.equal(this.headers.referer, undefined)
+  })
+})
+
+tape('should use same agent class on redirect', function(t) {
+  var agent
+  var calls = 0
+  var agentOptions = {}
+
+  function FakeAgent(agentOptions) {
+    var createConnection
+
+    agent = new http.Agent(agentOptions)
+    createConnection = agent.createConnection
+    agent.createConnection = function() {
+      calls++
+      return createConnection.apply(agent, arguments)
+    }
+
+    return agent
+  }
+
+  hits = {}
+  request.get({
+    uri: s.url + '/temp',
+    jar: jar,
+    headers: { cookie: 'foo=bar' },
+    agentOptions: agentOptions,
+    agentClass: FakeAgent
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(body, 'GET temp_landing', 'Got temporary landing content')
+    t.equal(calls, 2)
+    t.ok(this.agent === agent, 'Reinstantiated the user-specified agent')
+    t.ok(this.agentOptions === agentOptions, 'Reused agent options')
+    t.end()
   })
 })
 


### PR DESCRIPTION
Fixes #1304
Closes https://github.com/request/request/pull/1451

The problems I found before the fix: 
1. _updateProtocol was incorrect and is redundant with init(). 
2. The code was mixing configuration (options.agentClass) with state (self.agentClass). In my opinion, it would be better if the configuration is immutable which shouldn't be deleted on redirection. 