### PR TITLE
Support for aws service name

### DIFF
--- a/request.js
+++ b/request.js
@@ -1272,6 +1272,7 @@ Request.prototype.aws = function (opts, now) {
       host: self.uri.host,
       path: self.uri.path,
       method: self.method,
+      service: self.service,
       headers: {
         'content-type': self.getHeader('content-type') || ''
       },


### PR DESCRIPTION
There is a problem when using sigv4 to sign requests for URL endpoints that are not the traditional Amazon endpoint. The `aws4` library that works in conjunction with this module, will introspect the host url to determine the `service` and the `region`. Unfortunately, if you use DNS entries to provide your user with a more traditional API endpoint, the service name (and the region) are no longer deterministic.

Consider the same endpoint in two different formats
1. https://ye4r9923df.execute-api.us-west-2.amazonaws.com/test
2. https://myapi.example.org

The second host name has been configured via Cloudfront to direct to the API Gateway endpoint shown in the first example. However, a request signed and executed against URL 1 will succeed, while a request against URL 2 will fail with this exception.

```
Error: Credential should be scoped to correct service: 'execute-api'. 
```

If the aws property on the request is modified to accept a `service` property, and this property is passed through to `aws4`, the request will succeed. It may even be useful to allow a region to be specified in the same way. 

It is unfortunate that AWS is forcing clients to know something as extraneous as a service name in order to invoke a general API endpoint.
