### PR TITLE
Clear timeout on `#abort()`

### DIFF
--- a/request.js
+++ b/request.js
@@ -806,10 +806,7 @@ Request.prototype.onRequestError = function (error) {
     self.req.end()
     return
   }
-  if (self.timeout && self.timeoutTimer) {
-    clearTimeout(self.timeoutTimer)
-    self.timeoutTimer = null
-  }
+  self.clearTimeout()
   self.emit('error', error)
 }
 
@@ -856,10 +853,7 @@ Request.prototype.onRequestResponse = function (response) {
   if (self.setHost) {
     self.removeHeader('host')
   }
-  if (self.timeout && self.timeoutTimer) {
-    clearTimeout(self.timeoutTimer)
-    self.timeoutTimer = null
-  }
+  self.clearTimeout()
 
   var targetCookieJar = (self._jar && self._jar.setCookie) ? self._jar : globalCookieJar
   var addCookie = function (cookie) {
@@ -1423,6 +1417,13 @@ Request.prototype.destroy = function () {
     self.end()
   } else if (self.response) {
     self.response.destroy()
+  }
+}
+
+Request.prototype.clearTimeout = function () {
+  if (this.timeout && this.timeoutTimer) {
+    clearTimeout(this.timeoutTimer)
+    this.timeoutTimer = null
   }
 }
 

--- a/request.js
+++ b/request.js
@@ -1054,6 +1054,7 @@ Request.prototype.abort = function () {
     self.response.destroy()
   }
 
+  self.clearTimeout()
   self.emit('abort')
 }
 


### PR DESCRIPTION
Calling `#abort()` does not clear timeout, process hangs until timer is triggered. There are couple of places this is done correctly, `#abort()` happens not to be one of them. There are couple of relevant issues and PRs from **years ago**.

Sample script to reproduce:

``` js
'use strict';
const request = require('request');
const started = Date.now();
const printTime = label => () => console.log('%d ms\t%s', Date.now() - started, label);

const req = request({
  uri: 'http://example.com',
  timeout: 2500
}, printTime('callback'));

setTimeout(() => {
  req.abort();
  printTime('aborted')();
}, 10);

process.on('exit', printTime('exit'));

// 27 ms    aborted
// 2519 ms  callback
// 2521 ms  exit
```

Let's close this one finally. Can any of you guys help, please? @mikeal @simov
