### PR TITLE
Improve proxy support

### DIFF
--- a/lib/getProxyFromURI.js
+++ b/lib/getProxyFromURI.js
@@ -37,12 +37,12 @@ function uriInNoProxy(uri, noProxy) {
   })
 }
 
-function getProxyFromURI(uri) {
+function getProxyFromURI(uri, httpProxy, httpsProxy, noProxy) {
   // Decide the proper request proxy to use based on the request URI object and the
   // environmental variables (NO_PROXY, HTTP_PROXY, etc.)
   // respect NO_PROXY environment variables (see: http://lynx.isc.org/current/breakout/lynx_help/keystrokes/environments.html)
 
-  var noProxy = process.env.NO_PROXY || process.env.no_proxy || ''
+  noProxy = noProxy || process.env.NO_PROXY || process.env.no_proxy || ''
 
   // if the noProxy is a wildcard then return null
 
@@ -59,13 +59,16 @@ function getProxyFromURI(uri) {
   // Check for HTTP or HTTPS Proxy in environment Else default to null
 
   if (uri.protocol === 'http:') {
-    return process.env.HTTP_PROXY ||
+    return httpProxy ||
+           process.env.HTTP_PROXY ||
            process.env.http_proxy || null
   }
 
   if (uri.protocol === 'https:') {
-    return process.env.HTTPS_PROXY ||
+    return httpsProxy ||
+           process.env.HTTPS_PROXY ||
            process.env.https_proxy ||
+           httpProxy ||
            process.env.HTTP_PROXY  ||
            process.env.http_proxy  || null
   }

--- a/request.js
+++ b/request.js
@@ -286,8 +286,8 @@ Request.prototype.init = function (options) {
     return self.emit('error', new Error(message))
   }
 
-  if (!self.hasOwnProperty('proxy')) {
-    self.proxy = getProxyFromURI(self.uri)
+  if (!self.hasOwnProperty('proxy')) { 
+    self.proxy = getProxyFromURI(self.uri, self.httpProxy, self.httpsProxy, self.noProxy)
   }
 
   self.tunnel = self._tunnel.isEnabled()


### PR DESCRIPTION
Currently there's no option to pass NO_PROXY setting with the request options. The NO_PROXY setting is read from the env variables ONLY if no proxy is set in options. 

This pull request adds the options `httpProxy`, `httpsProxy`, `noProxy` while keeping the existing "proxy" for backward compatibility.

This way it is possible to do:

```
var r = request.defaults({'httpProxy':'http://localproxy.com', 'noProxy': 'artifactory'})
```

Modules like bower-art-resolver are unable to be properly implemented because of this limitation:
https://github.com/JFrogDev/bower-art-resolver/issues/9
