### PR TITLE
Revert doc about installation of tough-cookie added in #884

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 - `encoding` - Encoding to be used on `setEncoding` of response data. If `null`, the `body` is returned as a `Buffer`. Anything else **(including the default value of `undefined`)** will be passed as the [encoding](http://nodejs.org/api/buffer.html#buffer_buffer) parameter to `toString()` (meaning this is effectively `utf8` by default). (**Note:** if you expect binary data, you should set `encoding: null`.)
 - `gzip` - If `true`, add an `Accept-Encoding` header to request compressed content encodings from the server (if not already present) and decode supported content encodings in the response.  **Note:** Automatic decoding of the response content is performed on the body data returned through `request` (both through the `request` stream and passed to the callback function) but is not performed on the `response` stream (available from the `response` event) which is the unmodified `http.IncomingMessage` object which may contain compressed data. See example below.
-- `jar` - If `true` and `tough-cookie` is installed, remember cookies for future use (or define your custom cookie jar; see examples section)
+- `jar` - If `true`, remember cookies for future use (or define your custom cookie jar; see examples section)
 
 ---
 
@@ -1029,7 +1029,7 @@ the server sent a compressed response.
   })
 ```
 
-Cookies are disabled by default (else, they would be used in subsequent requests). To enable cookies, set `jar` to `true` (either in `defaults` or `options`) and install `tough-cookie`.
+Cookies are disabled by default (else, they would be used in subsequent requests). To enable cookies, set `jar` to `true` (either in `defaults` or `options`).
 
 ```js
 var request = request.defaults({jar: true})


### PR DESCRIPTION
I merged PR #884 but it was a mistake. `tough-cookie` is builtin and required by `request` for a while. There is no need for user to install it manually. So I revert the PR. Sorry for confusion.