### PR TITLE
Updated har-validator to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "stringstream": "0.0.4",
     "combined-stream": "1.0.5",
     "isstream": "0.1.2",
-    "har-validator": "1.8.0"
+    "har-validator": "2.0.0"
   },
   "scripts": {
     "test": "npm run lint && npm run test-ci && npm run test-browser",


### PR DESCRIPTION
:rocket:

har-validator just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 6 commits (ahead by 6, behind by 0).

- [b4ad33d](https://github.com/ahmadnassri/har-validator/commit/b4ad33d7e4e34b8e78b465dcd89a2609c14cc64e): 2.0.0
- [4feea3a](https://github.com/ahmadnassri/har-validator/commit/4feea3af2641510234c4ca5b663b53ef0f51d645): chore(Travis): update Node.js testing versions in Travis.CI
- [e6a14aa](https://github.com/ahmadnassri/har-validator/commit/e6a14aa81a9aa3328f2f5ef37a41c9cc4a8bcee4): feat(Promise): update CLI to use native Promises
- [7540757](https://github.com/ahmadnassri/har-validator/commit/7540757a54a53ad2def1b3445a1f0672593aebb1): feat(Promise): switch to Promises by default, and move callback async to secondary API
- [7c328a6](https://github.com/ahmadnassri/har-validator/commit/7c328a6f7b09c7bafc55def807dc442332f09c9d): Merge pull request #7 from LinusU/standard-style
- [5b036dd](https://github.com/ahmadnassri/har-validator/commit/5b036dd804c04e59933e612c9067b0e5db06dd91): adhere to padded-blocks

See the [full diff](https://github.com/ahmadnassri/har-validator/compare/8fd21c30edb23a1fed2d50b934d055d1be3dd7c9...b4ad33d7e4e34b8e78b465dcd89a2609c14cc64e).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>