### PR TITLE
Error on initialization should prevent actual HTTP request from being sent

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "server-destroy": "^1.0.1",
     "tape": "^4.2.0",
     "taper": "^0.4.0",
-    "bluebird": "^3.0.2"
+    "bluebird": "^3.0.2",
+    "tape-catch": "^1.0.4"
   }
 }

--- a/tests/test-bearer-auth.js
+++ b/tests/test-bearer-auth.js
@@ -169,7 +169,7 @@ tape('null bearer', function(t) {
     }
   }, function(error, res, body) {
     t.equal(res.statusCode, 401)
-    t.equal(numBearerRequests, 13)
+    t.equal(numBearerRequests, 12)
     t.end()
   })
 })

--- a/tests/test-pipes.js
+++ b/tests/test-pipes.js
@@ -6,7 +6,7 @@ var server = require('./server')
   , request = require('../index')
   , path = require('path')
   , util = require('util')
-  , tape = require('tape')
+  , tape = require('tape-catch')
 
 var s = server.createServer()
 
@@ -87,6 +87,24 @@ tape('piping to a request object', function(t) {
 
   mydata.emit('data', 'mydata')
   mydata.emit('end')
+})
+
+tape('piping to a request object with invalid uri', function(t) {
+  var mybodydata = new stream.Stream()
+  mybodydata.readable = true
+
+  var r2 = request.put({
+    url: '/bad-uri',
+    json: true
+  }, function(err, res, body) {
+    t.ok(err instanceof Error)
+    t.equal(err.message, 'Invalid URI "/bad-uri"')
+    t.end()
+  })
+  mybodydata.pipe(r2)
+
+  mybodydata.emit('data', JSON.stringify({ foo: 'bar' }))
+  mybodydata.emit('end')
 })
 
 tape('piping to a request object with a json body', function(t) {


### PR DESCRIPTION
Hello

Working on a propitiatory piece of app the other day, I ran into a strange exception happening on nextTick. This exception would complain of **can not call method request of undefined**. When I inspected the problem deeply I understood the problem was that the URI which I passed to **request** did not have any protocol defined, like **/bad-uri** but also the problem seemed to be triggered because a stream was piped to **request** to upload some files to a WebDAV server. I also confirmed that **request** did in fact call my callback with provided exception error but was still trying to make the actual HTTP request regardless. The exception happened because initialization was failed thus leaving **undefined** variables behind but this case of error was never checked in **Request.write** method which was called in nextTick following stream of data from my file. So I tried to fix this problem by:

1. Creating a test case (which needed [tape-catch](https://www.npmjs.com/package/tape-catch) to fail tests creating exceptions on process level)
2. Setting **self._aborted** to **true** on every error inside **request**
3. Checking **self._aborted** in methods **Request.write** and **Request.end**
4. Fixing a test case in **test-bearer-auth** that falsely relied on **request** making HTTP requests regardless of errors in it's initialization

The following is an image showing the stacktrace of exception which I'm talking about:

![image](https://cloud.githubusercontent.com/assets/10746709/10868130/c9bcd85e-807b-11e5-8297-78d6d5a53eaa.png)