### PR TITLE
Update vulnerabilities in deps badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build status](https://img.shields.io/travis/request/request.svg?style=flat-square)](https://travis-ci.org/request/request)
 [![Coverage](https://img.shields.io/codecov/c/github/request/request.svg?style=flat-square)](https://codecov.io/github/request/request?branch=master)
 [![Coverage](https://img.shields.io/coveralls/request/request.svg?style=flat-square)](https://coveralls.io/r/request/request)
-[![Dependency Status](https://img.shields.io/david/request/request.svg?style=flat-square)](https://david-dm.org/request/request)
+[![Known Vulnerabilities](https://snyk.io/test/npm/request/badge.svg?style=flat-square)](https://snyk.io/test/npm/request)
 [![Gitter](https://img.shields.io/badge/gitter-join_chat-blue.svg?style=flat-square)](https://gitter.im/request/request?utm_source=badge)
 
 


### PR DESCRIPTION
The badge that was being used was *incorrectly* showing that request held vulns in it's (production) dependencies, but this is wrong. 

Request uses hawk, which _had_ a vuln, but has been patched and released in 3.1.3 (and is [vuln free](https://snyk.io/test/npm/hawk/3) in the 3.x branch), and the semver range for hawk in the `package.json` is `~3.1.0` - so 3.1.3 is going to be installed.

Disclosure: I've been working on snyk since mid-last year, but I've been relying on request for even longer and I didn't want it be wrongly represented as vulnerable 💙