### PR TITLE
Enable loose cookie parsing in tough-cookie

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -13,13 +13,13 @@ exports.parse = function(str) {
   if (typeof str !== 'string') {
     throw new Error('The cookie function only accepts STRING as param')
   }
-  return Cookie.parse(str)
+  return Cookie.parse(str, {loose: true})
 }
 
 // Adapt the sometimes-Async api of tough.CookieJar to our requirements
 function RequestJar(store) {
   var self = this
-  self._jar = new CookieJar(store)
+  self._jar = new CookieJar(store, {looseMode: true})
 }
 RequestJar.prototype.setCookie = function(cookieOrStr, uri, options) {
   var self = this

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node-uuid": "1.4.3",
     "qs": "5.1.0",
     "tunnel-agent": "0.4.1",
-    "tough-cookie": "2.1.0",
+    "tough-cookie": "2.2.0",
     "http-signature": "0.11.0",
     "oauth-sign": "0.8.0",
     "hawk": "3.1.0",


### PR DESCRIPTION
tough-cookie 2.1.0 got a loose cookie mode which is more how browsers actually behave. It implies an empty key for value-only cookies.

Not sure how request handles strict spec-compliance vs. practicality, so I thought I'd just get this started with a PR.