### PR TITLE
Update tough-cookie to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "oauth-sign": "~0.8.1",
     "qs": "~6.2.0",
     "stringstream": "~0.0.4",
-    "tough-cookie": "~2.2.0",
+    "tough-cookie": "~2.3.0",
     "tunnel-agent": "~0.4.1"
   },
   "scripts": {


### PR DESCRIPTION
To address https://nodesecurity.io/advisories/130