### PR TITLE
Use own "isStream" helper

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,7 @@
 
 var jsonSafeStringify = require('json-stringify-safe')
   , crypto = require('crypto')
+  , stream = require('stream')
 
 var defer = typeof setImmediate === 'undefined'
   ? process.nextTick
@@ -28,6 +29,10 @@ function safeStringify (obj, replacer) {
 
 function md5 (str) {
   return crypto.createHash('md5').update(str).digest('hex')
+}
+
+function isStream (obj) {
+  return obj instanceof stream.Stream
 }
 
 function isReadStream (rs) {
@@ -58,6 +63,7 @@ function version () {
 exports.paramsHaveRequestBody = paramsHaveRequestBody
 exports.safeStringify         = safeStringify
 exports.md5                   = md5
+exports.isStream              = isStream
 exports.isReadStream          = isReadStream
 exports.toBase64              = toBase64
 exports.copy                  = copy

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -2,7 +2,9 @@
 
 var uuid = require('node-uuid')
   , CombinedStream = require('combined-stream')
-  , isstream = require('isstream')
+  , helpers = require('./helpers')
+
+var isStream = helpers.isStream
 
 
 function Multipart (request) {
@@ -34,7 +36,7 @@ Multipart.prototype.isChunked = function (options) {
       if (typeof part.body === 'undefined') {
         self.request.emit('error', new Error('Body attribute missing in multipart.'))
       }
-      if (isstream(part.body)) {
+      if (isStream(part.body)) {
         chunked = true
       }
     })

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "hawk": "~3.1.3",
     "http-signature": "~1.1.0",
     "is-typedarray": "~1.0.0",
-    "isstream": "~0.1.2",
     "json-stringify-safe": "~5.0.1",
     "mime-types": "~2.1.7",
     "node-uuid": "~1.4.7",

--- a/request.js
+++ b/request.js
@@ -17,7 +17,6 @@ var http = require('http')
   , ForeverAgent = require('forever-agent')
   , FormData = require('form-data')
   , extend = require('extend')
-  , isstream = require('isstream')
   , isTypedArray = require('is-typedarray').strict
   , helpers = require('./lib/helpers')
   , cookies = require('./lib/cookies')
@@ -31,6 +30,7 @@ var http = require('http')
   , Tunnel = require('./lib/tunnel').Tunnel
 
 var safeStringify = helpers.safeStringify
+  , isStream = helpers.isStream
   , isReadStream = helpers.isReadStream
   , toBase64 = helpers.toBase64
   , defer = helpers.defer
@@ -440,7 +440,7 @@ Request.prototype.init = function (options) {
       }
     }
   }
-  if (self.body && !isstream(self.body)) {
+  if (self.body && !isStream(self.body)) {
     setContentLength()
   }
 
@@ -540,7 +540,7 @@ Request.prototype.init = function (options) {
         self._multipart.body.pipe(self)
       }
       if (self.body) {
-        if (isstream(self.body)) {
+        if (isStream(self.body)) {
           self.body.pipe(self)
         } else {
           setContentLength()


### PR DESCRIPTION
Equivalent check as `isstream`, but this way related functionality is kept together for clarity (next to the preexisting `isReadStream`) - and you simplify the dependency graph a bit.
