### PR TITLE
Extract `readResponseBody` method out of `onRequestResponse`

### DIFF
--- a/request.js
+++ b/request.js
@@ -1014,54 +1014,7 @@ Request.prototype.onRequestResponse = function (response) {
     responseContent.on('close', function () {self.emit('close')})
 
     if (self.callback) {
-      var buffer = bl()
-        , strings = []
-
-      self.on('data', function (chunk) {
-        if (Buffer.isBuffer(chunk)) {
-          buffer.append(chunk)
-        } else {
-          strings.push(chunk)
-        }
-      })
-      self.on('end', function () {
-        debug('end event', self.uri.href)
-        if (self._aborted) {
-          debug('aborted', self.uri.href)
-          return
-        }
-
-        if (buffer.length) {
-          debug('has body', self.uri.href, buffer.length)
-          if (self.encoding === null) {
-            // response.body = buffer
-            // can't move to this until https://github.com/rvagg/bl/issues/13
-            response.body = buffer.slice()
-          } else {
-            response.body = buffer.toString(self.encoding)
-          }
-        } else if (strings.length) {
-          // The UTF8 BOM [0xEF,0xBB,0xBF] is converted to [0xFE,0xFF] in the JS UTC16/UCS2 representation.
-          // Strip this value out when the encoding is set to 'utf8', as upstream consumers won't expect it and it breaks JSON.parse().
-          if (self.encoding === 'utf8' && strings[0].length > 0 && strings[0][0] === '\uFEFF') {
-            strings[0] = strings[0].substring(1)
-          }
-          response.body = strings.join('')
-        }
-
-        if (self._json) {
-          try {
-            response.body = JSON.parse(response.body, self._jsonReviver)
-          } catch (e) {
-            debug('invalid JSON received', self.uri.href)
-          }
-        }
-        debug('emitting complete', self.uri.href)
-        if (typeof response.body === 'undefined' && !self._json) {
-          response.body = self.encoding === null ? new Buffer(0) : ''
-        }
-        self.emit('complete', response, response.body)
-      })
+      self.readResponseBody(response)
     }
     //if no callback
     else {
@@ -1075,6 +1028,59 @@ Request.prototype.onRequestResponse = function (response) {
     }
   }
   debug('finish init function', self.uri.href)
+}
+
+Request.prototype.readResponseBody = function (response) {
+  var self = this
+  debug('reading response\'s body')
+  var buffer = bl()
+    , strings = []
+
+  self.on('data', function (chunk) {
+    if (Buffer.isBuffer(chunk)) {
+      buffer.append(chunk)
+    } else {
+      strings.push(chunk)
+    }
+  })
+  self.on('end', function () {
+    debug('end event', self.uri.href)
+    if (self._aborted) {
+      debug('aborted', self.uri.href)
+      return
+    }
+
+    if (buffer.length) {
+      debug('has body', self.uri.href, buffer.length)
+      if (self.encoding === null) {
+        // response.body = buffer
+        // can't move to this until https://github.com/rvagg/bl/issues/13
+        response.body = buffer.slice()
+      } else {
+        response.body = buffer.toString(self.encoding)
+      }
+    } else if (strings.length) {
+      // The UTF8 BOM [0xEF,0xBB,0xBF] is converted to [0xFE,0xFF] in the JS UTC16/UCS2 representation.
+      // Strip this value out when the encoding is set to 'utf8', as upstream consumers won't expect it and it breaks JSON.parse().
+      if (self.encoding === 'utf8' && strings[0].length > 0 && strings[0][0] === '\uFEFF') {
+        strings[0] = strings[0].substring(1)
+      }
+      response.body = strings.join('')
+    }
+
+    if (self._json) {
+      try {
+        response.body = JSON.parse(response.body, self._jsonReviver)
+      } catch (e) {
+        debug('invalid JSON received', self.uri.href)
+      }
+    }
+    debug('emitting complete', self.uri.href)
+    if (typeof response.body === 'undefined' && !self._json) {
+      response.body = self.encoding === null ? new Buffer(0) : ''
+    }
+    self.emit('complete', response, response.body)
+  })
 }
 
 Request.prototype.abort = function () {


### PR DESCRIPTION
As mentionned in issue #1817 I've extracted the portion of `Request#onRequestResponse` that reads the response's body into `Request#readResponseBody`.