### PR TITLE
Fix Referer header to point to the original host name

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -140,7 +140,7 @@ Redirect.prototype.onResponse = function (response) {
   }
 
   if (!self.removeRefererHeader) {
-    request.setHeader('referer', request.uri.href)
+    request.setHeader('referer', uriPrev.href)
   }
 
   request.emit('redirect')

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -345,7 +345,7 @@ tape('should have the referer when following redirect by default', function(t) {
   })
   .on('redirect', function() {
     t.notEqual(this.headers.referer, undefined)
-    t.equal(this.headers.referer.substring(this.headers.referer.lastIndexOf('/')), '/temp_landing')
+    t.equal(this.headers.referer.substring(this.headers.referer.lastIndexOf('/')), '/temp')
   })
 })
 


### PR DESCRIPTION
I have no idea how this has gone unnoticed for so long. Here is how our single test regarding that behavior looks like before and after the change using `request-debug`:

> should have the referer when following redirect by default

```diff
{ request: 
   { debugId: 1,
     uri: 'http://localhost:6767/temp',
     method: 'POST',
     headers: 
      { cookie: 'foo=bar',
        host: 'localhost:6767',
        'content-length': 0 } } }
{ redirect: 
   { debugId: 1,
     statusCode: 301,
     headers: 
      { location: 'http://localhost:6767/temp_landing',
        'set-cookie': [Object],
        date: 'Fri, 23 Oct 2015 08:38:55 GMT',
        connection: 'close',
        'transfer-encoding': 'chunked' },
     uri: 'http://localhost:6767/temp_landing' } }
{ request: 
   { debugId: 1,
     uri: 'http://localhost:6767/temp_landing',
     method: 'GET',
     headers: 
      { cookie: 'foo=bar; ham=eggs',
-        referer: 'http://localhost:6767/temp_landing',
+        referer: 'http://localhost:6767/temp',
        host: 'localhost:6767' } } }
{ response: 
   { debugId: 1,
     headers: 
      { 'x-response': 'GET temp_landing',
        date: 'Fri, 23 Oct 2015 08:38:55 GMT',
        connection: 'close',
        'transfer-encoding': 'chunked' },
     statusCode: 200,
     body: 'GET temp_landing' } }
```

> Referer header should point to the host name of the original resource when redirecting.

Hopefully that's the correct behavior.