### PR TITLE
Updated tough-cookie to version 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node-uuid": "1.4.3",
     "qs": "5.1.0",
     "tunnel-agent": "0.4.1",
-    "tough-cookie": "2.1.0",
+    "tough-cookie": "2.2.0",
     "http-signature": "0.11.0",
     "oauth-sign": "0.8.0",
     "hawk": "3.1.0",


### PR DESCRIPTION
:rocket:

tough-cookie just published version 2.2.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [fb14561](https://github.com/SalesforceEng/tough-cookie/commit/fb1456177c9b51445afa34656eb314c70c2adcd2): 2.2.0
- [e10f8e9](https://github.com/SalesforceEng/tough-cookie/commit/e10f8e966d70233def2755388bde0d0cbf63e32d): Merge pull request 56 from Sebmaster/feature/loose-cookiejar
- [34894b3](https://github.com/SalesforceEng/tough-cookie/commit/34894b38ac95331cc2705cf6e887a82e84d05056): Implement loose mode for cookie jars

See the [full diff](https://github.com/SalesforceEng/tough-cookie/compare/63045791429fa8fd644e68676074da480a925448...fb1456177c9b51445afa34656eb314c70c2adcd2).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>