### PR TITLE
Progress event

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ request.post({url:'http://service.com/upload', formData: formData}, function opt
     return console.error('upload failed:', err);
   }
   console.log('Upload successful!  Server responded with:', body);
+}).on('progress', function(progress) {
+  if (progress.lengthComputable) {
+    // Follows the format of ProgressEvent
+    // See: https://xhr.spec.whatwg.org/#interface-progressevent
+  }
 });
 ```
 

--- a/request.js
+++ b/request.js
@@ -120,6 +120,7 @@ function Request (options) {
   if (options.method) {
     self.explicitMethod = true
   }
+  self.transferred = 0;
   self._qs = new Querystring(self)
   self._auth = new Auth(self)
   self._oauth = new OAuth(self)
@@ -1380,6 +1381,12 @@ Request.prototype.write = function () {
     self.start()
   }
   if (self.req) {
+    const contentLength = self.req._headers['content-length'];
+    self.emit('progress', {
+      lengthComputable: !!contentLength,
+      total: contentLength,
+      loaded: self.transferred += Buffer.byteLength(arguments[0])
+    });
     return self.req.write.apply(self.req, arguments)
   }
 }

--- a/request.js
+++ b/request.js
@@ -1385,7 +1385,7 @@ Request.prototype.write = function () {
     self.emit('progress', {
       lengthComputable: !!contentLength,
       total: contentLength,
-      loaded: self.transferred += Buffer.byteLength(arguments[0])
+      loaded: self.transferred += arguments[0].length
     })
     return self.req.write.apply(self.req, arguments)
   }

--- a/request.js
+++ b/request.js
@@ -120,7 +120,7 @@ function Request (options) {
   if (options.method) {
     self.explicitMethod = true
   }
-  self.transferred = 0;
+  self.transferred = 0
   self._qs = new Querystring(self)
   self._auth = new Auth(self)
   self._oauth = new OAuth(self)
@@ -1381,12 +1381,12 @@ Request.prototype.write = function () {
     self.start()
   }
   if (self.req) {
-    const contentLength = self.req._headers['content-length'];
+    var contentLength = self.req._headers['content-length']
     self.emit('progress', {
       lengthComputable: !!contentLength,
       total: contentLength,
       loaded: self.transferred += Buffer.byteLength(arguments[0])
-    });
+    })
     return self.req.write.apply(self.req, arguments)
   }
 }

--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -75,7 +75,7 @@ tape('form-data should throw on null value', function (t) {
         key: null
       }
     })
-  }, /Cannot read property 'path' of null/)
+  }, TypeError)
   t.end()
 })
 

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -109,6 +109,8 @@ function runTest(t, options) {
     if (options.auth) {
       reqOptions.auth = {user: 'user', pass: 'pass', sendImmediately: false}
     }
+    var progresses = []
+
     request.post(reqOptions, function (err, res, body) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
@@ -116,6 +118,20 @@ function runTest(t, options) {
       server.close(function() {
         t.end()
       })
+    }).on('progress', function(progress) {
+      progresses.push(progress)
+    }).on('end', function() {
+      // Sends progress events on writes
+      t.ok( progresses.length > 0 )
+
+      // Has a computable length
+      t.ok(progresses.every(function(progress) {
+        return progress.lengthComputable
+      }))
+
+      // Last progress loaded is 100%
+      var lastProgress = progresses[progresses.length - 1]
+      t.equal(lastProgress.loaded, lastProgress.total)
     })
 
   })


### PR DESCRIPTION
This completes my programs requirements, but as I'm not familiar with all of the ins and outs of `request`, I'm sure I'm missing some other point where a progress event might make sense.

At the moment it:
- ⏲  Adds a transferred property to the `Request` object to track bytes sent. 
- 🛫  During the `write` operation, it will emit a `progress` event that includes the standard `ProgressEvent` object as defined in the [ProgressEvent spec](https://xhr.spec.whatwg.org/#interface-progressevent).

Again, due to my unfamiliarity with the code base, and being the first time I've used `tape` tests, I would say my test cases are pretty minimal and permissive, so I definitely welcome some direction from the team on that.

Closes #1450 
