### PR TITLE
Fix remote memory disclosure with multipart attachments

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -68,6 +68,9 @@ Multipart.prototype.build = function (parts, chunked) {
   var body = chunked ? new CombinedStream() : []
 
   function add (part) {
+    if (typeof part === 'number') {
+      part = part.toString()
+    }
     return chunked ? body.append(part) : body.push(new Buffer(part))
   }
 


### PR DESCRIPTION
If the node process makes a request with a multipart attachment, and the type of the `body` option is a `Number`, then that many bytes of uninitialized memory will be sent in the body of the request. Here's an example:

```js
request({
  method: 'POST',
  uri: 'http://localhost:8000',
  multipart: [{ body: 1000 }]
}
```

And here's a more complete reproducible example:

```js
var http = require('http')
var request = require('request')

http.createServer(function (req, res) {
  var data = ''
  req.setEncoding('utf8')
  req.on('data', function (chunk) {
    console.log('data')
    data += chunk
  })
  req.on('end', function () {
    // this will print uninitialized memory from the client
    console.log('Client sent:\n', data)
  })
  res.end()
}).listen(8000)

request({
  method: 'POST',
  uri: 'http://localhost:8000',
  multipart: [{ body: 1000 }]
},
function (err, res, body) {
  if (err) return console.error('upload failed:', err)
  console.log('sent')
})
```

This PR fixes the issue by coercing the type of the `body` option to a string. (An alternate solution would be to throw an exception in this case.)

Further reading:

- https://github.com/nodejs/node/issues/4660
- https://github.com/nodejs/node-eps/pull/4