### PR TITLE
Support temporary redirects with authorization

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -125,7 +125,7 @@ Redirect.prototype.onResponse = function (response) {
   delete request.src
   delete request.req
   delete request._started
-  if (response.statusCode !== 401 && response.statusCode !== 307) {
+  if (response.statusCode !== 401) {
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.
     delete request.body


### PR DESCRIPTION
This PR is to remove the exclusion of 307 redirects when removing authorization headers. I'm not sure why this was excluded in the first place, but it's causing issues when I try to authenticate with a server that uses 307 instead of 301/302 to redirect after successfully authenticating. 

Original issue is here: #2455 

Authentication spec makes no mention of special handling for 307 redirects: http://www.webdav.org/specs/rfc2617.html#the.authorization.request.header