### PR TITLE
Check error type instead of string

### DIFF
--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -75,7 +75,7 @@ tape('form-data should throw on null value', function (t) {
         key: null
       }
     })
-  }, /Cannot read property 'path' of null/)
+  }, TypeError)
   t.end()
 })
 


### PR DESCRIPTION
Upstream change broke this unit test. Fixed this in another PR and realized that it's probably better off as it's own PR.

`form-data` just released 1.0.0, and it changed the order of property lookup what triggers a `TypeError` when we push up a null form-data property. This change just checks that it throws a `TypeError` instead of checking the string.

[Upstream code change link](https://github.com/form-data/form-data/compare/v1.0.0-rc4...v1.0.0#diff-121026c01234c71e2b3b316f7abc5afcR213)