### PR TITLE
Convert typed arrays into regular buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "stringstream": "~0.0.4",
     "combined-stream": "~1.0.5",
     "isstream": "~0.1.2",
+    "is-typedarray": "~1.0.0",
     "har-validator": "~2.0.2"
   },
   "scripts": {

--- a/request.js
+++ b/request.js
@@ -15,6 +15,7 @@ var http = require('http')
   , caseless = require('caseless')
   , ForeverAgent = require('forever-agent')
   , FormData = require('form-data')
+  , isTypedArray = require('is-typedarray').strict
   , helpers = require('./lib/helpers')
   , cookies = require('./lib/cookies')
   , getProxyFromURI = require('./lib/getProxyFromURI')
@@ -427,6 +428,10 @@ Request.prototype.init = function (options) {
   }
 
   function setContentLength () {
+    if (isTypedArray(self.body)) {
+      self.body = new Buffer(self.body)
+    }
+
     if (!self.hasHeader('content-length')) {
       var length
       if (typeof self.body === 'string') {

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -3,6 +3,7 @@
 var server = require('./server')
   , request = require('../index')
   , tape = require('tape')
+  , http = require('http')
 
 var s = server.createServer()
 
@@ -142,6 +143,25 @@ addTest('testPutMultipartPostambleCRLF', {
     [ {'content-type': 'text/html', 'body': '<html><body>Oh hi.</body></html>'}
     , {'body': 'Oh hi.'}
     ]
+})
+
+tape('typed array', function (t) {
+  var server = http.createServer()
+  server.on('request', function (req, res) {
+    req.pipe(res)
+  })
+  server.listen(6768, function () {
+    var data = new Uint8Array([1, 2, 3])
+    request({
+      uri: 'http://localhost:6768',
+      method: 'POST',
+      body: data,
+      encoding: null
+    }, function (err, res, body) {
+      t.deepEqual(new Buffer(data), body)
+      server.close(t.end)
+    })
+  })
 })
 
 tape('cleanup', function(t) {


### PR DESCRIPTION
Fixes #1904 

This bug was introduced in #1733 regarding this issue #1732

Bringing back the code that was removed in #1733. Converting to Buffer happens only when the body is a typed array. That way this won't affect the performance fix for #1732

One additional dependency was needed [is-typedarray](https://www.npmjs.com/package/is-typedarray)