### PR TITLE
Improvements in digest authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,15 +282,22 @@ If passed as an option, `auth` should be a hash containing values:
 - `pass` || `password`
 - `sendImmediately` (optional)
 - `bearer` (optional)
+- `disable` (optional)
 
 The method form takes parameters
-`auth(username, password, sendImmediately, bearer)`.
+`auth(username, password, sendImmediately, bearer, disable)`.
 
 `sendImmediately` defaults to `true`, which causes a basic or bearer
 authentication header to be sent.  If `sendImmediately` is `false`, then
 `request` will retry with a proper authentication header after receiving a
 `401` response from the server (which must contain a `WWW-Authenticate` header
 indicating the required authentication method).
+
+`disable` can be used to disable the use of any of the authentication methods when `sendImmedeatly` is set to `false`. 
+It is an object that may contain a boolean for each one of the three authentication
+methods supported (`basic`, `digest`, and `bearer`). If the coresponding boolean is set to `true`
+the request will fail if the `WWW-Authenticate` response from the server requires an authentication
+method that is disabled. By default, all methods are enabled.
 
 Note that you can also specify basic authentication using the URL itself, as
 detailed in [RFC 1738](http://www.ietf.org/rfc/rfc1738.txt).  Simply pass the

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -9,7 +9,7 @@ var md5 = helpers.md5
 
 
 
-function Auth (request, options) {
+function Auth (request) {
   // define all public properties here
   this.request = request
   this.hasAuth = false
@@ -17,7 +17,7 @@ function Auth (request, options) {
   this.bearerToken = null
   this.user = null
   this.pass = null
-  this.options = options
+  this.disable = null
 }
 
 Auth.prevDigestValue = null
@@ -32,7 +32,7 @@ Auth.prototype.resetPrevDigestAuth = function() {
 
 Auth.prototype.isEnabled = function(authMethod) {
   var self = this
-  return !(self.options && self.options.disabled && self.options.disabled[authMethod])
+  return !(self.disable && self.disable[authMethod])
 }
 
 Auth.prototype.basic = function (user, pass, sendImmediately) {
@@ -158,9 +158,10 @@ Auth.prototype.digest = function (user, pass, method, path, authHeader) {
   return authHeader
 }
 
-Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
+Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer, disable) {
   var self = this
     , request = self.request
+  self.disable = disable
 
   if (sendImmediately === undefined) {
     sendImmediately = true

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -8,7 +8,8 @@ var md5 = helpers.md5
   , toBase64 = helpers.toBase64
 
 
-function Auth (request) {
+
+function Auth (request, options) {
   // define all public properties here
   this.request = request
   this.hasAuth = false
@@ -16,6 +17,22 @@ function Auth (request) {
   this.bearerToken = null
   this.user = null
   this.pass = null
+  this.options = options
+}
+
+Auth.prevDigestValue = null
+
+Auth.prototype.isPrevDigestAuthValid = function() {
+  return Auth.prevDigestAuthValue
+}
+
+Auth.prototype.resetPrevDigestAuth = function() {
+  Auth.prevDigestAuthValue = null
+}
+
+Auth.prototype.isEnabled = function(authMethod) {
+  var self = this
+  return !(self.options && self.options.disabled && self.options.disabled[authMethod])
 }
 
 Auth.prototype.basic = function (user, pass, sendImmediately) {
@@ -48,7 +65,7 @@ Auth.prototype.bearer = function (bearer, sendImmediately) {
   }
 }
 
-Auth.prototype.digest = function (method, path, authHeader) {
+Auth.prototype.digest = function (user, pass, method, path, authHeader) {
   // TODO: More complete implementation of RFC 2617.
   //   - handle challenge.domain
   //   - support qop="auth-int" only
@@ -61,14 +78,22 @@ Auth.prototype.digest = function (method, path, authHeader) {
 
   var self = this
 
+  self.user = user
+  self.pass = pass
+  self.hasAuth = true
+
   var challenge = {}
-  var re = /([a-z0-9_-]+)=(?:"([^"]+)"|([a-z0-9_-]+))/gi
-  for (;;) {
-    var match = re.exec(authHeader)
-    if (!match) {
-      break
+  if (self.isPrevDigestAuthValid()) {
+    challenge = Auth.prevDigestAuthValue
+  } else {
+    var re = /([a-z0-9_-]+)=(?:"([^"]+)"|([a-z0-9_-]+))/gi
+    for (;;) {
+      var match = re.exec(authHeader)
+      if (!match) {
+        break
+      }
+      challenge[match[1]] = match[2] || match[3]
     }
-    challenge[match[1]] = match[2] || match[3]
   }
 
   /**
@@ -89,14 +114,22 @@ Auth.prototype.digest = function (method, path, authHeader) {
   }
 
   var qop = /(^|,)\s*auth\s*($|,)/.test(challenge.qop) && 'auth'
-  var nc = qop && '00000001'
+  var nc
+  if (self.isPrevDigestAuthValid()) {
+    nc = (parseInt(Auth.prevDigestAuthValue.nc) + 1) + ''
+    while (nc.length < 8) {
+      nc = '0' + nc
+    }
+  } else {
+    nc = qop && '00000001'
+  }
   var cnonce = qop && uuid().replace(/-/g, '')
   var ha1 = ha1Compute(challenge.algorithm, self.user, challenge.realm, self.pass, challenge.nonce, cnonce)
   var ha2 = md5(method + ':' + path)
   var digestResponse = qop
     ? md5(ha1 + ':' + challenge.nonce + ':' + nc + ':' + cnonce + ':' + qop + ':' + ha2)
     : md5(ha1 + ':' + challenge.nonce + ':' + ha2)
-  var authValues = {
+  var authValues = Auth.prevDigestAuthValue = {
     username: self.user,
     realm: challenge.realm,
     nonce: challenge.nonce,
@@ -109,6 +142,7 @@ Auth.prototype.digest = function (method, path, authHeader) {
     opaque: challenge.opaque
   }
 
+
   authHeader = []
   for (var k in authValues) {
     if (authValues[k]) {
@@ -120,7 +154,7 @@ Auth.prototype.digest = function (method, path, authHeader) {
     }
   }
   authHeader = 'Digest ' + authHeader.join(', ')
-  self.sentAuth = true
+  self.sentAuth = !self.isPrevDigestAuthValid()
   return authHeader
 }
 
@@ -128,17 +162,22 @@ Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
   var self = this
     , request = self.request
 
+  if (sendImmediately === undefined) {
+    sendImmediately = true
+  }
   var authHeader
   if (bearer === undefined && user === undefined) {
     self.request.emit('error', new Error('no auth mechanism defined'))
   } else if (bearer !== undefined) {
     authHeader = self.bearer(bearer, sendImmediately)
+  } else if (!sendImmediately && self.isPrevDigestAuthValid()) {
+    authHeader = self.digest(user, pass, request.method, request.uri.href, null)
   } else {
     authHeader = self.basic(user, pass, sendImmediately)
   }
   if (authHeader) {
     request.setHeader('authorization', authHeader)
-  }
+  } 
 }
 
 Auth.prototype.onResponse = function (response) {
@@ -153,15 +192,31 @@ Auth.prototype.onResponse = function (response) {
   var authVerb = authHeader && authHeader.split(' ')[0].toLowerCase()
   request.debug('reauth', authVerb)
 
-  switch (authVerb) {
-    case 'basic':
-      return self.basic(self.user, self.pass, true)
+  switch (authVerb) { 
+    case 'basic':  
+      if (self.isEnabled('basic')) {
+        return self.basic(self.user, self.pass, true)
+      } else {
+        self.request.emit('error', new Error('server requested Basic authentication'))
+      }
+      break
 
     case 'bearer':
-      return self.bearer(self.bearerToken, true)
+      if (self.isEnabled('bearer')) {
+        return self.bearer(self.bearerToken, true)
+      } else {
+        self.request.emit('error', new Error('server requested Bearer authentication'))
+      }
+      break
 
     case 'digest':
-      return self.digest(request.method, request.path, authHeader)
+      if (self.isEnabled('digest')) {
+        self.resetPrevDigestAuth()
+        return self.digest(self.user, self.pass, request.method, request.path, authHeader)
+      } else {
+        self.request.emit('error', new Error('server requested Digest Authentication'))
+      }
+      break    
   }
 }
 

--- a/request.js
+++ b/request.js
@@ -380,7 +380,8 @@ Request.prototype.init = function (options) {
       options.auth.user,
       options.auth.pass,
       options.auth.sendImmediately,
-      options.auth.bearer
+      options.auth.bearer,
+      options.auth.disable
     )
   }
 
@@ -1264,10 +1265,10 @@ Request.prototype.enableUnixSocket = function () {
 }
 
 
-Request.prototype.auth = function (user, pass, sendImmediately, bearer) {
+Request.prototype.auth = function (user, pass, sendImmediately, bearer, disable) {
   var self = this
 
-  self._auth.onRequest(user, pass, sendImmediately, bearer)
+  self._auth.onRequest(user, pass, sendImmediately, bearer, disable)
 
   return self
 }

--- a/request.js
+++ b/request.js
@@ -120,7 +120,7 @@ function Request (options) {
     self.explicitMethod = true
   }
   self._qs = new Querystring(self)
-  self._auth = new Auth(self)
+  self._auth = new Auth(self, options.auth)
   self._oauth = new OAuth(self)
   self._multipart = new Multipart(self)
   self._redirect = new Redirect(self)
@@ -946,20 +946,11 @@ Request.prototype.onRequestResponse = function (response) {
       var contentEncoding = response.headers['content-encoding'] || 'identity'
       contentEncoding = contentEncoding.trim().toLowerCase()
 
-      // Be more lenient with decoding compressed responses, since (very rarely)
-      // servers send slightly invalid gzip responses that are still accepted
-      // by common browsers.
-      // Always using Z_SYNC_FLUSH is what cURL does.
-      var zlibOptions = {
-        flush: zlib.Z_SYNC_FLUSH
-      , finishFlush: zlib.Z_SYNC_FLUSH
-      }
-
       if (contentEncoding === 'gzip') {
-        responseContent = zlib.createGunzip(zlibOptions)
+        responseContent = zlib.createGunzip()
         response.pipe(responseContent)
       } else if (contentEncoding === 'deflate') {
-        responseContent = zlib.createInflate(zlibOptions)
+        responseContent = zlib.createInflate()
         response.pipe(responseContent)
       } else {
         // Since previous versions didn't check for Content-Encoding header,

--- a/tests/test-digest-auth.js
+++ b/tests/test-digest-auth.js
@@ -251,3 +251,24 @@ tape('cleanup', function(t) {
     t.end()
   })
 })
+
+tape('with disabled authentication methods', function(t) {
+  var numRedirects = 0
+
+  request({
+    method: 'GET',
+    uri: digestServer.url + '/test/',
+    auth: {
+      user: 'test',
+      pass: 'testing',
+      sendImmediately: false,
+      disable: {
+        digest: true
+      }
+    }
+  }, function(error, response, body) {
+    t.notEqual(error, null)
+    t.end()
+  })
+})
+

--- a/tests/test-digest-auth.js
+++ b/tests/test-digest-auth.js
@@ -40,6 +40,13 @@ var digestServer = http.createServer(function(req, res) {
       } else {
         // Bad auth header, don't send back WWW-Authenticate header
         ok = false
+        res.setHeader('www-authenticate', makeHeader(
+          'Digest realm="Private"',
+          'nonce="WpcHS2/TBAA=dffcc0dbd5f96d49a5477166649b7c0ae3866a93"',
+          'algorithm=MD5',
+          'qop="auth"',
+          'opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+        ))
       }
     } else {
       // No auth header, send back WWW-Authenticate header
@@ -84,6 +91,14 @@ var digestServer = http.createServer(function(req, res) {
       )
 
       ok = testHeader.test(req.headers.authorization)
+      if (!ok) {
+        res.setHeader('www-authenticate', makeHeader(
+          'Digest realm="' + realm + '"',
+          'nonce="' + nonce + '"',
+          'algorithm=' + algorithm,
+          'qop="' + qop + '"'
+        ))
+      }
     } else {
       // No auth header, send back WWW-Authenticate header
       ok = false
@@ -111,6 +126,11 @@ var digestServer = http.createServer(function(req, res) {
       } else {
         // Bad auth header, don't send back WWW-Authenticate header
         ok = false
+        res.setHeader('www-authenticate', makeHeader(
+        'Digest realm="testrealm@host.com"',
+        'nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093"',
+        'opaque="5ccc069c403ebaf9f0171e9517f40e41"'
+      ))
       }
     } else {
       // No auth header, send back WWW-Authenticate header


### PR DESCRIPTION
As I mentioned in issue #2546, there are a couple of improvements in the implementation of digest authentication:

1.- have a mechanism to make sure that digest authentication is used:
What I did is adding a new (optional) parameter to the auth() method that can disable the use of specific authorization methods when sendImmediately is set to false. With this parameter, teh caller can disable, for example, basic and bearer authentication, thus ensuring that only digest authentication is used. 

2.- optimize the use of digest authentication when consecutive requests are issued
I added a new class variable to Auth to store the information from the previous sent digest authentication. When a new request with sendImmediately=false is sent, and if there was a previous digest authentication sent, it tries to send dircetly a new digest auithentication using the parameters (qop, nonce, cnonce, seq,...) from the revious one. If the request does not work due to baud authentication, the currently implemented mechanism if resending the request with teh authentication required by the server will work.

