### PR TITLE
add complete proxy options to request config

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,14 @@ Here's some examples of valid `no_proxy` values:
  * `google.com:443` - don't proxy HTTPS requests to Google, but *do* proxy HTTP requests to Google.
  * `google.com:443, yahoo.com:80` - don't proxy HTTPS requests to Google, and don't proxy HTTP requests to Yahoo!
  * `*` - ignore `https_proxy`/`http_proxy` environment variables altogether.
+ 
+### Controlling proxy behaviour using specific proxy options variables
+ 
+If you specify a `http_proxy`, `https_proxy` or `no_proxy` options, then
+the request (and any subsequent redirects) will be sent via a connection
+to the proxy server, just like if you had set  the environment variables.
+These specific option values take precedence over environment variable
+values then you can set none, one o more of them.
 
 [back to top](#table-of-contents)
 

--- a/lib/getProxyFromURI.js
+++ b/lib/getProxyFromURI.js
@@ -37,12 +37,12 @@ function uriInNoProxy(uri, noProxy) {
   })
 }
 
-function getProxyFromURI(uri) {
+function getProxyFromURI(uri, http_proxy, https_proxy, no_proxy) {
   // Decide the proper request proxy to use based on the request URI object and the
   // environmental variables (NO_PROXY, HTTP_PROXY, etc.)
   // respect NO_PROXY environment variables (see: http://lynx.isc.org/current/breakout/lynx_help/keystrokes/environments.html)
 
-  var noProxy = process.env.NO_PROXY || process.env.no_proxy || ''
+  var noProxy = no_proxy || process.env.NO_PROXY || process.env.no_proxy || ''
 
   // if the noProxy is a wildcard then return null
 
@@ -59,12 +59,14 @@ function getProxyFromURI(uri) {
   // Check for HTTP or HTTPS Proxy in environment Else default to null
 
   if (uri.protocol === 'http:') {
-    return process.env.HTTP_PROXY ||
+    return http_proxy ||
+           process.env.HTTP_PROXY ||
            process.env.http_proxy || null
   }
 
   if (uri.protocol === 'https:') {
-    return process.env.HTTPS_PROXY ||
+    return https_proxy ||
+           process.env.HTTPS_PROXY ||
            process.env.https_proxy ||
            process.env.HTTP_PROXY  ||
            process.env.http_proxy  || null

--- a/request.js
+++ b/request.js
@@ -276,7 +276,7 @@ Request.prototype.init = function (options) {
   }
 
   if (!self.hasOwnProperty('proxy')) {
-    self.proxy = getProxyFromURI(self.uri)
+    self.proxy = getProxyFromURI(self.uri, self.http_proxy, self.https_proxy, self.no_proxy)
   }
 
   self.tunnel = self._tunnel.isEnabled()

--- a/tests/test-proxy.js
+++ b/tests/test-proxy.js
@@ -296,6 +296,23 @@ if (process.env.TEST_PROXY_HARNESS) {
     t.equal(req.headers['proxy-authorization'], undefined)
     t.equal(req.headers.authorization, 'Basic dXNlcjpwYXNz')
   })
+  
+  //Use proxy options configuration
+  runTest('http_proxy setting option', {
+    http_proxy :  s.url
+  }, true)
+
+  runTest('https_proxy setting option', {
+    url    : 'https://google.com',
+    tunnel : false,
+    https_proxy :  s.url
+  }, true)
+
+  runTest('no_proxy setting option', {
+    proxy_http :  s.url,
+    no_proxy: 'google.com'
+  }, false)
+  
 }
 
 


### PR DESCRIPTION
I added proxy options to some strange cases when the complete proxy configuration is set on runtime time or simply is not configured on environment variables and the url is dynamic too.
