### PR TITLE
Add config option to disable body or form encoding

### DIFF
--- a/request.js
+++ b/request.js
@@ -257,6 +257,8 @@ Request.prototype.init = function (options) {
     self.rejectUnauthorized = false
   }
 
+  self._disableEncoding = !!options.disableEncoding
+
   if (!self.uri.pathname) {self.uri.pathname = '/'}
 
   if (!(self.uri.host || (self.uri.hostname && self.uri.port)) && !self.uri.isUnix) {
@@ -1137,6 +1139,10 @@ Request.prototype.form = function (form) {
     if (!/^application\/x-www-form-urlencoded\b/.test(self.getHeader('content-type'))) {
       self.setHeader('content-type', 'application/x-www-form-urlencoded')
     }
+    if (self._disableEncoding) {
+      self.body = form.toString('utf8')
+      return self
+    }
     self.body = (typeof form === 'string')
       ? self._qs.rfc3986(form.toString('utf8'))
       : self._qs.stringify(form).toString('utf8')
@@ -1178,6 +1184,8 @@ Request.prototype.json = function (val) {
     if (self.body !== undefined) {
       if (!/^application\/x-www-form-urlencoded\b/.test(self.getHeader('content-type'))) {
         self.body = safeStringify(self.body, self._jsonReplacer)
+      } else if (self._disableEncoding) {
+        self.body = self.body
       } else {
         self.body = self._qs.rfc3986(self.body)
       }


### PR DESCRIPTION
This allows for sending data exactly as it's intended, like cURL. We need this (or a comparable workaround) to POST data without it being altered by `rfc3986()`. See https://github.com/splunk/splunk-javascript-logging/issues/9

I'm happy to add some tests with a bit of guidance!
I saw the following test error on Node 4, but not on 6:

```
/Users/me/git/request/tests/test-headers.js:172
    t.equal(err.message, 'The header content contains invalid characters')
```