### PR TITLE
declare the character set used in the body for x-www-form-urlencoded post

### DIFF
--- a/request.js
+++ b/request.js
@@ -1123,7 +1123,7 @@ Request.prototype.form = function (form) {
   var self = this
   if (form) {
     if (!/^application\/x-www-form-urlencoded\b/.test(self.getHeader('content-type'))) {
-      self.setHeader('content-type', 'application/x-www-form-urlencoded')
+      self.setHeader('content-type', 'application/x-www-form-urlencoded; charset=UTF-8')
     }
     self.body = (typeof form === 'string')
       ? self._qs.rfc3986(form.toString('utf8'))
@@ -1229,10 +1229,10 @@ Request.prototype.aws = function (opts, now) {
     self._aws = opts
     return self
   }
-  
+
   if (opts.sign_version == 4 || opts.sign_version == '4') {
     var aws4 = require('aws4')
-    // use aws4  
+    // use aws4
     var options = {
       host: self.uri.host,
       path: self.uri.path,

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -41,7 +41,7 @@ tape('setup', function(t) {
       })
       assert.equal(req.method, 'POST')
       assert.equal(req.headers['content-length'], '' + expectedContent.length)
-      assert.equal(req.headers['content-type'], 'application/x-www-form-urlencoded')
+      assert.equal(req.headers['content-type'], 'application/x-www-form-urlencoded; charset=UTF-8')
     }
 
     if (ok) {

--- a/tests/test-bearer-auth.js
+++ b/tests/test-bearer-auth.js
@@ -35,7 +35,7 @@ tape('setup', function(t) {
       })
       assert.equal(req.method, 'POST')
       assert.equal(req.headers['content-length'], '' + expectedContent.length)
-      assert.equal(req.headers['content-type'], 'application/x-www-form-urlencoded')
+      assert.equal(req.headers['content-type'], 'application/x-www-form-urlencoded; charset=UTF-8')
     }
 
     if (ok) {

--- a/tests/test-form-urlencoded.js
+++ b/tests/test-form-urlencoded.js
@@ -10,9 +10,9 @@ function runTest (t, options, index) {
   var server = http.createServer(function(req, res) {
 
     if (index === 0 || index === 3) {
-      t.equal(req.headers['content-type'], 'application/x-www-form-urlencoded')
-    } else {
       t.equal(req.headers['content-type'], 'application/x-www-form-urlencoded; charset=UTF-8')
+    } else {
+      t.equal(req.headers['content-type'], 'application/x-www-form-urlencoded; charset=GBK')
     }
     t.equal(req.headers['content-length'], '21')
     t.equal(req.headers.accept, 'application/json')
@@ -54,12 +54,12 @@ var cases = [
     json: true
   },
   {
-    headers: {'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+    headers: {'content-type': 'application/x-www-form-urlencoded; charset=GBK'},
     form: {some: 'url', encoded: 'data'},
     json: true
   },
   {
-    headers: {'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'},
+    headers: {'content-type': 'application/x-www-form-urlencoded; charset=GBK'},
     body: 'some=url&encoded=data',
     json: true
   },


### PR DESCRIPTION
Declare the character set used in the body for x-www-form-urlencoded post (basic form request) . It could help the server side , especially for which default charset is not utf8, decoding the request body. Otherwise the server will use it's default charset decode our utf8 encoded body.
