### PR TITLE
Check form-data content-length value before setting up the header

### DIFF
--- a/request.js
+++ b/request.js
@@ -579,7 +579,7 @@ Request.prototype.init = function (options) {
       // Before ending the request, we had to compute the length of the whole form, asyncly
       self.setHeader(self._form.getHeaders(), true)
       self._form.getLength(function (err, length) {
-        if (!err) {
+        if (!err && !isNaN(length)) {
           self.setHeader('content-length', length)
         }
         end()


### PR DESCRIPTION
When creating a POST request with form data where the contents of the form data comes from http.IncomingMessage stream from another HTTP response, sometimes the length of the request cannot be calculated.  One case is when the IncomingMessage is a chunked response.  Then the form-data module cannot calculate the length until the stream is fully read, and it returns NaN in getLength() callback.  The header Content-Length should not be set in such situation, otherwise the remote server returns with 400.

Ran into this problem a lot while processing the responses from google drive servers as they tend to send chunked response.
