### PR TITLE
Handle buffers directly instead of using "bl"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "aws-sign2": "~0.6.0",
     "aws4": "^1.2.1",
-    "bl": "~1.1.2",
     "caseless": "~0.11.0",
     "combined-stream": "~1.0.5",
     "extend": "~3.0.0",


### PR DESCRIPTION
`bl` does a lot, but `request`'s needs are pretty simple. This PR removes `bl` in favor of operating on buffers directly. There is no change in functionality here - `bl` also calls `Buffer.concat` when slicing an all buffer `BufferList`.