### PR TITLE
Add followOriginalHttpMethod to redirect to original HTTP method

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 - `followRedirect` - follow HTTP 3xx responses as redirects (default: `true`). This property can also be implemented as function which gets `response` object as a single argument and should return `true` if redirects should continue or `false` otherwise.
 - `followAllRedirects` - follow non-GET HTTP 3xx responses as redirects (default: `false`)
+- `followOriginalHttpMethod` - by default we redirect to HTTP method GET. you can enable this property to redirect to the original HTTP method (default: `false`)
 - `maxRedirects` - the maximum number of redirects to follow (default: `10`)
 - `removeRefererHeader` - removes the referer header when a redirect happens (default: `false`). **Note:** if true, referer header set in the initial request is preserved during redirect chain.
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -8,6 +8,7 @@ function Redirect (request) {
   this.followRedirect = true
   this.followRedirects = true
   this.followAllRedirects = false
+  this.followOriginalHttpMethod = false
   this.allowRedirect = function () {return true}
   this.maxRedirects = 10
   this.redirects = []
@@ -35,6 +36,9 @@ Redirect.prototype.onRequest = function (options) {
   }
   if (options.removeRefererHeader !== undefined) {
     self.removeRefererHeader = options.removeRefererHeader
+  }
+  if (options.followOriginalHttpMethod !== undefined) {
+    self.followOriginalHttpMethod = options.followOriginalHttpMethod
   }
 }
 
@@ -115,7 +119,7 @@ Redirect.prototype.onResponse = function (response) {
   )
   if (self.followAllRedirects && request.method !== 'HEAD'
     && response.statusCode !== 401 && response.statusCode !== 307) {
-    request.method = 'GET'
+    request.method = self.followOriginalHttpMethod ? request.method : 'GET'
   }
   // request.method = 'GET' // Force all redirects to use GET || commented out fixes #215
   delete request.src

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -186,6 +186,24 @@ tape('should follow post redirects when followallredirects true', function(t) {
   })
 })
 
+tape('should follow post redirects when followallredirects true and followOriginalHttpMethod is enabled', function(t) {
+  hits = {}
+  request.post({
+    uri: s.url + '/temp',
+    followAllRedirects: true,
+    followOriginalHttpMethod: true,
+    jar: jar,
+    headers: { cookie: 'foo=bar' }
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(hits.temp, 'Original request is to /temp')
+    t.ok(hits.temp_landing, 'Forward to temporary landing URL')
+    t.equal(body, 'POST temp_landing', 'Got temporary landing content')
+    t.end()
+  })
+})
+
 tape('should not follow post redirects when followallredirects false', function(t) {
   hits = {}
   request.post({


### PR DESCRIPTION
Hey 👋

closes #2118

You can set `followOriginalHttpMethod` to follow the original HTTP method.
The problem was that request followed the requests with a hardcoded HTTP method.

---

An alternative solution would be to always redirect to the original HTTP method. Tell me what do you prefer and i will update my PR 👍 