### PR TITLE
Cancel timeout on aborted requests

### DIFF
--- a/request.js
+++ b/request.js
@@ -1041,6 +1041,11 @@ Request.prototype.abort = function () {
   var self = this
   self._aborted = true
 
+  if (self.timeout && self.timeoutTimer) {
+    clearTimeout(self.timeoutTimer)
+    self.timeoutTimer = null
+  }
+
   if (self.req) {
     self.req.abort()
   }
@@ -1229,10 +1234,10 @@ Request.prototype.aws = function (opts, now) {
     self._aws = opts
     return self
   }
-  
+
   if (opts.sign_version == 4 || opts.sign_version == '4') {
     var aws4 = require('aws4')
-    // use aws4  
+    // use aws4
     var options = {
       host: self.uri.host,
       path: self.uri.path,

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -138,6 +138,19 @@ if (process.env.TRAVIS === 'true') {
     })
   })
 
+  tape('abort', function (t) {
+    var shouldTimeout = {
+      url: s.url + '/timeout',
+      timeout: 10000
+    }
+
+    var req = request(shouldTimeout)
+    // This timer should be cleared:
+    req.timeoutTimer = setTimeout(t.end, 100)
+    req.abort()
+    t.end()
+  })
+
   tape('cleanup', function(t) {
     s.close(function() {
       t.end()


### PR DESCRIPTION
Fixes #2025

When a request with a `timeout` is aborted, the setTimeout needs to be cleared as well. Please let me know if I didn't think of anything, or otherwise didn't make a satisfactory PR!