### PR TITLE
Proposal to allow setting of timeout with env var

### DIFF
--- a/request.js
+++ b/request.js
@@ -128,6 +128,10 @@ function Request (options) {
   extend(self, nonReserved)
   options = filterOutReservedFunctions(reserved, options)
 
+  if (parseFloat(process.env.REQUEST_TIMEOUT) > 0) {
+    self.timeout = parseFloat(process.env.REQUEST_TIMEOUT)
+  }
+
   self.readable = true
   self.writable = true
   if (options.method) {

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -98,6 +98,52 @@ if (process.env.TRAVIS === 'true') {
     })
   })
 
+  tape('generous process.env.REQUEST_TIMEOUT', function(t) {
+    process.env.REQUEST_TIMEOUT = 2000
+
+    var noTimeoutInOptions = {
+      url: s.url + '/timeout'
+    }
+
+    request(noTimeoutInOptions, function(err, res, body) {
+      t.equal(err, null)
+      t.equal(body, 'waited')
+      t.end()
+      process.env.REQUEST_TIMEOUT = null
+    })
+  })
+
+  tape('ambitious process.env.REQUEST_TIMEOUT', function(t) {
+    process.env.REQUEST_TIMEOUT = 100
+
+    var noTimeoutInOptions = {
+      url: s.url + '/timeout'
+    }
+
+    request(noTimeoutInOptions, function(err, res, body) {
+      checkErrCode(t, err)
+      t.end()
+
+      process.env.REQUEST_TIMEOUT = null
+    })
+  })
+
+  tape('process.env.REQUEST_TIMEOUT overwrites timeout options', function(t) {
+    process.env.REQUEST_TIMEOUT = 100
+
+    var shouldntTimeoutButWillBecauseOfEnv = {
+      url: s.url + '/timeout',
+      timeout: 1200
+    }
+
+    request(shouldntTimeoutButWillBecauseOfEnv, function(err, res, body) {
+      checkErrCode(t, err)
+      t.end()
+
+      process.env.REQUEST_TIMEOUT = null
+    })
+  })
+
   tape('negative timeout', function(t) { // should be treated a zero or the minimum delay
     var negativeTimeout = {
       url: s.url + '/timeout',


### PR DESCRIPTION
When I start work with an unfamiliar open source project I try to make sure the tests pass. Some of these projects use request. Sometimes, the connection or requests their tests make timeout. It would be nice if I could get the tests to pass without modifying any of the code of a build that passes in other contexts. Being able to set a different timeout across all the calls made with request is one way that I can work around exceptional latency, without changing the requirements of the open source project under test.

I am curious as to your own approach for debugging this. Sometimes unfamiliar open source projects layer abstractions on top of request. It can be difficult to find where to provide an alternate timeout value.