### PR TITLE
Update Init to include the npm_config_strict_ssl env param

### DIFF
--- a/request.js
+++ b/request.js
@@ -252,7 +252,8 @@ Request.prototype.init = function (options) {
     self.enableUnixSocket()
   }
 
-  if (self.strictSSL === false) {
+  if (self.strictSSL === false ||
+      process.env.npm_config_strict_ssl === false) {
     self.rejectUnauthorized = false
   }
 
@@ -276,10 +277,6 @@ Request.prototype.init = function (options) {
 
   if (!self.hasOwnProperty('proxy')) {
     self.proxy = getProxyFromURI(self.uri)
-    //Check againt null instead because default is true and any specific callout would be false
-    if (process.env.npm_config_strict_ssl !== null) {
-        self.strictSSL = process.env.npm_config_strict_ssl
-    }
   }
 
   self.tunnel = self._tunnel.isEnabled()

--- a/request.js
+++ b/request.js
@@ -276,6 +276,10 @@ Request.prototype.init = function (options) {
 
   if (!self.hasOwnProperty('proxy')) {
     self.proxy = getProxyFromURI(self.uri)
+    //Check againt null instead because default is true and any specific callout would be false
+    if (process.env.npm_config_strict_ssl !== null) {
+        self.strictSSL = process.env.npm_config_strict_ssl
+    }
   }
 
   self.tunnel = self._tunnel.isEnabled()


### PR DESCRIPTION
In larger libraries that utilize Request, setting the strict ssl (and also the tunnel) setting is difficult. I often have to edit the source implementation to allow my system to access resources from behind a corporate proxy. This update would allow users to set the npm_config_strict_ssl environment variable to better customize the proxy implementation. 

I have run into this problem using Electron, node-pre-gyp, nightmare.js and a few other smaller npm packages.