### PR TITLE
Tunnel: fix wrong property name

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -34,7 +34,7 @@ var defaultProxyHeaderExclusiveList = [
 ]
 
 function constructProxyHost(uriObject) {
-  var port = uriObject.portA
+  var port = uriObject.port
     , protocol = uriObject.protocol
     , proxyHost = uriObject.hostname + ':'
 


### PR DESCRIPTION
Unless `portA` is on purpose? ;)