### PR TITLE
Change tags to keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "request",
   "description": "Simplified HTTP request client.",
-  "tags": [
+  "keywords": [
     "http",
     "simple",
     "util",


### PR DESCRIPTION
I'm in the process of teaching my students about how to do PRs, and trying @mafintosh's [first PR idea](https://twitter.com/mafintosh/status/782288714785492992) with them.  As I was writing up an example for their lab, I noticed that the `package.json` here uses `tags` vs. `keywords.

This fixes it to properly include the existing keywords, which aren't currently being picked up by npmjs, see:

![screen shot 2017-01-16 at 12 19 07 pm](https://cloud.githubusercontent.com/assets/427398/22000458/29b69b58-dc0d-11e6-91ae-7b79bfd5e0c2.png)
