### PR TITLE
Reduce npm payload size by updating .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,7 @@ node_modules
 examples
 release.sh
 disabled.appveyor.yml
+.eslintrc
+.npmignore
+.travis.yml
+CONTRIBUTING.md

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 coverage
 tests
-node_modules
 examples
 release.sh
 disabled.appveyor.yml


### PR DESCRIPTION
Thanks for creating a module I used every day! I'm trying to give back in whatever little way I can.

The npm payload delivered from `npm install request` contains a few files which are not needed for the module to actually work, so I added these things to the `.npmignore` file. Here is the data for your package before and after this change:

|  | Including deps | Excluding deps |
| :-: | :-: | :-: |
| Current | 5,136 KB | 276 KB |
| Updated | 5,120 KB | 260 KB |
| **Savings** | **0.31%** | **5.80%** |

_I got these numbers using `du -shk <directory>`_

The difference between the "Including / Excluding deps" columns is whether or not the `node_modules/` directory containing `request`'s dependencies is included.

[According to `request`'s npmjs.com page](https://www.npmjs.com/package/request), `request` has been downloaded 588,799 times in the last day. At 276 KB per download (ignoring `request`'s dependencies), that is 162.5 GB per day for this module alone! With this change, that number drops by 5.80% to 153.1 GB.

In case you want to double check the resulting package, you can do so locally:

```
# Create a tarball of the resulting package
$ npm pack

# See the file list of that tarball
$ tar -tf request-<version>.tgz
package/package.json
package/README.md
package/LICENSE
package/index.js
package/request.js
package/CHANGELOG.md
package/lib/auth.js
package/lib/cookies.js
package/lib/getProxyFromURI.js
package/lib/har.js
package/lib/helpers.js
package/lib/multipart.js
package/lib/oauth.js
package/lib/querystring.js
package/lib/redirect.js
package/lib/tunnel.js

# Install the tarball as a local node module
$ npm install request-<version>.tgz
```
