### PR TITLE
Add responseStartTime timing

### DIFF
--- a/request.js
+++ b/request.js
@@ -958,6 +958,10 @@ Request.prototype.onRequestResponse = function (response) {
     })
 
     responseContent.on('data', function (chunk) {
+      if (self.timing && !self.responseStarted) {
+        self.responseStartTime = (new Date()).getTime()
+        response.responseStartTime = self.responseStartTime
+      }
       self._destdata = true
       self.emit('data', chunk)
     })

--- a/tests/test-timing.js
+++ b/tests/test-timing.js
@@ -27,21 +27,26 @@ tape('setup', function(t) {
 
 tape('non-redirected request is timed', function(t) {
   var options = {time: true}
-  request('http://localhost:' + plain_server.port + '/', options, function(err, res, body) {
+  var r = request('http://localhost:' + plain_server.port + '/', options, function(err, res, body) {
     t.equal(err, null)
     t.equal(typeof res.elapsedTime, 'number')
+    t.equal(typeof res.responseStartTime, 'number')
     t.equal((res.elapsedTime > 0), true)
+    t.equal((res.responseStartTime > r.startTime), true)
     t.end()
   })
 })
 
 tape('redirected request is timed with rollup', function(t) {
   var options = {time: true}
-  request('http://localhost:' + plain_server.port + '/redir', options, function(err, res, body) {
+  var r = request('http://localhost:' + plain_server.port + '/redir', options, function(err, res, body) {
     t.equal(err, null)
     t.equal(typeof res.elapsedTime, 'number')
+    t.equal(typeof res.responseStartTime, 'number')
     t.equal((res.elapsedTime > 0), true)
+    t.equal((res.responseStartTime > 0), true)
     t.equal((res.elapsedTime > redirect_mock_time), true)
+    t.equal((res.responseStartTime > r.startTime), true)
     t.end()
   })
 })


### PR DESCRIPTION
When `time:true` is set in options, elapsedTime is added to the response object.

This PR will _also_ include `responseStartTime`, the timestamp when the response begins. With this moment tagged, we can now recreate a rich network waterfall of the network activity. 

For example, here's a network waterfall of some project's `npm install` with this patch and [`request-capture-har`](https://github.com/paulirish/node-request-capture-har):
![image](https://cloud.githubusercontent.com/assets/39191/18031306/9401070c-6c8f-11e6-994d-03e6b8b511e4.png)
