### PR TITLE
Fix tunneling after redirection from https

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,8 +799,7 @@ default in Linux can be anywhere from 20-120 seconds][linux-timeout]).
 - `tunnel` - controls the behavior of
   [HTTP `CONNECT` tunneling](https://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_tunneling)
   as follows:
-   - `undefined` (default) - `true` if the destination is `https` or a previous
-     request in the redirect chain used a tunneling proxy, `false` otherwise
+   - `undefined` (default) - `true` if the destination is `https`, `false` otherwise
    - `true` - always tunnel to the destination by making a `CONNECT` request to
      the proxy
    - `false` - request the destination as a `GET` request.

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -135,6 +135,8 @@ Redirect.prototype.onResponse = function (response) {
         // changing ports or protocols).  This matches the behavior of curl:
         // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
         request.removeHeader('authorization')
+        delete request.options.auth
+        delete request.options.oauth
       }
     }
   }
@@ -145,7 +147,7 @@ Redirect.prototype.onResponse = function (response) {
 
   request.emit('redirect')
 
-  request.init()
+  request.init(request.options)
 
   return true
 }

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -113,14 +113,7 @@ function Tunnel (request) {
 
 Tunnel.prototype.isEnabled = function (options) {
   var request = this.request
-  // Tunnel HTTPS by default, or if a previous request in the redirect chain
-  // was tunneled.  Allow the user to override this setting.
-
-  // If self.tunnel is already set (because this is a redirect), use the
-  // existing value.
-  if (typeof request.tunnel !== 'undefined') {
-    return request.tunnel
-  }
+  // Tunnel HTTPS by default. Allow the user to override this setting.
 
   // If options.tunnel is set (the user specified a value), use it.
   if (typeof options.tunnel !== 'undefined') {
@@ -132,10 +125,8 @@ Tunnel.prototype.isEnabled = function (options) {
     return true
   }
 
-  // Otherwise, leave tunnel unset, because if a later request in the redirect
-  // chain is HTTPS then that request (and any subsequent ones) should be
-  // tunneled.
-  return undefined
+  // Otherwise, do not use tunnel.
+  return false
 }
 
 Tunnel.prototype.setup = function (options) {

--- a/request.js
+++ b/request.js
@@ -137,6 +137,7 @@ function Request (options) {
   self._redirect = new Redirect(self)
   self._tunnel = new Tunnel(self)
   self.init(options)
+  self.options = options
 }
 
 util.inherits(Request, stream.Stream)

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -376,7 +376,7 @@ runTest('https->http over http, tunnel=default', {
 }, [
   'http connect to localhost:' + ss.port,
   'https redirect to http',
-  'http connect to localhost:' + s.port,
+  'http proxy to http',
   'http response',
   '200 http ok'
 ])


### PR DESCRIPTION
Current stable module cannot handle https-to-http redirection with proxy properly.

When redirected from https to **http** with `options.tunnel = undefined`,
the **http** request should be proxied without CONNECT tunneling.

This pull-request includes these changes:

1. use `options` again after redirection.
2. fix test case for https-to-http redirection.
3. fix description about `tunnel` option.

This pull-request solves [this problem](https://github.com/atom/apm/issues/322).