### PR TITLE
Removal of body and some headers on redirects

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -9,6 +9,8 @@ function Redirect (request) {
   this.followRedirects = true
   this.followAllRedirects = false
   this.followOriginalHttpMethod = false
+  this.followOriginalBodyForCodes = [401, 307]
+  this.followOriginalBody = false
   this.allowRedirect = function () {return true}
   this.maxRedirects = 10
   this.redirects = []
@@ -39,6 +41,12 @@ Redirect.prototype.onRequest = function (options) {
   }
   if (options.followOriginalHttpMethod !== undefined) {
     self.followOriginalHttpMethod = options.followOriginalHttpMethod
+  }
+  if (options.followOriginalBodyForCodes !== undefined) {
+    self.followOriginalBodyForCodes = options.followOriginalBodyForCodes
+  }
+  if (options.followOriginalBody !== undefined) {
+    self.followOriginalBody = options.followOriginalBody
   }
 }
 
@@ -125,7 +133,7 @@ Redirect.prototype.onResponse = function (response) {
   delete request.src
   delete request.req
   delete request._started
-  if (response.statusCode !== 401 && response.statusCode !== 307) {
+  if (!self.followOriginalBody && !self.followOriginalBodyForCodes.includes(response.statusCode)) {
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.
     delete request.body

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -154,6 +154,9 @@ Redirect.prototype.onResponse = function (response) {
   if (!self.removeRefererHeader) {
     request.setHeader('referer', uriPrev.href)
   }
+  request.debug('redirect with headers', request.headers)
+  request.debug('redirect with body', request.body)
+  request.debug('redirect with _form', request._form)
 
   request.emit('redirect')
 

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -133,21 +133,25 @@ Redirect.prototype.onResponse = function (response) {
   delete request.src
   delete request.req
   delete request._started
-  if (!self.followOriginalBody && !self.followOriginalBodyForCodes.includes(response.statusCode)) {
+
+  if (response.statusCode !== 401 && response.statusCode !== 307) {
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.
+    if (request.headers && request.uri.hostname !== request.originalHost.split(':')[0]) {
+      // Remove authorization if changing hostnames (but not if just
+      // changing ports or protocols).  This matches the behavior of curl:
+      // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
+      request.removeHeader('authorization')
+    }
+  }
+
+  if (!self.followOriginalBody && !self.followOriginalBodyForCodes.includes(response.statusCode)) {
     delete request.body
     delete request._form
     if (request.headers) {
       request.removeHeader('host')
       request.removeHeader('content-type')
       request.removeHeader('content-length')
-      if (request.uri.hostname !== request.originalHost.split(':')[0]) {
-        // Remove authorization if changing hostnames (but not if just
-        // changing ports or protocols).  This matches the behavior of curl:
-        // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710
-        request.removeHeader('authorization')
-      }
     }
   }
 

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -55,7 +55,6 @@ function createLandingEndpointForFollowOriginalBody(landing) {
     assert.equal(req.headers.host, 'localhost')
     assert.equal(req.headers['content-type'], 'application/json')
     assert.equal(req.headers['content-length'], '15')
-    assert.equal(req.headers.authorization, 'authorization')
     // Make sure host is set properly after redirect
     hits[landing] = true
     res.writeHead(200, {'x-response': req.method.toUpperCase() + ' ' + landing})
@@ -152,7 +151,8 @@ tape('preserve HEAD method when using followAllRedirects', function(t) {
   })
 })
 
-tape('preserve body, _form, and the host, content-type, content-length and authorization headers when using followOriginalBody', function(t) {
+//TODO: Add check for the body and _form
+tape('preserve host, content-type and content-length headers when using followOriginalBody', function(t) {
   hits = {}
   request({
     method: 'POST',
@@ -163,8 +163,7 @@ tape('preserve body, _form, and the host, content-type, content-length and autho
     headers: {
       'host': 'localhost',
       'content-type': 'application/json',
-      'content-length': '15',
-      'authorization': 'authorization'
+      'content-length': '15'
     }
   }, function(err, res, body) {
     t.equal(err, null)
@@ -175,7 +174,8 @@ tape('preserve body, _form, and the host, content-type, content-length and autho
   })
 })
 
-tape('preserve body, _form, and the host, content-type, content-length and authorization headers when using followOriginalBodyForCodes', function(t) {
+//TODO: Add check for the body and _form
+tape('preserve host, content-type and content-length headers when using followOriginalBodyForCodes', function(t) {
   hits = {}
   request({
     method: 'POST',
@@ -186,8 +186,7 @@ tape('preserve body, _form, and the host, content-type, content-length and autho
     headers: {
       'host': 'localhost',
       'content-type': 'application/json',
-      'content-length': '15',
-      'authorization': 'authorization'
+      'content-length': '15'
     }
   }, function(err, res, body) {
     t.equal(err, null)
@@ -198,7 +197,8 @@ tape('preserve body, _form, and the host, content-type, content-length and autho
   })
 })
 
-tape('do not preserve body, _form, and the host, content-type, content-length and authorization headers when using status code is not in followOriginalBodyForCodes or followOriginalBodyForCodes is true', function(t) {
+//TODO: Add check for the body and _form
+tape('do not preserve host, content-type and content-length headers when using status code is not in followOriginalBodyForCodes or followOriginalBodyForCodes is true', function(t) {
   hits = {}
   request({
     method: 'POST',
@@ -208,8 +208,7 @@ tape('do not preserve body, _form, and the host, content-type, content-length an
     headers: {
       'host': 'localhost',
       'content-type': 'application/json',
-      'content-length': '15',
-      'authorization': 'authorization'
+      'content-length': '15'
     }
   }, function(err, res, body) {
     t.equal(err, null)

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -63,7 +63,22 @@ function createLandingEndpointForFollowOriginalBody(landing) {
   })
 }
 
-function bouncer(code, label, hops, followOriginalBody) {
+function createLandingEndpointForNoFollowOriginalBody(landing) {
+  s.on('/' + landing, function(req, res) {
+    // Make sure content-type and content-length headers parameters are removed
+    assert.equal(req.headers['content-type'], undefined)
+    assert.equal(req.headers['content-length'], undefined)
+    hits[landing] = true
+    res.writeHead(200, {'x-response': req.method.toUpperCase() + ' ' + landing})
+    res.end(req.method.toUpperCase() + ' ' + landing)
+  })
+}
+
+function bouncer(code, label, hops, landingEndpointCallback) {
+  if (landingEndpointCallback === undefined) {
+    landingEndpointCallback = createLandingEndpoint
+  }
+
   var hop,
     landing = label + '_landing',
     currentLabel,
@@ -82,11 +97,7 @@ function bouncer(code, label, hops, followOriginalBody) {
     }
   }
 
-  if (followOriginalBody) {
-    createLandingEndpointForFollowOriginalBody(landing)
-  } else {
-    createLandingEndpoint(landing)
-  }
+  landingEndpointCallback(landing)
 }
 
 tape('setup', function(t) {
@@ -96,7 +107,8 @@ tape('setup', function(t) {
       bouncer(301, 'double', 2)
       bouncer(301, 'treble', 3)
       bouncer(302, 'perm')
-      bouncer(302, 'perm2', null, true)
+      bouncer(302, 'perm2', null, createLandingEndpointForFollowOriginalBody)
+      bouncer(302, 'perm3', null, createLandingEndpointForNoFollowOriginalBody)
       bouncer(302, 'nope')
       bouncer(307, 'fwd')
       t.end()
@@ -147,7 +159,6 @@ tape('preserve body, _form, and the host, content-type, content-length and autho
     uri: s.url + '/perm2',
     followAllRedirects: true,
     followOriginalBody: true,
-    jar: jar,
     body: '{"var":"value"}',
     headers: {
       'host': 'localhost',
@@ -160,6 +171,51 @@ tape('preserve body, _form, and the host, content-type, content-length and autho
     t.equal(res.statusCode, 200)
     t.ok(hits.perm2, 'Original request is to /perm2')
     t.ok(hits.perm2_landing, 'Forward to permanent landing URL')
+    t.end()
+  })
+})
+
+tape('preserve body, _form, and the host, content-type, content-length and authorization headers when using followOriginalBodyForCodes', function(t) {
+  hits = {}
+  request({
+    method: 'POST',
+    uri: s.url + '/perm2',
+    followAllRedirects: true,
+    followOriginalBodyForCodes: [302],
+    body: '{"var":"value"}',
+    headers: {
+      'host': 'localhost',
+      'content-type': 'application/json',
+      'content-length': '15',
+      'authorization': 'authorization'
+    }
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(hits.perm2, 'Original request is to /perm2')
+    t.ok(hits.perm2_landing, 'Forward to permanent landing URL')
+    t.end()
+  })
+})
+
+tape('do not preserve body, _form, and the host, content-type, content-length and authorization headers when using status code is not in followOriginalBodyForCodes or followOriginalBodyForCodes is true', function(t) {
+  hits = {}
+  request({
+    method: 'POST',
+    uri: s.url + '/perm3',
+    followAllRedirects: true,
+    body: '{"var":"value"}',
+    headers: {
+      'host': 'localhost',
+      'content-type': 'application/json',
+      'content-length': '15',
+      'authorization': 'authorization'
+    }
+  }, function(err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.ok(hits.perm3, 'Original request is to /perm3')
+    t.ok(hits.perm3_landing, 'Forward to permanent landing URL')
     t.end()
   })
 })


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [#2464](https://github.com/request/request/issues/2464) (please note that an related issue has already been created, however no solution had been discussed)
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->

## PR Description
As pointed out in issue [#2464](https://github.com/request/request/issues/2464) some headers, body and _form are being remove on redirects.

Added options followOriginalBody (boolean) and followOriginalBodyForCodes (list) such that if the response status is in followOriginalBodyForCodes ([401, 307] by default to maintain current behavior) or followOriginalBody is true (false by default to maintain current behavior), then host, content-type and content-length headers, body and _form are not removed.

Added the debug information of the headers, body and _form on redirection as the debug info in request.init(options) contains the options, which are not defined in case of redirections.

Also added some tests to check that in case of redirection the above mentioned headers are being removed when the response status is not in followOriginalBodyForCodes and followOriginalBody is false, and not being removed otherwise. The removal or not of the body and _form should also be tested but couldn't find them in the request (indications on how to test them are welcome and appreciated).

Please find below the debug output, including the empty "REQUEST" and the added "REQUEST redirect with headers", "REQUEST redirect with body" and "REQUEST redirect with _form".

```
REQUEST { uri: 'http://localhost:56556/temp',
  jar:
   RequestJar {
     _jar:
      CookieJar {
        enableLooseMode: true,
        store:
         { idx: { localhost:
            { '/':
               { quux: Cookie="quux=baz; Path=/; hostOnly=true; aAge=3ms; cAge=178ms",
                 ham: Cookie="ham=eggs; Path=/; hostOnly=true; aAge=3ms; cAge=157ms" } } } } } },
  headers: { cookie: 'foo=bar' },
  agentOptions: {},
  agentClass: [Function: FakeAgent],
  callback: [Function],
  method: 'GET' }
REQUEST make request http://localhost:56556/temp
REQUEST onRequestResponse http://localhost:56556/temp 301 { location: 'http://localhost:56556/temp_landing',
  'set-cookie': [ 'ham=eggs' ],
  date: 'Wed, 22 Feb 2017 14:54:58 GMT',
  connection: 'close',
  'transfer-encoding': 'chunked' }
REQUEST redirect http://localhost:56556/temp_landing
REQUEST redirect to http://localhost:56556/temp_landing
REQUEST redirect with headers { cookie: 'foo=bar; quux=baz; ham=eggs',
  referer: 'http://localhost:56556/temp' }
REQUEST redirect with body undefined
REQUEST redirect with _form undefined
REQUEST {}
REQUEST response end http://localhost:56556/temp_landing 301 { location: 'http://localhost:56556/temp_landing',
  'set-cookie': [ 'ham=eggs' ],
  date: 'Wed, 22 Feb 2017 14:54:58 GMT',
  connection: 'close',
  'transfer-encoding': 'chunked' }
REQUEST make request http://localhost:56556/temp_landing
REQUEST onRequestResponse http://localhost:56556/temp_landing 200 { 'x-response': 'GET temp_landing',
  date: 'Wed, 22 Feb 2017 14:54:58 GMT',
  connection: 'close',
  'transfer-encoding': 'chunked' }
REQUEST reading response's body
REQUEST finish init function http://localhost:56556/temp_landing
REQUEST response end http://localhost:56556/temp_landing 200 { 'x-response': 'GET temp_landing',
  date: 'Wed, 22 Feb 2017 14:54:58 GMT',
  connection: 'close',
  'transfer-encoding': 'chunked' }
REQUEST end event http://localhost:56556/temp_landing
REQUEST has body http://localhost:56556/temp_landing 16
REQUEST emitting complete http://localhost:56556/temp_landing
```