### PR TITLE
Honour RFC 1945 & RFC 2048

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -114,14 +114,16 @@ Redirect.prototype.onResponse = function (response) {
     }
   )
   if (self.followAllRedirects && request.method !== 'HEAD'
-    && response.statusCode !== 401 && response.statusCode !== 307) {
+    && response.statusCode !== 401 && response.statusCode !== 307
+    && response.statusCode !== 302 && response.statusCode !== 301) {
     request.method = 'GET'
   }
   // request.method = 'GET' // Force all redirects to use GET || commented out fixes #215
   delete request.src
   delete request.req
   delete request._started
-  if (response.statusCode !== 401 && response.statusCode !== 307) {
+  if (response.statusCode !== 401 && response.statusCode !== 307
+    && response.statusCode !== 301 && response.statusCode !== 302) {
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.
     delete request.body


### PR DESCRIPTION
RFC 1945 & RFC 2048 state that upon a 301 or 302 redirect, user agents should not automatically change the request method to GET:

> Note: When automatically redirecting a POST request after
>        receiving a 301 status code, some existing user agents will
>        erroneously change it into a GET request.

(There is a relevant note for the 302 redirection as well)
https://tools.ietf.org/html/rfc1945#section-9.3

This relates to #2060 
