### PR TITLE
Fix tunneling after redirection from https (Original: #1881)

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,8 +799,7 @@ default in Linux can be anywhere from 20-120 seconds][linux-timeout]).
 - `tunnel` - controls the behavior of
   [HTTP `CONNECT` tunneling](https://en.wikipedia.org/wiki/HTTP_tunnel#HTTP_CONNECT_tunneling)
   as follows:
-   - `undefined` (default) - `true` if the destination is `https` or a previous
-     request in the redirect chain used a tunneling proxy, `false` otherwise
+   - `undefined` (default) - `true` if the destination is `https`, `false` otherwise
    - `true` - always tunnel to the destination by making a `CONNECT` request to
      the proxy
    - `false` - request the destination as a `GET` request.

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -111,20 +111,20 @@ function Tunnel (request) {
   this.proxyHeaderExclusiveList = []
 }
 
-Tunnel.prototype.isEnabled = function (options) {
-  var request = this.request
-  // Tunnel HTTPS by default, or if a previous request in the redirect chain
-  // was tunneled.  Allow the user to override this setting.
-
-  // If self.tunnel is already set (because this is a redirect), use the
-  // existing value.
-  if (typeof request.tunnel !== 'undefined') {
-    return request.tunnel
-  }
-
-  // If options.tunnel is set (the user specified a value), use it.
+Tunnel.prototype.init = function (options) {
   if (typeof options.tunnel !== 'undefined') {
-    return options.tunnel
+    this.tunnelOverride = options.tunnel
+  }
+}
+
+Tunnel.prototype.isEnabled = function () {
+  var self = this
+    , request = self.request
+  // Tunnel HTTPS by default. Allow the user to override this setting.
+
+  // If self.tunnelOverride is set (the user specified a value), use it.
+  if (typeof self.tunnelOverride !== 'undefined') {
+    return self.tunnelOverride
   }
 
   // If the destination is HTTPS, tunnel.
@@ -132,10 +132,8 @@ Tunnel.prototype.isEnabled = function (options) {
     return true
   }
 
-  // Otherwise, leave tunnel unset, because if a later request in the redirect
-  // chain is HTTPS then that request (and any subsequent ones) should be
-  // tunneled.
-  return undefined
+  // Otherwise, do not use tunnel.
+  return false
 }
 
 Tunnel.prototype.setup = function (options) {

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -109,11 +109,8 @@ function Tunnel (request) {
   this.request = request
   this.proxyHeaderWhiteList = defaultProxyHeaderWhiteList
   this.proxyHeaderExclusiveList = []
-}
-
-Tunnel.prototype.init = function (options) {
-  if (typeof options.tunnel !== 'undefined') {
-    this.tunnelOverride = options.tunnel
+  if (typeof request.tunnel !== 'undefined') {
+    this.tunnelOverride = request.tunnel
   }
 }
 

--- a/request.js
+++ b/request.js
@@ -288,7 +288,6 @@ Request.prototype.init = function (options) {
     self.proxy = getProxyFromURI(self.uri)
   }
 
-  self._tunnel.init(options)
   self.tunnel = self._tunnel.isEnabled()
   if (self.proxy) {
     self._tunnel.setup(options)

--- a/request.js
+++ b/request.js
@@ -288,7 +288,8 @@ Request.prototype.init = function (options) {
     self.proxy = getProxyFromURI(self.uri)
   }
 
-  self.tunnel = self._tunnel.isEnabled(options)
+  self._tunnel.init(options)
+  self.tunnel = self._tunnel.isEnabled()
   if (self.proxy) {
     self._tunnel.setup(options)
   }

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -376,7 +376,7 @@ runTest('https->http over http, tunnel=default', {
 }, [
   'http connect to localhost:' + ss.port,
   'https redirect to http',
-  'http connect to localhost:' + s.port,
+  'http proxy to http',
   'http response',
   '200 http ok'
 ])


### PR DESCRIPTION
Current stable module cannot handle https-to-http redirection with proxy properly.

When redirected from https to **http** with `options.tunnel = undefined`,
the **http** request should be proxied without CONNECT tunneling.

This pull-request includes these changes:

1. use initial `options.tunnel` again after redirection.
2. fix test case for https-to-http redirection.
3. fix description about `tunnel` option.

Closes #1881