### PR TITLE
Re-enable timeout tests on Travis + other fixes

### DIFF
--- a/tests/browser/karma.conf.js
+++ b/tests/browser/karma.conf.js
@@ -3,6 +3,7 @@ var istanbul = require('browserify-istanbul')
 
 module.exports = function(config) {
   config.set({
+    client: { requestTestUrl: process.argv[4] },
     basePath: '../..',
     frameworks: ['tap', 'browserify'],
     preprocessors: {

--- a/tests/browser/start.js
+++ b/tests/browser/start.js
@@ -4,8 +4,6 @@ var https = require('https')
 var fs = require('fs')
 var path = require('path')
 
-var port = 6767
-
 var server = https.createServer({
   key: fs.readFileSync(path.join(__dirname, '/ssl/server.key')),
   cert: fs.readFileSync(path.join(__dirname, '/ssl/server.crt')),
@@ -18,12 +16,14 @@ var server = https.createServer({
   res.writeHead(200)
   res.end('Can you hear the sound of an enormous door slamming in the depths of hell?\n')
 })
-server.listen(port, function() {
+server.listen(0, function() {
+  var port = this.address().port
   console.log('Started https server for karma tests on port ' + port)
   // Spawn process for karma.
   var c = spawn('karma', [
     'start',
-    path.join(__dirname, '/karma.conf.js')
+    path.join(__dirname, '/karma.conf.js'),
+    'https://localhost:' + port
   ])
   c.stdout.pipe(process.stdout)
   c.stderr.pipe(process.stderr)

--- a/tests/browser/test.js
+++ b/tests/browser/test.js
@@ -26,7 +26,7 @@ tape('returns on error', function(t) {
 tape('succeeds on valid URLs (with https and CORS)', function(t) {
   t.plan(1)
   request({
-    uri: 'https://localhost:6767',
+    uri: __karma__.config.requestTestUrl,
     withCredentials: false
   }, function (error, response) {
     t.equal(response.statusCode, 200)

--- a/tests/server.js
+++ b/tests/server.js
@@ -7,22 +7,20 @@ var fs = require('fs')
   , stream = require('stream')
   , assert = require('assert')
 
-exports.port = 6767
-exports.portSSL = 16167
-
-exports.createServer = function (port) {
-  port = port || exports.port
+exports.createServer = function () {
   var s = http.createServer(function (req, resp) {
     s.emit(req.url.replace(/(\?.*)/, ''), req, resp)
   })
-  s.port = port
-  s.url = 'http://localhost:' + port
+  s.on('listening', function () {
+    s.port = this.address().port
+    s.url = 'http://localhost:' + s.port
+  })
+  s.port = 0
   s.protocol = 'http'
   return s
 }
 
-exports.createEchoServer = function (port) {
-  port = port || exports.port
+exports.createEchoServer = function () {
   var s = http.createServer(function (req, resp) {
     var b = ''
     req.on('data', function (chunk) {b += chunk})
@@ -37,15 +35,16 @@ exports.createEchoServer = function (port) {
       resp.end()
     })
   })
-  s.port = port
-  s.url = 'http://localhost:' + port
+  s.on('listening', function () {
+    s.port = this.address().port
+    s.url = 'http://localhost:' + s.port
+  })
+  s.port = 0
   s.protocol = 'http'
   return s
 }
 
-exports.createSSLServer = function(port, opts) {
-  port = port || exports.portSSL
-
+exports.createSSLServer = function(opts) {
   var i
     , options = { 'key' : path.join(__dirname, 'ssl', 'test.key')
                 , 'cert': path.join(__dirname, 'ssl', 'test.crt')
@@ -65,8 +64,11 @@ exports.createSSLServer = function(port, opts) {
   var s = https.createServer(options, function (req, resp) {
     s.emit(req.url, req, resp)
   })
-  s.port = port
-  s.url = 'https://localhost:' + port
+  s.on('listening', function () {
+    s.port = this.address().port
+    s.url = 'https://localhost:' + s.port
+  })
+  s.port = 0
   s.protocol = 'https'
   return s
 }

--- a/tests/ssl/ca/localhost.js
+++ b/tests/ssl/ca/localhost.js
@@ -10,20 +10,24 @@ var server = https.createServer(options, function (req, res) {
   res.end()
   server.close()
 })
-server.listen(1337)
+server.listen(0, function() {
+  var ca = fs.readFileSync('./ca.crt')
+  var agent = new https.Agent({
+    host: 'localhost',
+    port: this.address().port,
+    ca: ca
+  })
 
-var ca = fs.readFileSync('./ca.crt')
-var agent = new https.Agent({ host: 'localhost', port: 1337, ca: ca })
-
-https.request({ host: 'localhost'
-              , method: 'HEAD'
-              , port: 1337
-              , agent: agent
-              , ca: [ ca ]
-              , path: '/' }, function (res) {
-  if (res.socket.authorized) {
-    console.log('node test: OK')
-  } else {
-    throw new Error(res.socket.authorizationError)
-  }
-}).end()
+  https.request({ host: 'localhost'
+                , method: 'HEAD'
+                , port: this.address().port
+                , agent: agent
+                , ca: [ ca ]
+                , path: '/' }, function (res) {
+    if (res.socket.authorized) {
+      console.log('node test: OK')
+    } else {
+      throw new Error(res.socket.authorizationError)
+    }
+  }).end()
+})

--- a/tests/ssl/ca/server.js
+++ b/tests/ssl/ca/server.js
@@ -10,21 +10,25 @@ var server = https.createServer(options, function (req, res) {
   res.end()
   server.close()
 })
-server.listen(1337)
+server.listen(0, function() {
+  var ca = fs.readFileSync('./ca.crt')
+  var agent = new https.Agent({
+    host: 'localhost',
+    port: this.address().port,
+    ca: ca
+  })
 
-var ca = fs.readFileSync('./ca.crt')
-var agent = new https.Agent({ host: 'localhost', port: 1337, ca: ca })
-
-https.request({ host: 'localhost'
-              , method: 'HEAD'
-              , port: 1337
-              , headers: { host: 'testing.request.mikealrogers.com' }
-              , agent: agent
-              , ca: [ ca ]
-              , path: '/' }, function (res) {
-  if (res.socket.authorized) {
-    console.log('node test: OK')
-  } else {
-    throw new Error(res.socket.authorizationError)
-  }
-}).end()
+  https.request({ host: 'localhost'
+                , method: 'HEAD'
+                , port: this.address().port
+                , headers: { host: 'testing.request.mikealrogers.com' }
+                , agent: agent
+                , ca: [ ca ]
+                , path: '/' }, function (res) {
+    if (res.socket.authorized) {
+      console.log('node test: OK')
+    } else {
+      throw new Error(res.socket.authorizationError)
+    }
+  }).end()
+})

--- a/tests/test-agent.js
+++ b/tests/test-agent.js
@@ -12,7 +12,9 @@ var s = http.createServer(function (req, res) {
 })
 
 tape('setup', function (t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.port = this.address().port
+    s.url = 'http://localhost:' + s.port
     t.end()
   })
 })
@@ -25,8 +27,8 @@ function httpAgent (t, options, req) {
     t.equal(Object.keys(r.agent.sockets).length, 1, '1 socket name')
 
     var name = (typeof r.agent.getName === 'function')
-      ? r.agent.getName({port:6767})
-      : 'localhost:6767' // node 0.10-
+      ? r.agent.getName({port:s.port})
+      : 'localhost:' + s.port // node 0.10-
     t.equal(r.agent.sockets[name].length, 1, '1 open socket')
 
     var socket = r.agent.sockets[name][0]
@@ -44,7 +46,7 @@ function foreverAgent (t, options, req) {
     t.ok(r.agent instanceof ForeverAgent, 'is ForeverAgent')
     t.equal(Object.keys(r.agent.sockets).length, 1, '1 socket name')
 
-    var name = 'localhost:6767' // node 0.10-
+    var name = 'localhost:' + s.port // node 0.10-
     t.equal(r.agent.sockets[name].length, 1, '1 open socket')
 
     var socket = r.agent.sockets[name][0]
@@ -60,14 +62,14 @@ function foreverAgent (t, options, req) {
 
 tape('options.agent', function (t) {
   httpAgent(t, {
-    uri: 'http://localhost:6767',
+    uri: s.url,
     agent: new http.Agent({keepAlive: true})
   })
 })
 
 tape('options.agentClass + options.agentOptions', function (t) {
   httpAgent(t, {
-    uri: 'http://localhost:6767',
+    uri: s.url,
     agentClass: http.Agent,
     agentOptions: {keepAlive: true}
   })
@@ -78,7 +80,7 @@ tape('options.agentClass + options.agentOptions', function (t) {
 tape('options.forever = true', function (t) {
   var v = version()
   var options = {
-    uri: 'http://localhost:6767',
+    uri: s.url,
     forever: true
   }
 
@@ -89,7 +91,7 @@ tape('options.forever = true', function (t) {
 tape('forever() method', function (t) {
   var v = version()
   var options = {
-    uri: 'http://localhost:6767'
+    uri: s.url
   }
   var r = request.forever({maxSockets: 1})
 

--- a/tests/test-agentOptions.js
+++ b/tests/test-agentOptions.js
@@ -11,22 +11,23 @@ var request = require('../index')
   , server  = require('./server')
   , tape    = require('tape')
 
-var s = server.createServer(function (req, resp) {
+var s = server.createServer()
+
+s.on('/', function (req, resp) {
   resp.statusCode = 200
   resp.end('')
 })
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })
 
 tape('without agentOptions should use global agent', function(t) {
-  var r = request(s.url, function(/*err, res, body*/) {
-    // TODO: figure out why err.code === 'ECONNREFUSED' on Travis?
-    //if (err) console.log(err)
-    //t.equal(err, null)
+  var r = request(s.url, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
     t.deepEqual(r.agent, http.globalAgent)
     t.equal(Object.keys(r.pool).length, 0)
     t.end()
@@ -36,10 +37,9 @@ tape('without agentOptions should use global agent', function(t) {
 tape('with agentOptions should apply to new agent in pool', function(t) {
   var r = request(s.url, {
     agentOptions: { foo: 'bar' }
-  }, function(/*err, res, body*/) {
-    // TODO: figure out why err.code === 'ECONNREFUSED' on Travis?
-    //if (err) console.log(err)
-    //t.equal(err, null)
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
     t.equal(r.agent.options.foo, 'bar')
     t.equal(Object.keys(r.pool).length, 1)
     t.end()

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -12,12 +12,15 @@ tape('setup', function (t) {
     res.writeHead(202)
     req.pipe(res)
   })
-  server.listen(6767, t.end)
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
+    t.end()
+  })
 })
 
 tape('callback option', function (t) {
   request({
-    url: 'http://localhost:6767',
+    url: server.url,
     callback: function (err, res, body) {
       t.equal(res.statusCode, 202)
       t.end()

--- a/tests/test-aws.js
+++ b/tests/test-aws.js
@@ -16,7 +16,7 @@ s.on(path, function(req, res) {
 })
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })

--- a/tests/test-baseUrl.js
+++ b/tests/test-baseUrl.js
@@ -17,44 +17,6 @@ var s = http.createServer(function(req, res) {
   res.end('ok')
 })
 
-tape('setup', function(t) {
-  s.listen(6767, function() {
-    t.end()
-  })
-})
-
-tape('baseUrl', function(t) {
-  request('resource', {
-    baseUrl: 'http://localhost:6767'
-  }, function(err, resp, body) {
-    t.equal(err, null)
-    t.equal(body, 'ok')
-    t.end()
-  })
-})
-
-tape('baseUrl defaults', function(t) {
-  var withDefaults = request.defaults({
-    baseUrl: 'http://localhost:6767'
-  })
-  withDefaults('resource', function(err, resp, body) {
-    t.equal(err, null)
-    t.equal(body, 'ok')
-    t.end()
-  })
-})
-
-tape('baseUrl and redirects', function(t) {
-  request('/', {
-    baseUrl: 'http://localhost:6767/redirect'
-  }, function(err, resp, body) {
-    t.equal(err, null)
-    t.equal(body, 'ok')
-    t.equal(resp.headers['x-path'], '/')
-    t.end()
-  })
-})
-
 function addTest(baseUrl, uri, expected) {
   tape('test baseurl="' + baseUrl + '" uri="' + uri + '"', function(t) {
     request(uri, { baseUrl: baseUrl }, function(err, resp, body) {
@@ -66,26 +28,73 @@ function addTest(baseUrl, uri, expected) {
   })
 }
 
-addTest('http://localhost:6767', '', '/')
-addTest('http://localhost:6767/', '', '/')
-addTest('http://localhost:6767', '/', '/')
-addTest('http://localhost:6767/', '/', '/')
-addTest('http://localhost:6767/api', '', '/api')
-addTest('http://localhost:6767/api/', '', '/api/')
-addTest('http://localhost:6767/api', '/', '/api/')
-addTest('http://localhost:6767/api/', '/', '/api/')
-addTest('http://localhost:6767/api', 'resource', '/api/resource')
-addTest('http://localhost:6767/api/', 'resource', '/api/resource')
-addTest('http://localhost:6767/api', '/resource', '/api/resource')
-addTest('http://localhost:6767/api/', '/resource', '/api/resource')
-addTest('http://localhost:6767/api', 'resource/', '/api/resource/')
-addTest('http://localhost:6767/api/', 'resource/', '/api/resource/')
-addTest('http://localhost:6767/api', '/resource/', '/api/resource/')
-addTest('http://localhost:6767/api/', '/resource/', '/api/resource/')
+function addTests() {
+  addTest(s.url, '', '/')
+  addTest(s.url + '/', '', '/')
+  addTest(s.url, '/', '/')
+  addTest(s.url + '/', '/', '/')
+  addTest(s.url + '/api', '', '/api')
+  addTest(s.url + '/api/', '', '/api/')
+  addTest(s.url + '/api', '/', '/api/')
+  addTest(s.url + '/api/', '/', '/api/')
+  addTest(s.url + '/api', 'resource', '/api/resource')
+  addTest(s.url + '/api/', 'resource', '/api/resource')
+  addTest(s.url + '/api', '/resource', '/api/resource')
+  addTest(s.url + '/api/', '/resource', '/api/resource')
+  addTest(s.url + '/api', 'resource/', '/api/resource/')
+  addTest(s.url + '/api/', 'resource/', '/api/resource/')
+  addTest(s.url + '/api', '/resource/', '/api/resource/')
+  addTest(s.url + '/api/', '/resource/', '/api/resource/')
+}
+
+tape('setup', function(t) {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
+    addTests()
+    tape('cleanup', function(t) {
+      s.close(function() {
+        t.end()
+      })
+    })
+    t.end()
+  })
+})
+
+tape('baseUrl', function(t) {
+  request('resource', {
+    baseUrl: s.url
+  }, function(err, resp, body) {
+    t.equal(err, null)
+    t.equal(body, 'ok')
+    t.end()
+  })
+})
+
+tape('baseUrl defaults', function(t) {
+  var withDefaults = request.defaults({
+    baseUrl: s.url
+  })
+  withDefaults('resource', function(err, resp, body) {
+    t.equal(err, null)
+    t.equal(body, 'ok')
+    t.end()
+  })
+})
+
+tape('baseUrl and redirects', function(t) {
+  request('/', {
+    baseUrl: s.url + '/redirect'
+  }, function(err, resp, body) {
+    t.equal(err, null)
+    t.equal(body, 'ok')
+    t.equal(resp.headers['x-path'], '/')
+    t.end()
+  })
+})
 
 tape('error when baseUrl is not a String', function(t) {
   request('resource', {
-    baseUrl: url.parse('http://localhost:6767/path')
+    baseUrl: url.parse(s.url + '/path')
   }, function(err, resp, body) {
     t.notEqual(err, null)
     t.equal(err.message, 'options.baseUrl must be a string')
@@ -95,7 +104,7 @@ tape('error when baseUrl is not a String', function(t) {
 
 tape('error when uri is not a String', function(t) {
   request(url.parse('resource'), {
-    baseUrl: 'http://localhost:6767/path'
+    baseUrl: s.url + '/path'
   }, function(err, resp, body) {
     t.notEqual(err, null)
     t.equal(err.message, 'options.uri must be a string when using options.baseUrl')
@@ -104,8 +113,8 @@ tape('error when uri is not a String', function(t) {
 })
 
 tape('error on baseUrl and uri with scheme', function(t) {
-  request('http://localhost:6767/path/ignoring/baseUrl', {
-    baseUrl: 'http://localhost:6767/path/'
+  request(s.url + '/path/ignoring/baseUrl', {
+    baseUrl: s.url + '/path/'
   }, function(err, resp, body) {
     t.notEqual(err, null)
     t.equal(err.message, 'options.uri must be a path when using options.baseUrl')
@@ -114,17 +123,11 @@ tape('error on baseUrl and uri with scheme', function(t) {
 })
 
 tape('error on baseUrl and uri with scheme-relative url', function(t) {
-  request('//localhost:6767/path/ignoring/baseUrl', {
-    baseUrl: 'http://localhost:6767/path/'
+  request(s.url.slice('http:'.length) + '/path/ignoring/baseUrl', {
+    baseUrl: s.url + '/path/'
   }, function(err, resp, body) {
     t.notEqual(err, null)
     t.equal(err.message, 'options.uri must be a path when using options.baseUrl')
-    t.end()
-  })
-})
-
-tape('cleanup', function(t) {
-  s.close(function() {
     t.end()
   })
 })

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -7,7 +7,6 @@ var assert = require('assert')
 
 var numBasicRequests = 0
   , basicServer
-  , port = 6767
 
 tape('setup', function(t) {
   basicServer = http.createServer(function (req, res) {
@@ -50,7 +49,9 @@ tape('setup', function(t) {
       res.statusCode = 401
       res.end('401')
     }
-  }).listen(port, function() {
+  }).listen(0, function() {
+    basicServer.port = this.address().port
+    basicServer.url = 'http://localhost:' + basicServer.port
     t.end()
   })
 })
@@ -58,7 +59,7 @@ tape('setup', function(t) {
 tape('sendImmediately - false', function(t) {
   var r = request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test/',
+    'uri': basicServer.url + '/test/',
     'auth': {
       'user': 'user',
       'pass': 'pass',
@@ -76,7 +77,7 @@ tape('sendImmediately - true', function(t) {
   // If we don't set sendImmediately = false, request will send basic auth
   var r = request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test2/',
+    'uri': basicServer.url + '/test2/',
     'auth': {
       'user': 'user',
       'pass': 'pass'
@@ -92,7 +93,7 @@ tape('sendImmediately - true', function(t) {
 tape('credentials in url', function(t) {
   var r = request({
     'method': 'GET',
-    'uri': 'http://user:pass@localhost:6767/test2/'
+    'uri': basicServer.url.replace(/:\/\//, '$&user:pass@') + '/test2/'
   }, function(error, res, body) {
     t.equal(r._auth.user, 'user')
     t.equal(res.statusCode, 200)
@@ -105,7 +106,7 @@ tape('POST request', function(t) {
   var r = request({
     'method': 'POST',
     'form': { 'key': 'value' },
-    'uri': 'http://localhost:6767/post/',
+    'uri': basicServer.url + '/post/',
     'auth': {
       'user': 'user',
       'pass': 'pass',
@@ -123,7 +124,7 @@ tape('user - empty string', function(t) {
   t.doesNotThrow( function() {
     var r = request({
       'method': 'GET',
-      'uri': 'http://localhost:6767/allow_empty_user/',
+      'uri': basicServer.url + '/allow_empty_user/',
       'auth': {
         'user': '',
         'pass': 'pass',
@@ -142,7 +143,7 @@ tape('pass - undefined', function(t) {
   t.doesNotThrow( function() {
     var r = request({
       'method': 'GET',
-      'uri': 'http://localhost:6767/allow_undefined_password/',
+      'uri': basicServer.url + '/allow_undefined_password/',
       'auth': {
         'user': 'user',
         'pass': undefined,
@@ -162,7 +163,7 @@ tape('pass - utf8', function(t) {
   t.doesNotThrow( function() {
     var r = request({
       'method': 'GET',
-      'uri': 'http://localhost:6767/allow_undefined_password/',
+      'uri': basicServer.url + '/allow_undefined_password/',
       'auth': {
         'user': 'user',
         'pass': 'pâss',
@@ -180,7 +181,7 @@ tape('pass - utf8', function(t) {
 
 tape('auth method', function(t) {
   var r = request
-    .get('http://localhost:6767/test/')
+    .get(basicServer.url + '/test/')
     .auth('user', '', false)
     .on('response', function (res) {
       t.equal(r._auth.user, 'user')
@@ -191,7 +192,7 @@ tape('auth method', function(t) {
 })
 
 tape('get method', function(t) {
-  var r = request.get('http://localhost:6767/test/',
+  var r = request.get(basicServer.url + '/test/',
     {
       auth: {
         user: 'user',

--- a/tests/test-bearer-auth.js
+++ b/tests/test-bearer-auth.js
@@ -7,7 +7,6 @@ var assert = require('assert')
 
 var numBearerRequests = 0
   , bearerServer
-  , port = 6767
 
 tape('setup', function(t) {
   bearerServer = http.createServer(function (req, res) {
@@ -44,7 +43,8 @@ tape('setup', function(t) {
       res.statusCode = 401
       res.end('401')
     }
-  }).listen(port, function() {
+  }).listen(0, function() {
+    bearerServer.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -52,7 +52,7 @@ tape('setup', function(t) {
 tape('bearer auth', function(t) {
   request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test/',
+    'uri': bearerServer.url + '/test/',
     'auth': {
       'bearer': 'theToken',
       'sendImmediately': false
@@ -68,7 +68,7 @@ tape('bearer auth with default sendImmediately', function(t) {
   // If we don't set sendImmediately = false, request will send bearer auth
   request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test2/',
+    'uri': bearerServer.url + '/test2/',
     'auth': {
       'bearer': 'theToken'
     }
@@ -83,7 +83,7 @@ tape('', function(t) {
   request({
     'method': 'POST',
     'form': { 'data_key': 'data_value' },
-    'uri': 'http://localhost:6767/post/',
+    'uri': bearerServer.url + '/post/',
     'auth': {
       'bearer': 'theToken',
       'sendImmediately': false
@@ -97,7 +97,7 @@ tape('', function(t) {
 
 tape('using .auth, sendImmediately = false', function(t) {
   request
-    .get('http://localhost:6767/test/')
+    .get(bearerServer.url + '/test/')
     .auth(null, null, false, 'theToken')
     .on('response', function (res) {
       t.equal(res.statusCode, 200)
@@ -108,7 +108,7 @@ tape('using .auth, sendImmediately = false', function(t) {
 
 tape('using .auth, sendImmediately = true', function(t) {
   request
-    .get('http://localhost:6767/test/')
+    .get(bearerServer.url + '/test/')
     .auth(null, null, true, 'theToken')
     .on('response', function (res) {
       t.equal(res.statusCode, 200)
@@ -120,7 +120,7 @@ tape('using .auth, sendImmediately = true', function(t) {
 tape('bearer is a function', function(t) {
   request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test/',
+    'uri': bearerServer.url + '/test/',
     'auth': {
       'bearer': function() { return 'theToken' },
       'sendImmediately': false
@@ -136,7 +136,7 @@ tape('bearer is a function, path = test2', function(t) {
   // If we don't set sendImmediately = false, request will send bearer auth
   request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test2/',
+    'uri': bearerServer.url + '/test2/',
     'auth': {
       'bearer': function() { return 'theToken' }
     }
@@ -150,7 +150,7 @@ tape('bearer is a function, path = test2', function(t) {
 tape('no auth method', function(t) {
   request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test2/',
+    'uri': bearerServer.url + '/test2/',
     'auth': {
       'bearer': undefined
     }
@@ -163,7 +163,7 @@ tape('no auth method', function(t) {
 tape('null bearer', function(t) {
   request({
     'method': 'GET',
-    'uri': 'http://localhost:6767/test2/',
+    'uri': bearerServer.url + '/test2/',
     'auth': {
       'bearer': null
     }

--- a/tests/test-body.js
+++ b/tests/test-body.js
@@ -8,7 +8,7 @@ var server = require('./server')
 var s = server.createServer()
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })
@@ -150,10 +150,10 @@ tape('typed array', function (t) {
   server.on('request', function (req, res) {
     req.pipe(res)
   })
-  server.listen(6768, function () {
+  server.listen(0, function () {
     var data = new Uint8Array([1, 2, 3])
     request({
-      uri: 'http://localhost:6768',
+      uri: 'http://localhost:' + this.address().port,
       method: 'POST',
       body: data,
       encoding: null

--- a/tests/test-cookies.js
+++ b/tests/test-cookies.js
@@ -5,9 +5,9 @@ var http = require('http')
   , tape = require('tape')
 
 
-var validUrl = 'http://localhost:6767/valid'
-  , malformedUrl = 'http://localhost:6767/malformed'
-  , invalidUrl = 'http://localhost:6767/invalid'
+var validUrl
+  , malformedUrl
+  , invalidUrl
 
 var server = http.createServer(function (req, res) {
   if (req.url === '/valid') {
@@ -21,7 +21,11 @@ var server = http.createServer(function (req, res) {
 })
 
 tape('setup', function(t) {
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
+    validUrl = server.url + '/valid'
+    malformedUrl = server.url + '/malformed'
+    invalidUrl = server.url + '/invalid'
     t.end()
   })
 })

--- a/tests/test-defaults.js
+++ b/tests/test-defaults.js
@@ -8,7 +8,7 @@ var server = require('./server')
 var s = server.createServer()
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     s.on('/', function (req, res) {
       res.writeHead(200, {'content-type': 'application/json'})
       res.end(JSON.stringify({

--- a/tests/test-digest-auth.js
+++ b/tests/test-digest-auth.js
@@ -132,7 +132,8 @@ var digestServer = http.createServer(function(req, res) {
 })
 
 tape('setup', function(t) {
-  digestServer.listen(6767, function() {
+  digestServer.listen(0, function() {
+    digestServer.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -142,7 +143,7 @@ tape('with sendImmediately = false', function(t) {
 
   request({
     method: 'GET',
-    uri: 'http://localhost:6767/test/',
+    uri: digestServer.url + '/test/',
     auth: {
       user: 'test',
       pass: 'testing',
@@ -164,7 +165,7 @@ tape('with MD5-sess algorithm', function(t) {
 
   request({
     method: 'GET',
-    uri: 'http://localhost:6767/test/md5-sess',
+    uri: digestServer.url + '/test/md5-sess',
     auth: {
       user: 'test',
       pass: 'testing',
@@ -187,7 +188,7 @@ tape('without sendImmediately = false', function(t) {
   // If we don't set sendImmediately = false, request will send basic auth
   request({
     method: 'GET',
-    uri: 'http://localhost:6767/test/',
+    uri: digestServer.url + '/test/',
     auth: {
       user: 'test',
       pass: 'testing'
@@ -208,7 +209,7 @@ tape('with different credentials', function(t) {
 
   request({
     method: 'GET',
-    uri: 'http://localhost:6767/dir/index.html',
+    uri: digestServer.url + '/dir/index.html',
     auth: {
       user: 'Mufasa',
       pass: 'CircleOfLife',

--- a/tests/test-emptyBody.js
+++ b/tests/test-emptyBody.js
@@ -10,13 +10,14 @@ var s = http.createServer(function (req, resp) {
 })
 
 tape('setup', function(t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
 
 tape('empty body with encoding', function(t) {
-  request('http://localhost:6767', function(err, res, body) {
+  request(s.url, function(err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
     t.equal(body, '')
@@ -26,7 +27,7 @@ tape('empty body with encoding', function(t) {
 
 tape('empty body without encoding', function(t) {
   request({
-    url: 'http://localhost:6767',
+    url: s.url,
     encoding: null
   }, function(err, res, body) {
     t.equal(err, null)
@@ -38,7 +39,7 @@ tape('empty body without encoding', function(t) {
 
 tape('empty JSON body', function(t) {
   request({
-    url: 'http://localhost:6767',
+    url: s.url,
     json: {}
   }, function(err, res, body) {
     t.equal(err, null)

--- a/tests/test-errors.js
+++ b/tests/test-errors.js
@@ -3,7 +3,7 @@
 var request = require('../index')
   , tape = require('tape')
 
-var local = 'http://localhost:8888/asdf'
+var local = 'http://localhost:0/asdf'
 
 tape('without uri', function(t) {
   t.throws(function() {

--- a/tests/test-event-forwarding.js
+++ b/tests/test-event-forwarding.js
@@ -7,7 +7,7 @@ var server = require('./server')
 var s = server.createServer()
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     s.on('/', function(req, res) {
       res.writeHead(200, { 'content-type': 'text/plain' })
       res.write('waited')

--- a/tests/test-follow-all-303.js
+++ b/tests/test-follow-all-303.js
@@ -15,7 +15,8 @@ var server = http.createServer(function (req, res) {
 })
 
 tape('setup', function(t) {
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -24,7 +25,7 @@ tape('followAllRedirects with 303', function(t) {
   var redirects = 0
 
   request.post({
-    url: 'http://localhost:6767/foo',
+    url: server.url + '/foo',
     followAllRedirects: true,
     form: { foo: 'bar' }
   }, function (err, res, body) {

--- a/tests/test-follow-all.js
+++ b/tests/test-follow-all.js
@@ -26,7 +26,8 @@ var server = http.createServer(function (req, res) {
 })
 
 tape('setup', function(t) {
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -35,7 +36,7 @@ tape('followAllRedirects', function(t) {
   var redirects = 0
 
   request.post({
-    url: 'http://localhost:6767/foo',
+    url: server.url + '/foo',
     followAllRedirects: true,
     jar: true,
     form: { foo: 'bar' }

--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -7,7 +7,7 @@ var request = require('../index')
 var s = server.createServer()
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })
@@ -70,7 +70,7 @@ tape('form-data should throw on null value', function (t) {
   t.throws(function () {
     request({
       method: 'POST',
-      url: 'http://localhost:6767',
+      url: s.url,
       formData: {
         key: null
       }

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -71,7 +71,7 @@ function runTest(t, options) {
       t.ok( data.indexOf('form-data; name="batch"') !== -1 )
       t.ok( data.match(/form-data; name="batch"/g).length === 2 )
 
-      // check for http://localhost:6767/file traces
+      // check for http://localhost:nnnn/file traces
       t.ok( data.indexOf('Photoshop ICC') !== -1 )
       t.ok( data.indexOf('Content-Type: ' + mime.lookup(remoteFile) ) !== -1 )
 
@@ -80,13 +80,13 @@ function runTest(t, options) {
     })
   })
 
-  server.listen(6767, function() {
-
+  server.listen(0, function() {
+    var url = 'http://localhost:' + this.address().port
     // @NOTE: multipartFormData properties must be set here so that my_file read stream does not leak in node v0.8
     multipartFormData.my_field = 'my_value'
     multipartFormData.my_buffer = new Buffer([1, 2, 3])
     multipartFormData.my_file = fs.createReadStream(localFile)
-    multipartFormData.remote_file = request('http://localhost:6767/file')
+    multipartFormData.remote_file = request(url + '/file')
     multipartFormData.secret_file = {
       value: fs.createReadStream(localFile),
       options: {
@@ -100,7 +100,7 @@ function runTest(t, options) {
     ]
 
     var reqOptions = {
-      url: 'http://localhost:6767/upload',
+      url: url + '/upload',
       formData: multipartFormData
     }
     if (options.json) {

--- a/tests/test-form-urlencoded.js
+++ b/tests/test-form-urlencoded.js
@@ -32,9 +32,9 @@ function runTest (t, options, index) {
     })
   })
 
-  server.listen(6767, function() {
-
-    var r = request.post('http://localhost:6767', options, function(err, res, body) {
+  server.listen(0, function() {
+    var url = 'http://localhost:' + this.address().port
+    var r = request.post(url, options, function(err, res, body) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.equal(body, 'done')

--- a/tests/test-form.js
+++ b/tests/test-form.js
@@ -58,7 +58,7 @@ tape('multipart form append', function(t) {
       field = FIELDS.shift()
       t.ok( data.indexOf('form-data; name="' + field.name + '"') !== -1 )
       t.ok( data.indexOf('; filename="' + path.basename(field.value.path) + '"') !== -1 )
-      // check for http://localhost:6767/file traces
+      // check for http://localhost:nnnn/file traces
       t.ok( data.indexOf('Photoshop ICC') !== -1 )
       t.ok( data.indexOf('Content-Type: ' + mime.lookup(remoteFile) ) !== -1 )
 
@@ -71,16 +71,16 @@ tape('multipart form append', function(t) {
     })
   })
 
-  server.listen(6767, function() {
-
+  server.listen(0, function() {
+    var url = 'http://localhost:' + this.address().port
     FIELDS = [
       { name: 'my_field', value: 'my_value' },
       { name: 'my_buffer', value: new Buffer([1, 2, 3]) },
       { name: 'my_file', value: fs.createReadStream(localFile) },
-      { name: 'remote_file', value: request('http://localhost:6767/file') }
+      { name: 'remote_file', value: request(url + '/file') }
     ]
 
-    var req = request.post('http://localhost:6767/upload', function(err, res, body) {
+    var req = request.post(url + '/upload', function(err, res, body) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       t.equal(body, 'done')

--- a/tests/test-gzip.js
+++ b/tests/test-gzip.js
@@ -78,7 +78,8 @@ tape('setup', function(t) {
       t.equal(err, null)
       testContentBigGzip = data2
 
-      server.listen(6767, function() {
+      server.listen(0, function() {
+        server.url = 'http://localhost:' + this.address().port
         t.end()
       })
     })
@@ -86,7 +87,7 @@ tape('setup', function(t) {
 })
 
 tape('transparently supports gzip decoding to callbacks', function(t) {
-  var options = { url: 'http://localhost:6767/foo', gzip: true }
+  var options = { url: server.url + '/foo', gzip: true }
   request.get(options, function(err, res, body) {
     t.equal(err, null)
     t.equal(res.headers['content-encoding'], 'gzip')
@@ -96,7 +97,7 @@ tape('transparently supports gzip decoding to callbacks', function(t) {
 })
 
 tape('transparently supports gzip decoding to pipes', function(t) {
-  var options = { url: 'http://localhost:6767/foo', gzip: true }
+  var options = { url: server.url + '/foo', gzip: true }
   var chunks = []
   request.get(options)
     .on('data', function(chunk) {
@@ -114,7 +115,7 @@ tape('transparently supports gzip decoding to pipes', function(t) {
 tape('does not request gzip if user specifies Accepted-Encodings', function(t) {
   var headers = { 'Accept-Encoding': null }
   var options = {
-    url: 'http://localhost:6767/foo',
+    url: server.url + '/foo',
     headers: headers,
     gzip: true
   }
@@ -128,7 +129,7 @@ tape('does not request gzip if user specifies Accepted-Encodings', function(t) {
 
 tape('does not decode user-requested encoding by default', function(t) {
   var headers = { 'Accept-Encoding': 'gzip' }
-  var options = { url: 'http://localhost:6767/foo', headers: headers }
+  var options = { url: server.url + '/foo', headers: headers }
   request.get(options, function(err, res, body) {
     t.equal(err, null)
     t.equal(res.headers['content-encoding'], 'gzip')
@@ -140,7 +141,7 @@ tape('does not decode user-requested encoding by default', function(t) {
 tape('supports character encoding with gzip encoding', function(t) {
   var headers = { 'Accept-Encoding': 'gzip' }
   var options = {
-    url: 'http://localhost:6767/foo',
+    url: server.url + '/foo',
     headers: headers,
     gzip: true,
     encoding: 'utf8'
@@ -161,7 +162,7 @@ tape('supports character encoding with gzip encoding', function(t) {
 })
 
 tape('transparently supports gzip error to callbacks', function(t) {
-  var options = { url: 'http://localhost:6767/error', gzip: true }
+  var options = { url: server.url + '/error', gzip: true }
   request.get(options, function(err, res, body) {
     t.equal(err.code, 'Z_DATA_ERROR')
     t.equal(res, undefined)
@@ -171,7 +172,7 @@ tape('transparently supports gzip error to callbacks', function(t) {
 })
 
 tape('transparently supports gzip error to pipes', function(t) {
-  var options = { url: 'http://localhost:6767/error', gzip: true }
+  var options = { url: server.url + '/error', gzip: true }
   request.get(options)
     .on('data', function (/*chunk*/) {
       t.fail('Should not receive data event')
@@ -188,7 +189,7 @@ tape('transparently supports gzip error to pipes', function(t) {
 tape('pause when streaming from a gzip request object', function(t) {
   var chunks = []
   var paused = false
-  var options = { url: 'http://localhost:6767/chunks', gzip: true }
+  var options = { url: server.url + '/chunks', gzip: true }
   request.get(options)
     .on('data', function(chunk) {
       var self = this
@@ -214,7 +215,7 @@ tape('pause when streaming from a gzip request object', function(t) {
 
 tape('pause before streaming from a gzip request object', function(t) {
   var paused = true
-  var options = { url: 'http://localhost:6767/foo', gzip: true }
+  var options = { url: server.url + '/foo', gzip: true }
   var r = request.get(options)
   r.pause()
   r.on('data', function(data) {
@@ -230,7 +231,7 @@ tape('pause before streaming from a gzip request object', function(t) {
 })
 
 tape('transparently supports deflate decoding to callbacks', function(t) {
-  var options = { url: 'http://localhost:6767/foo', gzip: true, headers: { 'Accept-Encoding': 'deflate' } }
+  var options = { url: server.url + '/foo', gzip: true, headers: { 'Accept-Encoding': 'deflate' } }
 
   request.get(options, function(err, res, body) {
     t.equal(err, null)
@@ -241,7 +242,7 @@ tape('transparently supports deflate decoding to callbacks', function(t) {
 })
 
 tape('do not try to pipe HEAD request responses', function(t) {
-  var options = { method: 'HEAD', url: 'http://localhost:6767/foo', gzip: true }
+  var options = { method: 'HEAD', url: server.url + '/foo', gzip: true }
 
   request(options, function(err, res, body) {
     t.equal(err, null)
@@ -251,7 +252,7 @@ tape('do not try to pipe HEAD request responses', function(t) {
 })
 
 tape('do not try to pipe responses with no body', function(t) {
-  var options = { url: 'http://localhost:6767/foo', gzip: true }
+  var options = { url: server.url + '/foo', gzip: true }
 
   options.headers = {code: 105}
   request.post(options, function(err, res, body) {

--- a/tests/test-har.js
+++ b/tests/test-har.js
@@ -9,7 +9,7 @@ var server = require('./server')
 var s = server.createEchoServer()
 
 tape('setup', function (t) {
-  s.listen(s.port, function () {
+  s.listen(0, function () {
     t.end()
   })
 })

--- a/tests/test-hawk.js
+++ b/tests/test-hawk.js
@@ -26,7 +26,8 @@ var server = http.createServer(function(req, res) {
 })
 
 tape('setup', function(t) {
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -37,7 +38,7 @@ tape('hawk', function(t) {
     algorithm: 'sha256',
     id: 'dh37fgj492je'
   }
-  request('http://localhost:6767', {
+  request(server.url, {
     hawk: { credentials: creds }
   }, function(err, res, body) {
     t.equal(err, null)

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -26,12 +26,6 @@ s.on('/headers.json', function(req, res) {
   res.end(JSON.stringify(req.headers))
 })
 
-tape('setup', function(t) {
-  s.listen(s.port, function() {
-    t.end()
-  })
-})
-
 function runTest(name, path, requestObj, serverAssertFn) {
   tape(name, function(t) {
     s.on('/' + path, function(req, res) {
@@ -48,54 +42,68 @@ function runTest(name, path, requestObj, serverAssertFn) {
   })
 }
 
-runTest(
-  '#125: headers.cookie with no cookie jar',
-  'no-jar',
-  {headers: {cookie: 'foo=bar'}},
-  function(t, req, res) {
-    t.equal(req.headers.cookie, 'foo=bar')
-  })
+function addTests() {
+  runTest(
+    '#125: headers.cookie with no cookie jar',
+    'no-jar',
+    {headers: {cookie: 'foo=bar'}},
+    function(t, req, res) {
+      t.equal(req.headers.cookie, 'foo=bar')
+    })
 
-var jar = request.jar()
-jar.setCookie('quux=baz', s.url)
-runTest(
-  '#125: headers.cookie + cookie jar',
-  'header-and-jar',
-  {jar: jar, headers: {cookie: 'foo=bar'}},
-  function(t, req, res) {
-    t.equal(req.headers.cookie, 'foo=bar; quux=baz')
-  })
+  var jar = request.jar()
+  jar.setCookie('quux=baz', s.url)
+  runTest(
+    '#125: headers.cookie + cookie jar',
+    'header-and-jar',
+    {jar: jar, headers: {cookie: 'foo=bar'}},
+    function(t, req, res) {
+      t.equal(req.headers.cookie, 'foo=bar; quux=baz')
+    })
 
-var jar2 = request.jar()
-jar2.setCookie('quux=baz; Domain=foo.bar.com', s.url, {ignoreError: true})
-runTest(
-  '#794: ignore cookie parsing and domain errors',
-  'ignore-errors',
-  {jar: jar2, headers: {cookie: 'foo=bar'}},
-  function(t, req, res) {
-    t.equal(req.headers.cookie, 'foo=bar')
-  })
+  var jar2 = request.jar()
+  jar2.setCookie('quux=baz; Domain=foo.bar.com', s.url, {ignoreError: true})
+  runTest(
+    '#794: ignore cookie parsing and domain errors',
+    'ignore-errors',
+    {jar: jar2, headers: {cookie: 'foo=bar'}},
+    function(t, req, res) {
+      t.equal(req.headers.cookie, 'foo=bar')
+    })
 
-runTest(
-  '#784: override content-type when json is used',
-  'json',
-  {
-    json: true,
-    method: 'POST',
-    headers: { 'content-type': 'application/json; charset=UTF-8' },
-    body: { hello: 'my friend' }},
-  function(t, req, res) {
-    t.equal(req.headers['content-type'], 'application/json; charset=UTF-8')
-  }
-)
+  runTest(
+    '#784: override content-type when json is used',
+    'json',
+    {
+      json: true,
+      method: 'POST',
+      headers: { 'content-type': 'application/json; charset=UTF-8' },
+      body: { hello: 'my friend' }},
+    function(t, req, res) {
+      t.equal(req.headers['content-type'], 'application/json; charset=UTF-8')
+    }
+  )
 
-runTest(
-  'neither headers.cookie nor a cookie jar is specified',
-  'no-cookie',
-  {},
-  function(t, req, res) {
-    t.equal(req.headers.cookie, undefined)
+  runTest(
+    'neither headers.cookie nor a cookie jar is specified',
+    'no-cookie',
+    {},
+    function(t, req, res) {
+      t.equal(req.headers.cookie, undefined)
+    })
+}
+
+tape('setup', function(t) {
+  s.listen(0, function() {
+    addTests()
+    tape('cleanup', function(t) {
+      s.close(function() {
+        t.end()
+      })
+    })
+    t.end()
   })
+})
 
 tape('upper-case Host header and redirect', function(t) {
   // Horrible hack to observe the raw data coming to the server (before Node
@@ -190,12 +198,6 @@ tape('catch invalid characters error - POST', function(t) {
   })
   .on('error', function (err) {
     t.equal(err.message, 'The header content contains invalid characters')
-    t.end()
-  })
-})
-
-tape('cleanup', function(t) {
-  s.close(function() {
     t.end()
   })
 })

--- a/tests/test-http-signature.js
+++ b/tests/test-http-signature.js
@@ -69,7 +69,8 @@ var server = http.createServer(function (req, res) {
 })
 
 tape('setup', function(t) {
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -81,7 +82,7 @@ tape('correct key', function(t) {
       key: privateKeyPEMs['key-1']
     }
   }
-  request('http://localhost:6767', options, function(err, res, body) {
+  request(server.url, options, function(err, res, body) {
     t.equal(err, null)
     t.equal(200, res.statusCode)
     t.end()
@@ -95,7 +96,7 @@ tape('incorrect key', function(t) {
       key: privateKeyPEMs['key-1']
     }
   }
-  request('http://localhost:6767', options, function(err, res, body) {
+  request(server.url, options, function(err, res, body) {
     t.equal(err, null)
     t.equal(400, res.statusCode)
     t.end()

--- a/tests/test-httpModule.js
+++ b/tests/test-httpModule.js
@@ -41,7 +41,7 @@ destroyable(plain_server)
 destroyable(https_server)
 
 tape('setup', function(t) {
-  plain_server.listen(plain_server.port, function() {
+  plain_server.listen(0, function() {
     plain_server.on('/plain', function (req, res) {
       res.writeHead(200)
       res.end('plain')
@@ -51,7 +51,7 @@ tape('setup', function(t) {
       res.end()
     })
 
-    https_server.listen(https_server.port, function() {
+    https_server.listen(0, function() {
       https_server.on('/https', function (req, res) {
         res.writeHead(200)
         res.end('https')

--- a/tests/test-https.js
+++ b/tests/test-https.js
@@ -17,13 +17,13 @@ var s = server.createSSLServer()
     key: path.resolve(__dirname, 'ssl/ca/server.key'),
     cert: path.resolve(__dirname, 'ssl/ca/server.crt')
   }
-  , sStrict = server.createSSLServer(s.port + 1, opts)
+  , sStrict = server.createSSLServer(opts)
 
 function runAllTests(strict, s) {
   var strictMsg = (strict ? 'strict ' : 'relaxed ')
 
   tape(strictMsg + 'setup', function(t) {
-    s.listen(s.port, function() {
+    s.listen(0, function() {
       t.end()
     })
   })

--- a/tests/test-isUrl.js
+++ b/tests/test-isUrl.js
@@ -10,13 +10,15 @@ var s = http.createServer(function(req, res) {
 })
 
 tape('setup', function(t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.port = this.address().port
+    s.url = 'http://localhost:' + s.port
     t.end()
   })
 })
 
 tape('lowercase', function(t) {
-  request('http://localhost:6767', function(err, resp, body) {
+  request(s.url, function(err, resp, body) {
     t.equal(err, null)
     t.equal(body, 'ok')
     t.end()
@@ -24,7 +26,7 @@ tape('lowercase', function(t) {
 })
 
 tape('uppercase', function(t) {
-  request('HTTP://localhost:6767', function(err, resp, body) {
+  request(s.url.replace('http', 'HTTP'), function(err, resp, body) {
     t.equal(err, null)
     t.equal(body, 'ok')
     t.end()
@@ -32,7 +34,7 @@ tape('uppercase', function(t) {
 })
 
 tape('mixedcase', function(t) {
-  request('HtTp://localhost:6767', function(err, resp, body) {
+  request(s.url.replace('http', 'HtTp'), function(err, resp, body) {
     t.equal(err, null)
     t.equal(body, 'ok')
     t.end()
@@ -44,7 +46,7 @@ tape('hostname and port', function(t) {
     uri: {
       protocol: 'http:',
       hostname: 'localhost',
-      port: 6767
+      port: s.port
     }
   }, function(err, res, body) {
     t.equal(err, null)
@@ -58,7 +60,7 @@ tape('hostname and port 1', function(t) {
     uri: {
       protocol: 'http:',
       hostname: 'localhost',
-      port: 6767
+      port: s.port
     }
   }, function(err, res, body) {
     t.equal(err, null)
@@ -71,7 +73,7 @@ tape('hostname and port 2', function(t) {
   request({
     protocol: 'http:',
     hostname: 'localhost',
-    port: 6767
+    port: s.port
   }, {
     // need this empty options object, otherwise request thinks no uri was set
   }, function(err, res, body) {
@@ -85,7 +87,7 @@ tape('hostname and port 3', function(t) {
   request({
     protocol: 'http:',
     hostname: 'localhost',
-    port: 6767
+    port: s.port
   }, function(err, res, body) {
     t.notEqual(err, null)
     t.equal(err.message, 'options.uri is a required argument')
@@ -99,7 +101,7 @@ tape('hostname and query string', function(t) {
     uri: {
       protocol: 'http:',
       hostname: 'localhost',
-      port: 6767
+      port: s.port
     },
     qs: {
       test: 'test'

--- a/tests/test-json-request.js
+++ b/tests/test-json-request.js
@@ -7,7 +7,7 @@ var server = require('./server')
 var s = server.createServer()
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })

--- a/tests/test-multipart-encoding.js
+++ b/tests/test-multipart-encoding.js
@@ -124,7 +124,8 @@ function runTest(t, test) {
     })
   })
 
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    var url = 'http://localhost:' + this.address().port
     // @NOTE: multipartData properties must be set here
     // so that file read stream does not leak in node v0.8
     var parts = test.options.multipart.data || test.options.multipart
@@ -132,7 +133,7 @@ function runTest(t, test) {
       parts[0].body = fs.createReadStream(localFile)
     }
 
-    request.post('http://localhost:6767', test.options, function (err, res, body) {
+    request.post(url, test.options, function (err, res, body) {
       t.equal(err, null)
       t.equal(res.statusCode, 200)
       server.close(function () {

--- a/tests/test-multipart.js
+++ b/tests/test-multipart.js
@@ -60,7 +60,7 @@ function runTest(t, a) {
 
       // remote_file
       t.ok(data.indexOf('name: remote_file') !== -1)
-      // check for http://localhost:6767/file traces
+      // check for http://localhost:nnnn/file traces
       t.ok(data.indexOf('Photoshop ICC') !== -1)
 
       if (a.header && a.header.indexOf('boundary=XXX') !== -1) {
@@ -72,19 +72,19 @@ function runTest(t, a) {
     })
   })
 
-  server.listen(6767, function() {
-
+  server.listen(0, function() {
+    var url = 'http://localhost:' + this.address().port
     // @NOTE: multipartData properties must be set here so that my_file read stream does not leak in node v0.8
     multipartData = [
       {name: 'my_field', body: 'my_value'},
       {name: 'my_number', body: 1000},
       {name: 'my_buffer', body: new Buffer([1, 2, 3])},
       {name: 'my_file', body: fs.createReadStream(localFile)},
-      {name: 'remote_file', body: request('http://localhost:6767/file')}
+      {name: 'remote_file', body: request(url + '/file')}
     ]
 
     var reqOptions = {
-      url: 'http://localhost:6767/upload',
+      url: url + '/upload',
       multipart: multipartData
     }
     if (a.header) {

--- a/tests/test-node-debug.js
+++ b/tests/test-node-debug.js
@@ -18,7 +18,8 @@ tape('setup', function(t) {
     stderr.push(string)
   }
 
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -29,14 +30,15 @@ tape('a simple request should not fail with debugging enabled', function(t) {
   t.equal(request.debug, true, 'request.debug gets request.Request.debug')
   stderr = []
 
-  request('http://localhost:6767', function(err, res, body) {
+  request(s.url, function(err, res, body) {
     t.ifError(err, 'the request did not fail')
     t.ok(res, 'the request did not fail')
 
     t.ok(stderr.length, 'stderr has some messages')
+    var url = s.url.replace(/\//g, '\\/')
     var patterns = [
       /^REQUEST { uri: /,
-      /^REQUEST make request http:\/\/localhost:6767\/\n$/,
+      new RegExp('^REQUEST make request ' + url + '\/\n$'),
       /^REQUEST onRequestResponse /,
       /^REQUEST finish init /,
       /^REQUEST response end /,
@@ -61,7 +63,7 @@ tape('there should be no further lookups on process.env', function(t) {
   process.env.NODE_DEBUG = ''
   stderr = []
 
-  request('http://localhost:6767', function(err, res, body) {
+  request(s.url, function(err, res, body) {
     t.ifError(err, 'the request did not fail')
     t.ok(res, 'the request did not fail')
     t.equal(stderr.length, prevStderrLen, 'env.NODE_DEBUG is not retested')
@@ -75,7 +77,7 @@ tape('it should be possible to disable debugging at runtime', function(t) {
   t.equal(request.debug, false, 'request.debug gets request.Request.debug')
   stderr = []
 
-  request('http://localhost:6767', function(err, res, body) {
+  request(s.url, function(err, res, body) {
     t.ifError(err, 'the request did not fail')
     t.ok(res, 'the request did not fail')
     t.equal(stderr.length, 0, 'debugging can be disabled')

--- a/tests/test-onelineproxy.js
+++ b/tests/test-onelineproxy.js
@@ -28,24 +28,25 @@ var server = http.createServer(function(req, resp) {
   }
   if (req.url === '/proxy') {
     assert.equal(req.method, 'PUT')
-    req.pipe(request('http://localhost:6767/put')).pipe(resp)
+    req.pipe(request(server.url + '/put')).pipe(resp)
     return
   }
   if (req.url === '/test') {
-    request('http://localhost:6767/get').pipe(request.put('http://localhost:6767/proxy')).pipe(resp)
+    request(server.url + '/get').pipe(request.put(server.url + '/proxy')).pipe(resp)
     return
   }
   throw new Error('Unknown url', req.url)
 })
 
 tape('setup', function(t) {
-  server.listen(6767, function() {
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
 
 tape('chained one-line proxying', function(t) {
-  request('http://localhost:6767/test', function(err, res, body) {
+  request(server.url + '/test', function(err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
     t.equal(body, 'success')

--- a/tests/test-option-reuse.js
+++ b/tests/test-option-reuse.js
@@ -17,13 +17,14 @@ var s = http.createServer(function(req, res) {
 })
 
 tape('setup', function(t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
 
 tape('options object is not mutated', function(t) {
-  var url = 'http://localhost:6767'
+  var url = s.url
   var options = { url: url }
 
   request.head(options, function(err, resp, body) {

--- a/tests/test-params.js
+++ b/tests/test-params.js
@@ -24,7 +24,7 @@ function runTest(name, test) {
 }
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })

--- a/tests/test-piped-redirect.js
+++ b/tests/test-piped-redirect.js
@@ -4,8 +4,8 @@ var http = require('http')
   , request = require('../index')
   , tape = require('tape')
 
-var port1 = 6767
-  , port2 = 6768
+var port1
+  , port2
 
 var s1 = http.createServer(function(req, resp) {
   if (req.url === '/original') {
@@ -29,8 +29,10 @@ var s2 = http.createServer(function(req, resp) {
 })
 
 tape('setup', function(t) {
-  s1.listen(port1, function() {
-    s2.listen(port2, function() {
+  s1.listen(0, function() {
+    port1 = this.address().port
+    s2.listen(0, function() {
+      port2 = this.address().port
       t.end()
     })
   })

--- a/tests/test-pipes.js
+++ b/tests/test-pipes.js
@@ -64,7 +64,7 @@ ValidationStream.prototype.end = function(chunk) {
 
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })

--- a/tests/test-pipes.js
+++ b/tests/test-pipes.js
@@ -210,7 +210,7 @@ tape('pause before piping from a request object', function(t) {
   }, 100)
 })
 
-var fileContents = fs.readFileSync(__filename).toString()
+var fileContents = fs.readFileSync(__filename)
 function testPipeFromFile(testName, hasContentLength) {
   tape(testName, function(t) {
     s.once('/pushjs', function(req, res) {
@@ -220,13 +220,16 @@ function testPipeFromFile(testName, hasContentLength) {
           req.headers['content-length'],
           (hasContentLength ? '' + fileContents.length : undefined))
         var body = ''
+        req.setEncoding('utf8')
         req.on('data', function(data) {
           body += data
         })
         req.on('end', function() {
-          t.equal(body, fileContents)
+          res.end()
+          t.equal(body, fileContents.toString())
           t.end()
         })
+      } else {
         res.end()
       }
     })

--- a/tests/test-pool.js
+++ b/tests/test-pool.js
@@ -10,14 +10,15 @@ var s = http.createServer(function (req, res) {
 })
 
 tape('setup', function(t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
 
 tape('pool', function(t) {
   request({
-    url: 'http://localhost:6767',
+    url: s.url,
     pool: false
   }, function(err, res, body) {
     t.equal(err, null)
@@ -32,7 +33,7 @@ tape('pool', function(t) {
 
 tape('forever', function(t) {
   var r = request({
-    url: 'http://localhost:6767',
+    url: s.url,
     forever: true,
     pool: {maxSockets: 1024}
   }, function(err, res, body) {
@@ -62,8 +63,8 @@ tape('forever, should use same agent in sequential requests', function(t) {
   var r = request.defaults({
     forever: true
   })
-  var req1 = r('http://localhost:6767')
-  var req2 = r('http://localhost:6767/somepath')
+  var req1 = r(s.url)
+  var req2 = r(s.url + '/somepath')
   req1.abort()
   req2.abort()
   if (typeof req1.agent.destroy === 'function') {
@@ -81,8 +82,8 @@ tape('forever, should use same agent in sequential requests(with pool.maxSockets
     forever: true,
     pool: {maxSockets: 1024}
   })
-  var req1 = r('http://localhost:6767')
-  var req2 = r('http://localhost:6767/somepath')
+  var req1 = r(s.url)
+  var req2 = r(s.url + '/somepath')
   req1.abort()
   req2.abort()
   if (typeof req1.agent.destroy === 'function') {
@@ -101,8 +102,8 @@ tape('forever, should use same agent in request() and request.verb', function(t)
     forever: true,
     pool: {maxSockets: 1024}
   })
-  var req1 = r('http://localhost:6767')
-  var req2 = r.get('http://localhost:6767')
+  var req1 = r(s.url)
+  var req2 = r.get(s.url)
   req1.abort()
   req2.abort()
   if (typeof req1.agent.destroy === 'function') {
@@ -121,9 +122,9 @@ tape('should use different agent if pool option specified', function(t) {
     forever: true,
     pool: {maxSockets: 1024}
   })
-  var req1 = r('http://localhost:6767')
+  var req1 = r(s.url)
   var req2 = r.get({
-    url: 'http://localhost:6767',
+    url: s.url,
     pool: {maxSockets: 20}
   })
   req1.abort()

--- a/tests/test-promise.js
+++ b/tests/test-promise.js
@@ -11,7 +11,8 @@ var s = http.createServer(function(req, res) {
 })
 
 tape('setup', function(t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -19,7 +20,7 @@ tape('setup', function(t) {
 tape('promisify convenience method', function(t) {
   var get = request.get
   var p = Promise.promisify(get, {multiArgs: true})
-  p('http://localhost:6767')
+  p(s.url)
     .then(function (results) {
       var res = results[0]
       t.equal(res.statusCode, 200)
@@ -29,7 +30,7 @@ tape('promisify convenience method', function(t) {
 
 tape('promisify request function', function(t) {
   var p = Promise.promisify(request, {multiArgs: true})
-  p('http://localhost:6767')
+  p(s.url)
     .spread(function (res, body) {
       t.equal(res.statusCode, 200)
       t.end()
@@ -38,7 +39,7 @@ tape('promisify request function', function(t) {
 
 tape('promisify all methods', function(t) {
   Promise.promisifyAll(request, {multiArgs: true})
-  request.getAsync('http://localhost:6767')
+  request.getAsync(s.url)
     .spread(function (res, body) {
       t.equal(res.statusCode, 200)
       t.end()

--- a/tests/test-proxy-connect.js
+++ b/tests/test-proxy-connect.js
@@ -3,8 +3,7 @@
 var request = require('../index')
   , tape = require('tape')
 
-var port = 6768
-  , called = false
+var called = false
   , proxiedHost = 'google.com'
   , data = ''
 
@@ -28,7 +27,8 @@ var s = require('net').createServer(function(sock) {
 })
 
 tape('setup', function(t) {
-  s.listen(port, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -37,7 +37,7 @@ tape('proxy', function(t) {
   request({
     tunnel: true,
     url: 'http://' + proxiedHost,
-    proxy: 'http://localhost:' + port,
+    proxy: s.url,
     headers: {
       'Proxy-Authorization' : 'Basic dXNlcjpwYXNz',
       'authorization'       : 'Token deadbeef',

--- a/tests/test-proxy.js
+++ b/tests/test-proxy.js
@@ -79,228 +79,228 @@ function runTest(name, options, responseHandler) {
   })
 }
 
-tape('setup', function(t) {
-  s.listen(s.port, function() {
-    t.end()
-  })
-})
+function addTests() {
+  // If the `runTest` function is changed, run the following command and make
+  // sure both of these tests fail:
+  //
+  //   TEST_PROXY_HARNESS=y node tests/test-proxy.js
 
+  if (process.env.TEST_PROXY_HARNESS) {
 
-// If the `runTest` function is changed, run the following command and make
-// sure both of these tests fail:
-//
-//   TEST_PROXY_HARNESS=y node tests/test-proxy.js
+    runTest('should fail with "proxy response should not be called"', {
+      proxy : s.url
+    }, false)
 
-if (process.env.TEST_PROXY_HARNESS) {
+    runTest('should fail with "proxy response should be called"', {
+      proxy : null
+    }, true)
 
-  runTest('should fail with "proxy response should not be called"', {
-    proxy : s.url
-  }, false)
+  } else {
+    // Run the real tests
 
-  runTest('should fail with "proxy response should be called"', {
-    proxy : null
-  }, true)
+    runTest('basic proxy', {
+      proxy   : s.url,
+      headers : {
+        'proxy-authorization': 'Token Fooblez'
+      }
+    }, function(t, req, res) {
+      t.equal(req.headers['proxy-authorization'], 'Token Fooblez')
+    })
 
-} else {
-  // Run the real tests
+    runTest('proxy auth without uri auth', {
+      proxy : 'http://user:pass@localhost:' + s.port
+    }, function(t, req, res) {
+      t.equal(req.headers['proxy-authorization'], 'Basic dXNlcjpwYXNz')
+    })
 
-  runTest('basic proxy', {
-    proxy   : s.url,
-    headers : {
-      'proxy-authorization': 'Token Fooblez'
-    }
-  }, function(t, req, res) {
-    t.equal(req.headers['proxy-authorization'], 'Token Fooblez')
-  })
+    // http: urls and basic proxy settings
 
-  runTest('proxy auth without uri auth', {
-    proxy : 'http://user:pass@localhost:' + s.port
-  }, function(t, req, res) {
-    t.equal(req.headers['proxy-authorization'], 'Basic dXNlcjpwYXNz')
-  })
+    runTest('HTTP_PROXY environment variable and http: url', {
+      env : { HTTP_PROXY : s.url }
+    }, true)
 
-  // http: urls and basic proxy settings
+    runTest('http_proxy environment variable and http: url', {
+      env : { http_proxy : s.url }
+    }, true)
 
-  runTest('HTTP_PROXY environment variable and http: url', {
-    env : { HTTP_PROXY : s.url }
-  }, true)
+    runTest('HTTPS_PROXY environment variable and http: url', {
+      env : { HTTPS_PROXY : s.url }
+    }, false)
 
-  runTest('http_proxy environment variable and http: url', {
-    env : { http_proxy : s.url }
-  }, true)
+    runTest('https_proxy environment variable and http: url', {
+      env : { https_proxy : s.url }
+    }, false)
 
-  runTest('HTTPS_PROXY environment variable and http: url', {
-    env : { HTTPS_PROXY : s.url }
-  }, false)
+    // https: urls and basic proxy settings
 
-  runTest('https_proxy environment variable and http: url', {
-    env : { https_proxy : s.url }
-  }, false)
+    runTest('HTTP_PROXY environment variable and https: url', {
+      env    : { HTTP_PROXY : s.url },
+      url    : 'https://google.com',
+      tunnel : false,
+      pool   : false
+    }, true)
 
-  // https: urls and basic proxy settings
+    runTest('http_proxy environment variable and https: url', {
+      env    : { http_proxy : s.url },
+      url    : 'https://google.com',
+      tunnel : false
+    }, true)
 
-  runTest('HTTP_PROXY environment variable and https: url', {
-    env    : { HTTP_PROXY : s.url },
-    url    : 'https://google.com',
-    tunnel : false,
-    pool   : false
-  }, true)
+    runTest('HTTPS_PROXY environment variable and https: url', {
+      env    : { HTTPS_PROXY : s.url },
+      url    : 'https://google.com',
+      tunnel : false
+    }, true)
 
-  runTest('http_proxy environment variable and https: url', {
-    env    : { http_proxy : s.url },
-    url    : 'https://google.com',
-    tunnel : false
-  }, true)
+    runTest('https_proxy environment variable and https: url', {
+      env    : { https_proxy : s.url },
+      url    : 'https://google.com',
+      tunnel : false
+    }, true)
 
-  runTest('HTTPS_PROXY environment variable and https: url', {
-    env    : { HTTPS_PROXY : s.url },
-    url    : 'https://google.com',
-    tunnel : false
-  }, true)
+    runTest('multiple environment variables and https: url', {
+      env : {
+        HTTPS_PROXY : s.url,
+        HTTP_PROXY  : 'http://localhost:0/'
+      },
+      url    : 'https://google.com',
+      tunnel : false
+    }, true)
 
-  runTest('https_proxy environment variable and https: url', {
-    env    : { https_proxy : s.url },
-    url    : 'https://google.com',
-    tunnel : false
-  }, true)
+    // no_proxy logic
 
-  runTest('multiple environment variables and https: url', {
-    env : {
-      HTTPS_PROXY : s.url,
-      HTTP_PROXY  : 'http://localhost:4/'
-    },
-    url    : 'https://google.com',
-    tunnel : false
-  }, true)
+    runTest('NO_PROXY hostnames are case insensitive', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'GOOGLE.COM'
+      }
+    }, false)
 
-  // no_proxy logic
+    runTest('NO_PROXY hostnames are case insensitive 2', {
+      env : {
+        http_proxy : s.url,
+        NO_PROXY   : 'GOOGLE.COM'
+      }
+    }, false)
 
-  runTest('NO_PROXY hostnames are case insensitive', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'GOOGLE.COM'
-    }
-  }, false)
+    runTest('NO_PROXY hostnames are case insensitive 3', {
+      env : {
+        HTTP_PROXY : s.url,
+        no_proxy   : 'GOOGLE.COM'
+      }
+    }, false)
 
-  runTest('NO_PROXY hostnames are case insensitive 2', {
-    env : {
-      http_proxy : s.url,
-      NO_PROXY   : 'GOOGLE.COM'
-    }
-  }, false)
+    runTest('NO_PROXY ignored with explicit proxy passed', {
+      env   : { NO_PROXY : '*' },
+      proxy : s.url
+    }, true)
 
-  runTest('NO_PROXY hostnames are case insensitive 3', {
-    env : {
-      HTTP_PROXY : s.url,
-      no_proxy   : 'GOOGLE.COM'
-    }
-  }, false)
+    runTest('NO_PROXY overrides HTTP_PROXY for specific hostname', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'google.com'
+      }
+    }, false)
 
-  runTest('NO_PROXY ignored with explicit proxy passed', {
-    env   : { NO_PROXY : '*' },
-    proxy : s.url
-  }, true)
+    runTest('no_proxy overrides HTTP_PROXY for specific hostname', {
+      env : {
+        HTTP_PROXY : s.url,
+        no_proxy   : 'google.com'
+      }
+    }, false)
 
-  runTest('NO_PROXY overrides HTTP_PROXY for specific hostname', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'google.com'
-    }
-  }, false)
+    runTest('NO_PROXY does not override HTTP_PROXY if no hostnames match', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'foo.bar,bar.foo'
+      }
+    }, true)
 
-  runTest('no_proxy overrides HTTP_PROXY for specific hostname', {
-    env : {
-      HTTP_PROXY : s.url,
-      no_proxy   : 'google.com'
-    }
-  }, false)
+    runTest('NO_PROXY overrides HTTP_PROXY if a hostname matches', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'foo.bar,google.com'
+      }
+    }, false)
 
-  runTest('NO_PROXY does not override HTTP_PROXY if no hostnames match', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'foo.bar,bar.foo'
-    }
-  }, true)
+    runTest('NO_PROXY allows an explicit port', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'google.com:80'
+      }
+    }, false)
 
-  runTest('NO_PROXY overrides HTTP_PROXY if a hostname matches', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'foo.bar,google.com'
-    }
-  }, false)
+    runTest('NO_PROXY only overrides HTTP_PROXY if the port matches', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'google.com:1234'
+      }
+    }, true)
 
-  runTest('NO_PROXY allows an explicit port', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'google.com:80'
-    }
-  }, false)
+    runTest('NO_PROXY=* should override HTTP_PROXY for all hosts', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : '*'
+      }
+    }, false)
 
-  runTest('NO_PROXY only overrides HTTP_PROXY if the port matches', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'google.com:1234'
-    }
-  }, true)
+    runTest('NO_PROXY should override HTTP_PROXY for all subdomains', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'google.com'
+      },
+      headers : { host : 'www.google.com' }
+    }, false)
 
-  runTest('NO_PROXY=* should override HTTP_PROXY for all hosts', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : '*'
-    }
-  }, false)
+    runTest('NO_PROXY should not override HTTP_PROXY for partial domain matches', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'oogle.com'
+      }
+    }, true)
 
-  runTest('NO_PROXY should override HTTP_PROXY for all subdomains', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'google.com'
-    },
-    headers : { host : 'www.google.com' }
-  }, false)
+    runTest('NO_PROXY with port should not override HTTP_PROXY for partial domain matches', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'oogle.com:80'
+      }
+    }, true)
 
-  runTest('NO_PROXY should not override HTTP_PROXY for partial domain matches', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'oogle.com'
-    }
-  }, true)
+    // misc
 
-  runTest('NO_PROXY with port should not override HTTP_PROXY for partial domain matches', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'oogle.com:80'
-    }
-  }, true)
+    // this fails if the check 'isMatchedAt > -1' in lib/getProxyFromURI.js is
+    // missing or broken
+    runTest('http_proxy with length of one more than the URL', {
+      env : {
+        HTTP_PROXY : s.url,
+        NO_PROXY   : 'elgoog1.com' // one more char than google.com
+      }
+    }, true)
 
-  // misc
+    runTest('proxy: null should override HTTP_PROXY', {
+      env     : { HTTP_PROXY : s.url },
+      proxy   : null,
+      timeout : 500
+    }, false)
 
-  // this fails if the check 'isMatchedAt > -1' in lib/getProxyFromURI.js is
-  // missing or broken
-  runTest('http_proxy with length of one more than the URL', {
-    env : {
-      HTTP_PROXY : s.url,
-      NO_PROXY   : 'elgoog1.com' // one more char than google.com
-    }
-  }, true)
-
-  runTest('proxy: null should override HTTP_PROXY', {
-    env     : { HTTP_PROXY : s.url },
-    proxy   : null,
-    timeout : 500
-  }, false)
-
-  runTest('uri auth without proxy auth', {
-    url   : 'http://user:pass@google.com',
-    proxy : s.url
-  }, function(t, req, res) {
-    t.equal(req.headers['proxy-authorization'], undefined)
-    t.equal(req.headers.authorization, 'Basic dXNlcjpwYXNz')
-  })
+    runTest('uri auth without proxy auth', {
+      url   : 'http://user:pass@google.com',
+      proxy : s.url
+    }, function(t, req, res) {
+      t.equal(req.headers['proxy-authorization'], undefined)
+      t.equal(req.headers.authorization, 'Basic dXNlcjpwYXNz')
+    })
+  }
 }
 
-
-tape('cleanup', function(t) {
-  s.close(function() {
+tape('setup', function(t) {
+  s.listen(0, function() {
+    addTests()
+    tape('cleanup', function(t) {
+      s.close(function() {
+        t.end()
+      })
+    })
     t.end()
   })
 })

--- a/tests/test-redirect-complex.js
+++ b/tests/test-redirect-complex.js
@@ -47,9 +47,9 @@ function bouncy(s, serverUrl) {
 }
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
-    bouncy(s, ss.url)
-    ss.listen(ss.port, function() {
+  s.listen(0, function() {
+    ss.listen(0, function() {
+      bouncy(s, ss.url)
       bouncy(ss, s.url)
       t.end()
     })

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -72,8 +72,8 @@ function bouncer(code, label, hops) {
 }
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
-    ss.listen(ss.port, function() {
+  s.listen(0, function() {
+    ss.listen(0, function() {
       bouncer(301, 'temp')
       bouncer(301, 'double', 2)
       bouncer(301, 'treble', 3)

--- a/tests/test-rfc3986.js
+++ b/tests/test-rfc3986.js
@@ -27,9 +27,9 @@ function runTest (t, options) {
     })
   })
 
-  server.listen(6767, function() {
-
-    request.post('http://localhost:6767', options, function(err, res, body) {
+  server.listen(0, function() {
+    var port = this.address().port
+    request.post('http://localhost:' + port, options, function(err, res, body) {
       t.equal(err, null)
       server.close(function() {
         t.end()

--- a/tests/test-stream.js
+++ b/tests/test-stream.js
@@ -12,14 +12,17 @@ tape('before', function (t) {
   server.on('request', function (req, res) {
     req.pipe(res)
   })
-  server.listen(6767, t.end)
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
+    t.end()
+  })
 })
 
 tape('request body stream', function (t) {
   var fpath = path.join(__dirname, 'unicycle.jpg')
   var input = fs.createReadStream(fpath, {highWaterMark: 1000})
   request({
-    uri: 'http://localhost:6767',
+    uri: server.url,
     method: 'POST',
     body: input,
     encoding: null

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -22,7 +22,7 @@ s.on('/timeout', function(req, res) {
 })
 
 tape('setup', function(t) {
-  s.listen(s.port, function() {
+  s.listen(0, function() {
     t.end()
   })
 })

--- a/tests/test-timing.js
+++ b/tests/test-timing.js
@@ -8,7 +8,7 @@ var plain_server = server.createServer()
   , redirect_mock_time = 10
 
 tape('setup', function(t) {
-  plain_server.listen(plain_server.port, function() {
+  plain_server.listen(0, function() {
     plain_server.on('/', function (req, res) {
       res.writeHead(200)
       res.end('plain')

--- a/tests/test-toJSON.js
+++ b/tests/test-toJSON.js
@@ -10,14 +10,15 @@ var s = http.createServer(function (req, resp) {
 })
 
 tape('setup', function(t) {
-  s.listen(6767, function() {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
 
 tape('request().toJSON()', function(t) {
   var r = request({
-    url: 'http://localhost:6767',
+    url: s.url,
     headers: { foo: 'bar' }
   }, function(err, res) {
     var json_r   = JSON.parse(JSON.stringify(r))

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -36,8 +36,8 @@ httpsOpts.ca = httpsOpts.ca || []
 httpsOpts.ca.push(ca)
 
 var s = server.createServer()
-  , ss = server.createSSLServer(null, sslOpts)
-  , ss2 = server.createSSLServer(ss.port + 1, mutualSSLOpts)
+  , ss = server.createSSLServer(sslOpts)
+  , ss2 = server.createSSLServer(mutualSSLOpts)
 
 // XXX when tunneling https over https, connections get left open so the server
 // doesn't want to close normally (and same issue with http server on v0.8.x)
@@ -101,16 +101,6 @@ setListeners(s, 'http')
 setListeners(ss, 'https')
 setListeners(ss2, 'https')
 
-tape('setup', function(t) {
-  s.listen(s.port, function() {
-    ss.listen(ss.port, function() {
-      ss2.listen(ss2.port, 'localhost', function() {
-        t.end()
-      })
-    })
-  })
-})
-
 // monkey-patch since you can't set a custom certificate authority for the
 // proxy in tunnel-agent (this is necessary for "* over https" tests)
 var customCaCount = 0
@@ -138,334 +128,344 @@ function runTest(name, opts, expected) {
   })
 }
 
+function addTests() {
+  // HTTP OVER HTTP
 
-// HTTP OVER HTTP
+  runTest('http over http, tunnel=true', {
+    url    : s.url,
+    proxy  : s.url,
+    tunnel : true
+  }, [
+    'http connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
 
-runTest('http over http, tunnel=true', {
-  url    : s.url,
-  proxy  : s.url,
-  tunnel : true
-}, [
-  'http connect to localhost:' + s.port,
-  'http response',
-  '200 http ok'
-])
+  runTest('http over http, tunnel=false', {
+    url    : s.url,
+    proxy  : s.url,
+    tunnel : false
+  }, [
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
 
-runTest('http over http, tunnel=false', {
-  url    : s.url,
-  proxy  : s.url,
-  tunnel : false
-}, [
-  'http proxy to http',
-  'http response',
-  '200 http ok'
-])
-
-runTest('http over http, tunnel=default', {
-  url    : s.url,
-  proxy  : s.url
-}, [
-  'http proxy to http',
-  'http response',
-  '200 http ok'
-])
-
-
-// HTTP OVER HTTPS
-
-runTest('http over https, tunnel=true', {
-  url    : s.url,
-  proxy  : ss.url,
-  tunnel : true
-}, [
-  'https connect to localhost:' + s.port,
-  'http response',
-  '200 http ok'
-])
-
-runTest('http over https, tunnel=false', {
-  url    : s.url,
-  proxy  : ss.url,
-  tunnel : false
-}, [
-  'https proxy to http',
-  'http response',
-  '200 http ok'
-])
-
-runTest('http over https, tunnel=default', {
-  url    : s.url,
-  proxy  : ss.url
-}, [
-  'https proxy to http',
-  'http response',
-  '200 http ok'
-])
+  runTest('http over http, tunnel=default', {
+    url    : s.url,
+    proxy  : s.url
+  }, [
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
 
 
-// HTTPS OVER HTTP
+  // HTTP OVER HTTPS
 
-runTest('https over http, tunnel=true', {
-  url    : ss.url,
-  proxy  : s.url,
-  tunnel : true
-}, [
-  'http connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('http over https, tunnel=true', {
+    url    : s.url,
+    proxy  : ss.url,
+    tunnel : true
+  }, [
+    'https connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
 
-runTest('https over http, tunnel=false', {
-  url    : ss.url,
-  proxy  : s.url,
-  tunnel : false
-}, [
-  'http proxy to https',
-  'https response',
-  '200 https ok'
-])
+  runTest('http over https, tunnel=false', {
+    url    : s.url,
+    proxy  : ss.url,
+    tunnel : false
+  }, [
+    'https proxy to http',
+    'http response',
+    '200 http ok'
+  ])
 
-runTest('https over http, tunnel=default', {
-  url    : ss.url,
-  proxy  : s.url
-}, [
-  'http connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
-
-
-// HTTPS OVER HTTPS
-
-runTest('https over https, tunnel=true', {
-  url    : ss.url,
-  proxy  : ss.url,
-  tunnel : true
-}, [
-  'https connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
-
-runTest('https over https, tunnel=false', {
-  url    : ss.url,
-  proxy  : ss.url,
-  tunnel : false,
-  pool   : false // must disable pooling here or Node.js hangs
-}, [
-  'https proxy to https',
-  'https response',
-  '200 https ok'
-])
-
-runTest('https over https, tunnel=default', {
-  url    : ss.url,
-  proxy  : ss.url
-}, [
-  'https connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('http over https, tunnel=default', {
+    url    : s.url,
+    proxy  : ss.url
+  }, [
+    'https proxy to http',
+    'http response',
+    '200 http ok'
+  ])
 
 
-// HTTP->HTTP OVER HTTP
+  // HTTPS OVER HTTP
 
-runTest('http->http over http, tunnel=true', {
-  url    : s.url + '/redirect/http',
-  proxy  : s.url,
-  tunnel : true
-}, [
-  'http connect to localhost:' + s.port,
-  'http redirect to http',
-  'http connect to localhost:' + s.port,
-  'http response',
-  '200 http ok'
-])
+  runTest('https over http, tunnel=true', {
+    url    : ss.url,
+    proxy  : s.url,
+    tunnel : true
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
 
-runTest('http->http over http, tunnel=false', {
-  url    : s.url + '/redirect/http',
-  proxy  : s.url,
-  tunnel : false
-}, [
-  'http proxy to http->http',
-  'http redirect to http',
-  'http proxy to http',
-  'http response',
-  '200 http ok'
-])
+  runTest('https over http, tunnel=false', {
+    url    : ss.url,
+    proxy  : s.url,
+    tunnel : false
+  }, [
+    'http proxy to https',
+    'https response',
+    '200 https ok'
+  ])
 
-runTest('http->http over http, tunnel=default', {
-  url    : s.url + '/redirect/http',
-  proxy  : s.url
-}, [
-  'http proxy to http->http',
-  'http redirect to http',
-  'http proxy to http',
-  'http response',
-  '200 http ok'
-])
+  runTest('https over http, tunnel=default', {
+    url    : ss.url,
+    proxy  : s.url
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
 
 
-// HTTP->HTTPS OVER HTTP
+  // HTTPS OVER HTTPS
 
-runTest('http->https over http, tunnel=true', {
-  url    : s.url + '/redirect/https',
-  proxy  : s.url,
-  tunnel : true
-}, [
-  'http connect to localhost:' + s.port,
-  'http redirect to https',
-  'http connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('https over https, tunnel=true', {
+    url    : ss.url,
+    proxy  : ss.url,
+    tunnel : true
+  }, [
+    'https connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
 
-runTest('http->https over http, tunnel=false', {
-  url    : s.url + '/redirect/https',
-  proxy  : s.url,
-  tunnel : false
-}, [
-  'http proxy to http->https',
-  'http redirect to https',
-  'http proxy to https',
-  'https response',
-  '200 https ok'
-])
+  runTest('https over https, tunnel=false', {
+    url    : ss.url,
+    proxy  : ss.url,
+    tunnel : false,
+    pool   : false // must disable pooling here or Node.js hangs
+  }, [
+    'https proxy to https',
+    'https response',
+    '200 https ok'
+  ])
 
-runTest('http->https over http, tunnel=default', {
-  url    : s.url + '/redirect/https',
-  proxy  : s.url
-}, [
-  'http proxy to http->https',
-  'http redirect to https',
-  'http connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('https over https, tunnel=default', {
+    url    : ss.url,
+    proxy  : ss.url
+  }, [
+    'https connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
 
 
-// HTTPS->HTTP OVER HTTP
+  // HTTP->HTTP OVER HTTP
 
-runTest('https->http over http, tunnel=true', {
-  url    : ss.url + '/redirect/http',
-  proxy  : s.url,
-  tunnel : true
-}, [
-  'http connect to localhost:' + ss.port,
-  'https redirect to http',
-  'http connect to localhost:' + s.port,
-  'http response',
-  '200 http ok'
-])
+  runTest('http->http over http, tunnel=true', {
+    url    : s.url + '/redirect/http',
+    proxy  : s.url,
+    tunnel : true
+  }, [
+    'http connect to localhost:' + s.port,
+    'http redirect to http',
+    'http connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
 
-runTest('https->http over http, tunnel=false', {
-  url    : ss.url + '/redirect/http',
-  proxy  : s.url,
-  tunnel : false
-}, [
-  'http proxy to https->http',
-  'https redirect to http',
-  'http proxy to http',
-  'http response',
-  '200 http ok'
-])
+  runTest('http->http over http, tunnel=false', {
+    url    : s.url + '/redirect/http',
+    proxy  : s.url,
+    tunnel : false
+  }, [
+    'http proxy to http->http',
+    'http redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
 
-runTest('https->http over http, tunnel=default', {
-  url    : ss.url + '/redirect/http',
-  proxy  : s.url
-}, [
-  'http connect to localhost:' + ss.port,
-  'https redirect to http',
-  'http proxy to http',
-  'http response',
-  '200 http ok'
-])
-
-
-// HTTPS->HTTPS OVER HTTP
-
-runTest('https->https over http, tunnel=true', {
-  url    : ss.url + '/redirect/https',
-  proxy  : s.url,
-  tunnel : true
-}, [
-  'http connect to localhost:' + ss.port,
-  'https redirect to https',
-  'http connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
-
-runTest('https->https over http, tunnel=false', {
-  url    : ss.url + '/redirect/https',
-  proxy  : s.url,
-  tunnel : false
-}, [
-  'http proxy to https->https',
-  'https redirect to https',
-  'http proxy to https',
-  'https response',
-  '200 https ok'
-])
-
-runTest('https->https over http, tunnel=default', {
-  url    : ss.url + '/redirect/https',
-  proxy  : s.url
-}, [
-  'http connect to localhost:' + ss.port,
-  'https redirect to https',
-  'http connect to localhost:' + ss.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('http->http over http, tunnel=default', {
+    url    : s.url + '/redirect/http',
+    proxy  : s.url
+  }, [
+    'http proxy to http->http',
+    'http redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
 
 
-// MUTUAL HTTPS OVER HTTP
+  // HTTP->HTTPS OVER HTTP
 
-runTest('mutual https over http, tunnel=true', {
-  url        : ss2.url,
-  proxy      : s.url,
-  tunnel     : true,
-  cert       : clientCert,
-  key        : clientKey,
-  passphrase : clientPassword
-}, [
-  'http connect to localhost:' + ss2.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('http->https over http, tunnel=true', {
+    url    : s.url + '/redirect/https',
+    proxy  : s.url,
+    tunnel : true
+  }, [
+    'http connect to localhost:' + s.port,
+    'http redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
 
-// XXX causes 'Error: socket hang up'
-// runTest('mutual https over http, tunnel=false', {
-//   url        : ss2.url,
-//   proxy      : s.url,
-//   tunnel     : false,
-//   cert       : clientCert,
-//   key        : clientKey,
-//   passphrase : clientPassword
-// }, [
-//   'http connect to localhost:' + ss2.port,
-//   'https response',
-//   '200 https ok'
-// ])
+  runTest('http->https over http, tunnel=false', {
+    url    : s.url + '/redirect/https',
+    proxy  : s.url,
+    tunnel : false
+  }, [
+    'http proxy to http->https',
+    'http redirect to https',
+    'http proxy to https',
+    'https response',
+    '200 https ok'
+  ])
 
-runTest('mutual https over http, tunnel=default', {
-  url        : ss2.url,
-  proxy      : s.url,
-  cert       : clientCert,
-  key        : clientKey,
-  passphrase : clientPassword
-}, [
-  'http connect to localhost:' + ss2.port,
-  'https response',
-  '200 https ok'
-])
+  runTest('http->https over http, tunnel=default', {
+    url    : s.url + '/redirect/https',
+    proxy  : s.url
+  }, [
+    'http proxy to http->https',
+    'http redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
 
 
-tape('cleanup', function(t) {
-  s.destroy(function() {
-    ss.destroy(function() {
-      ss2.destroy(function() {
+  // HTTPS->HTTP OVER HTTP
+
+  runTest('https->http over http, tunnel=true', {
+    url    : ss.url + '/redirect/http',
+    proxy  : s.url,
+    tunnel : true
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to http',
+    'http connect to localhost:' + s.port,
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('https->http over http, tunnel=false', {
+    url    : ss.url + '/redirect/http',
+    proxy  : s.url,
+    tunnel : false
+  }, [
+    'http proxy to https->http',
+    'https redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+  runTest('https->http over http, tunnel=default', {
+    url    : ss.url + '/redirect/http',
+    proxy  : s.url
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to http',
+    'http proxy to http',
+    'http response',
+    '200 http ok'
+  ])
+
+
+  // HTTPS->HTTPS OVER HTTP
+
+  runTest('https->https over http, tunnel=true', {
+    url    : ss.url + '/redirect/https',
+    proxy  : s.url,
+    tunnel : true
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https->https over http, tunnel=false', {
+    url    : ss.url + '/redirect/https',
+    proxy  : s.url,
+    tunnel : false
+  }, [
+    'http proxy to https->https',
+    'https redirect to https',
+    'http proxy to https',
+    'https response',
+    '200 https ok'
+  ])
+
+  runTest('https->https over http, tunnel=default', {
+    url    : ss.url + '/redirect/https',
+    proxy  : s.url
+  }, [
+    'http connect to localhost:' + ss.port,
+    'https redirect to https',
+    'http connect to localhost:' + ss.port,
+    'https response',
+    '200 https ok'
+  ])
+
+
+  // MUTUAL HTTPS OVER HTTP
+
+  runTest('mutual https over http, tunnel=true', {
+    url        : ss2.url,
+    proxy      : s.url,
+    tunnel     : true,
+    cert       : clientCert,
+    key        : clientKey,
+    passphrase : clientPassword
+  }, [
+    'http connect to localhost:' + ss2.port,
+    'https response',
+    '200 https ok'
+  ])
+
+  // XXX causes 'Error: socket hang up'
+  // runTest('mutual https over http, tunnel=false', {
+  //   url        : ss2.url,
+  //   proxy      : s.url,
+  //   tunnel     : false,
+  //   cert       : clientCert,
+  //   key        : clientKey,
+  //   passphrase : clientPassword
+  // }, [
+  //   'http connect to localhost:' + ss2.port,
+  //   'https response',
+  //   '200 https ok'
+  // ])
+
+  runTest('mutual https over http, tunnel=default', {
+    url        : ss2.url,
+    proxy      : s.url,
+    cert       : clientCert,
+    key        : clientKey,
+    passphrase : clientPassword
+  }, [
+    'http connect to localhost:' + ss2.port,
+    'https response',
+    '200 https ok'
+  ])
+}
+
+tape('setup', function(t) {
+  s.listen(0, function() {
+    ss.listen(0, function() {
+      ss2.listen(0, 'localhost', function() {
+        addTests()
+        tape('cleanup', function(t) {
+          s.destroy(function() {
+            ss.destroy(function() {
+              ss2.destroy(function() {
+                t.end()
+              })
+            })
+          })
+        })
         t.end()
       })
     })


### PR DESCRIPTION
What started out as a simple re-enabling of `tests/test-timeout.js` on Travis has turned into more cleanup and fixes along the way.

If you want any of these commits parted out into separate PRs, let me know.

I have tested these commits on Travis many times now and each time all 4 node targets have been green, so I am fairly confident not only about `tests/test-timeout.js`, but also flaky tests in `tests/test-pipes.js`, and other random failures.

One possibly "major" change included here is the change in timeout behavior. IMHO the timeout changes (in request.js) I've provided here more accurately reflect the intended behavior.