### PR TITLE
Set href as request.js uses it

### DIFF
--- a/request.js
+++ b/request.js
@@ -247,6 +247,8 @@ Request.prototype.init = function (options) {
   // If a string URI/URL was given, parse it into a URL object
   if (typeof self.uri === 'string') {
     self.uri = url.parse(self.uri)
+  } else {
+    self.uri.href = url.format(self.uri)
   }
 
   // DEPRECATED: Warning for users of the old Unix Sockets URL Scheme

--- a/request.js
+++ b/request.js
@@ -247,7 +247,10 @@ Request.prototype.init = function (options) {
   // If a string URI/URL was given, parse it into a URL object
   if (typeof self.uri === 'string') {
     self.uri = url.parse(self.uri)
-  } else {
+  }
+
+  // Some URL objects are not from a URL parsed string and need href added
+  if (!self.uri.href) {
     self.uri.href = url.format(self.uri)
   }
 

--- a/tests/test-isUrl.js
+++ b/tests/test-isUrl.js
@@ -94,6 +94,23 @@ tape('hostname and port 3', function(t) {
   })
 })
 
+tape('hostname and query string', function(t) {
+  request({
+    uri: {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: 6767
+    },
+    qs: {
+      test: 'test'
+    }
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(body, 'ok')
+    t.end()
+  })
+})
+
 tape('cleanup', function(t) {
   s.close(function() {
     t.end()


### PR DESCRIPTION
If href was never defined in an original, dynamically generated request options object the rest of the code referencing href fails.