### PR TITLE
Use isstream for more robust stream.Readable detection

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,7 +1,9 @@
 'use strict'
 
 var jsonSafeStringify = require('json-stringify-safe')
+  , isReadable = require('isstream').isReadable
   , crypto = require('crypto')
+  , http = require('http')
 
 function deferMethod() {
   if (typeof setImmediate === 'undefined') {
@@ -38,8 +40,8 @@ function md5 (str) {
   return crypto.createHash('md5').update(str).digest('hex')
 }
 
-function isReadStream (rs) {
-  return rs.readable && rs.path && rs.mode
+function isReadStream (obj) {
+  return isReadable(obj) && !(obj instanceof http.IncomingMessage)
 }
 
 function toBase64 (str) {


### PR DESCRIPTION
See https://github.com/request/request/issues/1949 for the original issue description.

In short, `helpers.isReadStream` is overly restrictive in what it deems to be a readable stream. Specifically, only streams created via `fs` that stream file data from disk pass the test of this function. However, it is entirely valid to have a non `fs` stream that contains valid file data (e.g. streams generated from file data contained in `multipart/form-data` requests.

This pull request updates `helpers.isReadStream` to use the `.Readable` method contained within the existing dependency `isstream`. However, `isstream.isReadable` on its own is not restrictive enough to detect the kinds of readable streams that `request` needs to detect, as the `http.IncomingMessage` and its sub-classes are also readable streams, yet they need to be rejected by our test.

So, the combination of `isstream.isReadable` and `instanceof http.IncomingMessage` should be sufficient to successfully detect non http readable streams that may contain file data.