### PR TITLE
trimming the headers to avoid crash on node v5

### DIFF
--- a/request.js
+++ b/request.js
@@ -1080,7 +1080,7 @@ Request.prototype.pipeDest = function (dest) {
       // If the response content is being decoded, the Content-Encoding header
       // of the response doesn't represent the piped content, so don't pass it.
       if (!self.gzip || i !== 'content-encoding') {
-        dest.setHeader(i, response.headers[i])
+        dest.setHeader(i.trim(), response.headers[i])
       }
     }
     dest.statusCode = response.statusCode

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -162,6 +162,22 @@ tape('undefined headers', function(t) {
   })
 })
 
+tape('headers ending and starting with spaces', function(t) {
+  request({
+    url: s.url + '/headers.json',
+    headers: {
+      'X-TEST-1 ': 'test1',
+      ' X-TEST-2': 'test2'
+    },
+    json: true
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(body['x-test-1'], 'test1')
+    t.equal(body['x-test-2'], 'test2')
+    t.end()
+  })
+})
+
 tape('cleanup', function(t) {
   s.close(function() {
     t.end()


### PR DESCRIPTION
when doing very simple piping of websites that return headers of this type:

```
Authorization :

// instead of

Authorization:
```

Node v5.0 returns a `TypeError` (see https://github.com/linkeddata/ldnode/issues/240)

Here is the error:

```
TypeError: Header name must be a valid HTTP Token ["access-control-allow-origin "]
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:339:11)
        at Request.pipeDest (/Users/dmitri/code/_Solid/ldnode/node_modules/request/request.js:1082:14)
            at /Users/dmitri/code/_Solid/ldnode/node_modules/request/request.js:954:12
                at Array.forEach (native)
                    at Request.onRequestResponse (/Users/dmitri/code/_Solid/ldnode/node_modules/request/request.js:953:16)
                        at emitOne (events.js:77:13)
                            at ClientRequest.emit (events.js:169:7)
                                at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:421:21)
                                    at HTTPParser.parserOnHeadersComplete (_http_common.js:88:23)
                                        at Socket.socketOnData (_http_client.js:311:20)
```

I have added the fix and the test, that is basically trimming the header key
