### PR TITLE
Add proxy timeout support

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -72,7 +72,8 @@ function constructTunnelOptions (request, proxyHeaders) {
       host      : proxy.hostname,
       port      : +proxy.port,
       proxyAuth : proxy.auth,
-      headers   : proxyHeaders
+      headers   : proxyHeaders,
+      timeout   : proxy.timeout || request.timeout
     },
     headers            : request.headers,
     ca                 : request.ca,

--- a/tests/test-proxy-timeout.js
+++ b/tests/test-proxy-timeout.js
@@ -1,0 +1,54 @@
+'use strict'
+
+var request = require('../index')
+  , url = require('url')
+  , tape = require('tape')
+
+var called = false
+  , proxiedHost = 'google.com'
+  , data = ''
+
+var s = require('net').createServer(function(sock) {
+  called = true
+  sock.once('data', function (c) {
+    data += c
+  })
+})
+
+tape('setup', function(t) {
+  s.listen(0, function() {
+    s.url = 'http://localhost:' + this.address().port
+    t.end()
+  })
+})
+
+tape('proxy opts.proxy.timeout', function(t) {
+  request({
+    tunnel: true,
+    url: 'http://' + proxiedHost,
+    proxy: { port: s.address().port, hostname: 'localhost', timeout: 100 }
+  }, function(err, res, body) {
+    t.notEqual(err, null)
+    t.ok(err.code === 'ECONNRESET')
+    t.end()
+  })
+})
+
+tape('proxy opts.timeout', function(t) {
+  request({
+    tunnel: true,
+    url: 'http://' + proxiedHost,
+    proxy: s.url,
+    timeout: 100
+  }, function(err, res, body) {
+    t.notEqual(err, null)
+    t.ok(err.code === 'ECONNRESET')
+    t.end()
+  })
+})
+
+tape('cleanup', function(t) {
+  s.close(function() {
+    t.end()
+  })
+})


### PR DESCRIPTION
  - timeout value can be set in request.proxy.timeout or request.timeout

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] An issue has already been created where the problem / solution was discussed

## PR Description

Related to https://github.com/request/request/issues/2475 and https://github.com/request/tunnel-agent/pull/22

Some minor modifications are required on request/tunnel-agent and can be found here : https://github.com/fargies/tunnel-agent
