### PR TITLE
Avoid leaking callback functions when Agent pools with keepAlive=true

### DIFF
--- a/request.js
+++ b/request.js
@@ -748,6 +748,20 @@ Request.prototype.start = function () {
   var reqOptions = copy(self)
   delete reqOptions.auth
 
+  // Remove a bunch of attributes that are not used by the request API to avoid leaks.
+  // The leaks will happen when an Agent pool is used, for keepAlive=true requests,
+  // and without removing these attributes references to the callback function will stay
+  // in memory for each socket that is kept in the pool
+  delete reqOptions._callback
+  delete reqOptions.callback
+  delete reqOptions._events
+  delete reqOptions._multipart
+  delete reqOptions._qs
+  delete reqOptions._tunnel
+  delete reqOptions._auth
+  delete reqOptions._oauth
+  delete reqOptions._redirect
+
   debug('make request', self.uri.href)
 
   try {


### PR DESCRIPTION
While analyzing some heapdumps I noticed that some callback functions (and all of their closure data) were being kept in memory longer than I expected.  It turns out that if request uses an Agent pool, and the pool keeps sockets around for keepAlive, then the memory is held until the initial connection is closed.  

The most obvious leak is the `callback` and `_callback` references.  The agent pool holds onto references to the connection options, and if the callback is in the options it will stay in memory until the socket is removed from the pool.  The other options I removed hold less direct references back to the callbacks.

I've put a testcase up here: https://gist.github.com/mdlavin/97b4e6755c18cdb8305681fbb6433ac0.  Without the fix below, the output looks like this:

```
leak changes [ { what: 'LeakingClass',
    size_bytes: 240,
    size: '240 bytes',
    '+': 10,
    '-': 0 } ]
leak changes []
```

Showing that the LeakingClass gets created and never removed from memory.  With the fix, the testcase outputs:

```
leak changes [ { what: 'LeakingClass',
    size_bytes: 240,
    size: '240 bytes',
    '+': 10,
    '-': 0 } ]
leak changes [ { what: 'LeakingClass',
    size_bytes: -240,
    size: '-240 bytes',
    '+': 0,
    '-': 10 } ]
```

Showing that the LeakingClass is created and then released from memory.
