### PR TITLE
Add convenience method for HTTP OPTIONS

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ function verbFunc (verb) {
 // define like this to please codeintel/intellisense IDEs
 request.get = verbFunc('get')
 request.head = verbFunc('head')
+request.options = verbFunc('options')
 request.post = verbFunc('post')
 request.put = verbFunc('put')
 request.patch = verbFunc('patch')

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "util",
     "utility"
   ],
-  "version": "2.79.1",
+  "version": "2.80.0",
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "util",
     "utility"
   ],
-  "version": "2.80.0",
+  "version": "2.79.1",
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com>",
   "repository": {
     "type": "git",

--- a/tests/test-options-convenience-method.js
+++ b/tests/test-options-convenience-method.js
@@ -25,8 +25,10 @@ tape('setup', function (t) {
 })
 
 tape('options(string, function)', function (t) {
-  request.options(s.url + '/options', function (e, r) {
-    t.equal(r.headers['x-original-method'], 'OPTIONS')
+  request.options(s.url + '/options', function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['x-original-method'], 'OPTIONS')
     t.end()
   })
 })
@@ -35,8 +37,10 @@ tape('options(object, function)', function (t) {
   request.options({
     url: s.url + '/options',
     headers: { foo: 'bar' }
-  }, function (e, r) {
-    t.equal(r.headers['x-original-method'], 'OPTIONS')
+  }, function (err, res) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(res.headers['x-original-method'], 'OPTIONS')
     t.end()
   })
 })

--- a/tests/test-options-convenience-method.js
+++ b/tests/test-options-convenience-method.js
@@ -1,0 +1,48 @@
+'use strict'
+
+var server = require('./server')
+  , request = require('../index')
+  , tape = require('tape')
+  , destroyable = require('server-destroy')
+
+var s = server.createServer()
+
+destroyable(s)
+
+tape('setup', function (t) {
+  s.listen(0, function () {
+    s.on('/options', function (req, res) {
+      res.writeHead(200, {
+        'x-original-method': req.method,
+        'allow': 'OPTIONS, GET, HEAD'
+      })
+
+      res.end()
+    })
+
+    t.end()
+  })
+})
+
+tape('options(string, function)', function (t) {
+  request.options(s.url + '/options', function (e, r) {
+    t.equal(r.headers['x-original-method'], 'OPTIONS')
+    t.end()
+  })
+})
+
+tape('options(object, function)', function (t) {
+  request.options({
+    url: s.url + '/options',
+    headers: { foo: 'bar' }
+  }, function (e, r) {
+    t.equal(r.headers['x-original-method'], 'OPTIONS')
+    t.end()
+  })
+})
+
+tape('cleanup', function(t) {
+  s.destroy(function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
Hey guys,

I'm currently working on a feature that involves a HTTP OPTIONS request. I really appreciate the convenience methods as they are easy to stub with my library of choice (Sinon).

I noticed that there is not an equivalent for HTTP OPTIONS, so I've added one. There may be a reason why this hasn't been exposed already, but implementing it didn't impact any of the existing tests, plus searching the existing PRs and issues didn't suggest anything.

My PR also has new version number (i.e. new minor revision), but this is merely a suggestion; I'm sure you'll have your own processes surrounding this.

Let me know if you have any questions or thoughts.

Thanks,
James