### PR TITLE
Remove redundant call to Stream constructor

### DIFF
--- a/request.js
+++ b/request.js
@@ -122,7 +122,6 @@ function Request (options) {
   var reserved = Object.keys(Request.prototype)
   var nonReserved = filterForNonReserved(reserved, options)
 
-  stream.Stream.call(self)
   util._extend(self, nonReserved)
   options = filterOutReservedFunctions(reserved, options)
 


### PR DESCRIPTION
I'm not sure if this is some sort of witchcraft that I'm not familiar with, but I would normally not call the parent constructor twice as it have been done now for about a year since ef4016f.

If this is indeed on purpose I think it's one of those rare occasions that deserves a code-comment explaining it :wink: 