### PR TITLE
Check if the functions exist before executing

### DIFF
--- a/request.js
+++ b/request.js
@@ -839,7 +839,7 @@ Request.prototype.onRequestResponse = function (response) {
   }
   if (self._aborted) {
     debug('aborted', self.uri.href)
-    response.resume()
+    if(typeof response.resume == 'function') response.resume();
     return
   }
 
@@ -1040,7 +1040,7 @@ Request.prototype.abort = function () {
   var self = this
   self._aborted = true
 
-  if (self.req) {
+  if (self.req && typeof self.req.abort == 'function') {
     self.req.abort()
   }
   else if (self.response) {


### PR DESCRIPTION
Sometimes you get the error self.req.abort/response.resume is not a function. To prevent the error first check if the function exists.
