### PR TITLE
Add 'delete' alias for the 'del' API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -888,6 +888,14 @@ Same as `request()`, but defaults to `method: "HEAD"`.
 request.head(url)
 ```
 
+### request.delete
+
+Same as `request()`, but defaults to `method: "DELETE"`.
+
+```js
+request.delete(url)
+```
+
 ### request.del
 
 Same as `request()`, but defaults to `method: "DELETE"`.

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function request (uri, options, callback) {
 }
 
 function verbFunc (verb) {
-  var method = verb === 'del' ? 'DELETE' : verb.toUpperCase()
+  var method = verb.toUpperCase()
   return function (uri, options, callback) {
     var params = initParams(uri, options, callback)
     params.method = method
@@ -70,7 +70,7 @@ request.head = verbFunc('head')
 request.post = verbFunc('post')
 request.put = verbFunc('put')
 request.patch = verbFunc('patch')
-request.del = verbFunc('del')
+request.del = request.delete = verbFunc('delete')
 
 request.jar = function (store) {
   return cookies.jar(store)
@@ -91,7 +91,7 @@ function wrapRequestMethod (method, options, requester, verb) {
     target.pool = params.pool || options.pool
 
     if (verb) {
-      target.method = (verb === 'del' ? 'DELETE' : verb.toUpperCase())
+      target.method = verb.toUpperCase()
     }
 
     if (isFunction(requester)) {
@@ -114,7 +114,7 @@ request.defaults = function (options, requester) {
 
   var defaults      = wrapRequestMethod(self, options, requester)
 
-  var verbs = ['get', 'head', 'post', 'put', 'patch', 'del']
+  var verbs = ['get', 'head', 'post', 'put', 'patch', 'del', 'delete']
   verbs.forEach(function(verb) {
     defaults[verb]  = wrapRequestMethod(self[verb], options, requester, verb)
   })

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -138,6 +138,17 @@ tape('del(string, function)', function(t) {
   })
 })
 
+tape('delete(string, function)', function(t) {
+  request.defaults({
+    headers: {foo: 'bar'},
+    json: true
+  }).delete(s.url + '/', function (e, r, b) {
+    t.equal(b.method, 'DELETE')
+    t.equal(b.headers.foo, 'bar')
+    t.end()
+  })
+})
+
 tape('head(object, function)', function(t) {
   request.defaults({
     headers: { foo: 'bar' }


### PR DESCRIPTION
Only Using 'del' seems to be a little bit opinionated if there is no 'delete' method provided together; and 'del' also introduced redundant ternary assignment. Thanks!

Fixes #1917