### PR TITLE
Remove "isFunction" helper in favor of "typeof" check

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ var extend                = require('extend')
   , cookies               = require('./lib/cookies')
   , helpers               = require('./lib/helpers')
 
-var isFunction            = helpers.isFunction
-  , paramsHaveRequestBody = helpers.paramsHaveRequestBody
+var paramsHaveRequestBody = helpers.paramsHaveRequestBody
 
 
 // organize params for patch, post, put, head, del
@@ -95,7 +94,7 @@ function wrapRequestMethod (method, options, requester, verb) {
       target.method = verb.toUpperCase()
     }
 
-    if (isFunction(requester)) {
+    if (typeof requester === 'function') {
       method = requester
     }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -11,10 +11,6 @@ function deferMethod() {
   return setImmediate
 }
 
-function isFunction(value) {
-  return typeof value === 'function'
-}
-
 function paramsHaveRequestBody(params) {
   return (
     params.body ||
@@ -63,7 +59,6 @@ function version () {
   }
 }
 
-exports.isFunction            = isFunction
 exports.paramsHaveRequestBody = paramsHaveRequestBody
 exports.safeStringify         = safeStringify
 exports.md5                   = md5


### PR DESCRIPTION
There's already precedent for function `typeof` checks - in fact there are more of them, than `isFunction` calls.