### PR TITLE
Add store accessor to the RequestJar.

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -20,6 +20,7 @@ exports.parse = function(str) {
 function RequestJar(store) {
   var self = this
   self._jar = new CookieJar(store, {looseMode: true})
+  self.store = self._jar.store
 }
 RequestJar.prototype.setCookie = function(cookieOrStr, uri, options) {
   var self = this


### PR DESCRIPTION
With this patch, you can remove or find cookies from the store like this.

``` javascript
var FileCookieStore = require('tough-cookie-filestore');
var jar = request.jar(new FileCookieStore(__dirname + '/data/cookies.json'));

jar.store.removeCookie('foo.com', '/', 'foo', function (err) {
    ...
});

jar.store.removeCookies('example.com', null, function (err) {
    ...
});

jar.store.findCookies('example.com', null, function (err, cookies) {
    ...
});

```
