### PR TITLE
Exception fix for malformed urls to url.parse

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -101,7 +101,12 @@ Redirect.prototype.onResponse = function (response) {
   }
 
   var uriPrev = request.uri
-  request.uri = url.parse(redirectTo)
+  
+  try{
+	  request.uri = url.parse(redirectTo)
+  } catch(e) {
+	  return false;
+  }
 
   // handle the case where we change protocol from https to http or vice versa
   if (request.uri.protocol !== uriPrev.protocol) {


### PR DESCRIPTION
I am getting the following exception when calling request(URL,function(err,res,body){});

```
URIError: URI malformed at decodeURIComponent (native) at Url.parse (url.js:185:19) at Object.urlParse [as parse] (url.js:101:5) at Redirect.onResponse (/myproject/node_modules/request/lib/redirect.js:104:21) at Request.onRequestResponse (/myproject/node_modules/request/request.js:944:22) at ClientRequest.emit (events.js:95:17) at HTTPParser.parserOnIncomingClient [as onIncoming] (http.js:1692:21) at HTTPParser.parserOnHeadersComplete [as onHeadersComplete] (http.js:121:23) at Socket.socketOnData [as ondata] (http.js:1587:20) at TCP.onread (net.js:527:27)
```

The URL has multiple redirects.

Unfortunately, I don't know the exact URL, since we are processing 1000s of URLs at a time, and couldn't narrow it down.

Made the follow change to the redirect.js module for line 104:

``` js
try {
    request.uri = url.parse(redirectTo)
} catch(err) {
    return false;
}
```

Fixes #1864
