### PR TITLE
Add more descriptive error message on ETIMEDOUT

### DIFF
--- a/request.js
+++ b/request.js
@@ -815,7 +815,7 @@ Request.prototype.start = function () {
     self.timeoutTimer = setTimeout(function () {
       var connectTimeout = self.req.socket && self.req.socket.readable === false
       self.abort()
-      var e = new Error('ETIMEDOUT')
+      var e = new Error('connect ETIMEDOUT ' + self.host + ':' + self.port)
       e.code = 'ETIMEDOUT'
       e.connect = connectTimeout
       self.emit('error', e)
@@ -832,7 +832,7 @@ Request.prototype.start = function () {
       self.req.setTimeout(timeout, function () {
         if (self.req) {
           self.req.abort()
-          var e = new Error('ESOCKETTIMEDOUT')
+          var e = new Error('connect ESOCKETTIMEDOUT ' + self.host + ':' + self.port)
           e.code = 'ESOCKETTIMEDOUT'
           e.connect = false
           self.emit('error', e)

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -57,7 +57,7 @@ if (process.env.TRAVIS === 'true') {
   })
 
   tape('should timeout with events', function(t) {
-    t.plan(3)
+    t.plan(4)
 
     var shouldTimeoutWithEvents = {
       url: s.url + '/timeout',
@@ -70,6 +70,7 @@ if (process.env.TRAVIS === 'true') {
         eventsEmitted++
         t.equal(1, eventsEmitted)
         checkErrCode(t, err)
+        t.equal('connect ETIMEDOUT localhost' + ':' + s.port, err.message)
       })
   })
 


### PR DESCRIPTION
This makes the `ETIMEDOUT` error more useful and inline with what io.js throws.
