### PR TITLE
Use server-destory to close hanging sockets

### DIFF
--- a/tests/test-httpModule.js
+++ b/tests/test-httpModule.js
@@ -2,6 +2,7 @@
 
 var http = require('http')
   , https = require('https')
+  , destroyable = require('server-destroy')
   , server = require('./server')
   , request = require('../index')
   , tape = require('tape')
@@ -35,6 +36,9 @@ var faux_http = wrap_request('http', http)
   , faux_https = wrap_request('https', https)
   , plain_server = server.createServer()
   , https_server = server.createSSLServer()
+
+destroyable(plain_server)
+destroyable(https_server)
 
 tape('setup', function(t) {
   plain_server.listen(plain_server.port, function() {
@@ -100,8 +104,8 @@ run_tests('https only', { 'https:': faux_https })
 run_tests('http and https', { 'http:': faux_http, 'https:': faux_https })
 
 tape('cleanup', function(t) {
-  plain_server.close(function() {
-    https_server.close(function() {
+  plain_server.destroy(function() {
+    https_server.destroy(function() {
       t.end()
     })
   })

--- a/tests/test-redirect-auth.js
+++ b/tests/test-redirect-auth.js
@@ -4,9 +4,13 @@ var server = require('./server')
   , request = require('../index')
   , util = require('util')
   , tape = require('tape')
+  , destroyable = require('server-destroy')
 
 var s = server.createServer()
   , ss = server.createSSLServer()
+
+destroyable(s)
+destroyable(ss)
 
 // always send basic auth and allow non-strict SSL
 request = request.defaults({
@@ -117,8 +121,8 @@ runTest('different host and protocol',
   false)
 
 tape('cleanup', function(t) {
-  s.close(function() {
-    ss.close(function() {
+  s.destroy(function() {
+    ss.destroy(function() {
       t.end()
     })
   })

--- a/tests/test-redirect-complex.js
+++ b/tests/test-redirect-complex.js
@@ -4,10 +4,14 @@ var server = require('./server')
   , request = require('../index')
   , events = require('events')
   , tape = require('tape')
+  , destroyable = require('server-destroy')
 
 var s = server.createServer()
   , ss = server.createSSLServer()
   , e = new events.EventEmitter()
+
+destroyable(s)
+destroyable(ss)
 
 function bouncy(s, serverUrl) {
   var redirs = { a: 'b'
@@ -79,8 +83,8 @@ tape('lots of redirects', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close(function() {
-    ss.close(function() {
+  s.destroy(function() {
+    ss.destroy(function() {
       t.end()
     })
   })

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -5,11 +5,15 @@ var server = require('./server')
   , request = require('../index')
   , tape = require('tape')
   , http = require('http')
+  , destroyable = require('server-destroy')
 
 var s = server.createServer()
   , ss = server.createSSLServer()
   , hits = {}
   , jar = request.jar()
+
+destroyable(s)
+destroyable(ss)
 
 s.on('/ssl', function(req, res) {
   res.writeHead(302, {
@@ -419,8 +423,8 @@ tape('should use same agent class on redirect', function(t) {
 })
 
 tape('cleanup', function(t) {
-  s.close(function() {
-    ss.close(function() {
+  s.destroy(function() {
+    ss.destroy(function() {
       t.end()
     })
   })


### PR DESCRIPTION
when running the coverage report (in single process)