### PR TITLE
Update to form-data RC4 and pass null values to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "combined-stream": "~1.0.5",
     "extend": "~3.0.0",
     "forever-agent": "~0.6.1",
-    "form-data": "~1.0.0-rc3",
+    "form-data": "~1.0.0-rc4",
     "har-validator": "~2.0.6",
     "hawk": "~3.1.3",
     "http-signature": "~1.1.0",

--- a/request.js
+++ b/request.js
@@ -336,7 +336,7 @@ Request.prototype.init = function (options) {
     var formData = options.formData
     var requestForm = self.form()
     var appendFormValue = function (key, value) {
-      if (value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
+      if (value && value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
         requestForm.append(key, value.value, value.options)
       } else {
         requestForm.append(key, value)

--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -65,6 +65,20 @@ tape('omit content-length header if the value is set to NaN', function(t) {
   })
 })
 
+// TODO: remove this test after form-data@2.0 starts stringifying null values
+tape('form-data should throw on null value', function (t) {
+  t.throws(function () {
+    request({
+      method: 'POST',
+      url: 'http://localhost:6767',
+      formData: {
+        key: null
+      }
+    })
+  }, /Cannot read property 'path' of null/)
+  t.end()
+})
+
 tape('cleanup', function(t) {
   s.close(function() {
     t.end()


### PR DESCRIPTION
Closes https://github.com/request/request/pull/2160
Closes https://github.com/request/request/issues/1832

This is a temporary solution until form-data@2.0 starts stringifying null values. See https://github.com/form-data/form-data/issues/147