### PR TITLE
Remove connectionErrorHandler to fix #1903

### DIFF
--- a/request.js
+++ b/request.js
@@ -71,20 +71,6 @@ function filterOutReservedFunctions(reserved, options) {
 
 }
 
-// Function for properly handling a connection error
-function connectionErrorHandler(error) {
-  var socket = this
-  if (socket.res) {
-    if (socket.res.request) {
-      socket.res.request.emit('error', error)
-    } else {
-      socket.res.emit('error', error)
-    }
-  } else {
-    socket._httpMessage.emit('error', error)
-  }
-}
-
 // Return a simpler request object to allow serialization
 function requestToJSON() {
   var self = this
@@ -805,11 +791,6 @@ Request.prototype.start = function () {
     self.emit('socket', socket)
   })
 
-  self.on('end', function() {
-    if ( self.req.connection ) {
-      self.req.connection.removeListener('error', connectionErrorHandler)
-    }
-  })
   self.emit('request', self.req)
 }
 
@@ -844,11 +825,6 @@ Request.prototype.onRequestResponse = function (response) {
     debug('response end', self.uri.href, response.statusCode, response.headers)
   })
 
-  // The check on response.connection is a workaround for browserify.
-  if (response.connection && response.connection.listeners('error').indexOf(connectionErrorHandler) === -1) {
-    response.connection.setMaxListeners(0)
-    response.connection.once('error', connectionErrorHandler)
-  }
   if (self._aborted) {
     debug('aborted', self.uri.href)
     response.resume()


### PR DESCRIPTION
The "socket._httpMessage.emit('error', error)" line currently throws when the keep-alive period expires and the socket resets, after a redirect to a different host. This is because the listener on the socket is never cleaned up, and the socket no longer has _httpMessage (the ClientRequest is long gone). This is bug #1903, which is also responsible for npm/npm#9984.

It looks to me like node core correctly re-emits socket error events on _httpMessage now, so we shouldn't have to. Looking at core I also cannot even find a "res" property on socket - if there's a reason to leave this, please speak up.

Closes https://github.com/request/request/issues/1903