### PR TITLE
Update qs dependency to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "json-stringify-safe": "~5.0.1",
     "mime-types": "~2.1.7",
     "node-uuid": "~1.4.3",
-    "qs": "~5.2.0",
+    "qs": "~6.0.0",
     "tunnel-agent": "~0.4.1",
     "tough-cookie": "~2.2.0",
     "http-signature": "~1.0.2",


### PR DESCRIPTION
Update to the latest `qs` version.

Fixes the following error when using the latest version of `qs` in addition to `request`:

```
npm WARN unmet dependency /node_modules/jsdom/node_modules/request requires qs@'~5.2.0' but will load
npm WARN unmet dependency /node_modules/qs,
npm WARN unmet dependency which is version 6.0.0
```