### PR TITLE
Set default application/json content-type when using json option

### DIFF
--- a/request.js
+++ b/request.js
@@ -1198,6 +1198,9 @@ Request.prototype.json = function (val) {
   }
 
   self._json = true
+  if (!self.hasHeader('content-type')) {
+    self.setHeader('content-type', 'application/json')
+  }
   if (typeof val === 'boolean') {
     if (self.body !== undefined) {
       if (!/^application\/x-www-form-urlencoded\b/.test(self.getHeader('content-type'))) {
@@ -1205,15 +1208,9 @@ Request.prototype.json = function (val) {
       } else {
         self.body = self._qs.rfc3986(self.body)
       }
-      if (!self.hasHeader('content-type')) {
-        self.setHeader('content-type', 'application/json')
-      }
     }
   } else {
     self.body = safeStringify(val)
-    if (!self.hasHeader('content-type')) {
-      self.setHeader('content-type', 'application/json')
-    }
   }
 
   if (typeof self.jsonReviver === 'function') {

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -73,6 +73,7 @@ tape('deep extend', function(t) {
   }, function (e, r, b) {
     delete b.headers.host
     delete b.headers.accept
+    delete b.headers['content-type']
     delete b.headers.connection
     t.deepEqual(b.headers, { a: '1', b: '3', c: '4' })
     t.deepEqual(b.qs, { a: '1', b: '3', c: '4' })
@@ -97,7 +98,7 @@ tape('post(string, object, function)', function(t) {
   }).post(s.url + '/', { json: true }, function (e, r, b) {
     t.equal(b.method, 'POST')
     t.equal(b.headers.foo, 'bar')
-    t.equal(b.headers['content-type'], undefined)
+    t.equal(b.headers['content-type'], 'application/json')
     t.end()
   })
 })
@@ -108,7 +109,7 @@ tape('patch(string, object, function)', function(t) {
   }).patch(s.url + '/', { json: true }, function (e, r, b) {
     t.equal(b.method, 'PATCH')
     t.equal(b.headers.foo, 'bar')
-    t.equal(b.headers['content-type'], undefined)
+    t.equal(b.headers['content-type'], 'application/json')
     t.end()
   })
 })


### PR DESCRIPTION
Will set the header when using `json: true` without a body.

Fixes #1759