### PR TITLE
Improve timeouts accuracy and node v6.8.0+ compatibility

### DIFF
--- a/request.js
+++ b/request.js
@@ -754,7 +754,11 @@ Request.prototype.start = function () {
 
   var timeout
   if (self.timeout && !self.timeoutTimer) {
-    timeout = self.timeout < 0 ? 0 : self.timeout
+    if (self.timeout < 0) {
+      timeout = 0
+    } else if (typeof self.timeout === 'number' && isFinite(self.timeout)) {
+      timeout = self.timeout
+    }
   }
 
   self.req.on('response', self.onRequestResponse.bind(self))
@@ -763,7 +767,7 @@ Request.prototype.start = function () {
     self.emit('drain')
   })
   self.req.on('socket', function(socket) {
-    if (typeof timeout === 'number') {
+    if (timeout !== undefined) {
       socket.once('connect', function() {
         clearTimeout(self.timeoutTimer)
         self.timeoutTimer = null

--- a/request.js
+++ b/request.js
@@ -736,6 +736,11 @@ Request.prototype.start = function () {
 
   debug('make request', self.uri.href)
 
+  // node v6.8.0 now supports a `timeout` value in `http.request()`, but we
+  // should delete it for now since we handle timeouts manually for better
+  // consistency with node versions before v6.8.0
+  delete reqOptions.timeout
+
   try {
     self.req = self.httpModule.request(reqOptions)
   } catch (err) {


### PR DESCRIPTION
This PR fixes a timeout-related compatibility issue with node v6.8.0+ and makes the connection and request/response timeout more accurate by starting them at more appropriate times.