### PR TITLE
Remove content-length and transfer-encoding headers from defaultProxyHeaderWhiteList

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -12,7 +12,6 @@ var defaultProxyHeaderWhiteList = [
   'cache-control',
   'content-encoding',
   'content-language',
-  'content-length',
   'content-location',
   'content-md5',
   'content-range',
@@ -24,7 +23,6 @@ var defaultProxyHeaderWhiteList = [
   'pragma',
   'referer',
   'te',
-  'transfer-encoding',
   'user-agent',
   'via'
 ]


### PR DESCRIPTION
Fixes https://github.com/request/request/issues/1886

This change is to address the issue https://github.com/request/request/issues/1886