### PR TITLE
Timings: Tracks 'lookup', adds 'wait' time, fixes connection re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,7 +819,7 @@ default in Linux can be anywhere from 20-120 seconds][linux-timeout]).
   - `timings` Contains event timestamps in millisecond resolution relative to `timingStart`. If there were redirects, the properties reflect the timings of the final request in the redirect chain:
     - `socket` Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_socket) module's `socket` event fires. This happens when the socket is assigned to the request.
     - `lookup` Relative timestamp when the [`net`](https://nodejs.org/api/net.html#net_event_lookup) module's `lookup` event fires. This happens when the DNS has been resolved.
-    - `connect`: Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_connect) module's `connect` event fires. This happens when the server acknowledges the TCP connection.
+    - `connect`: Relative timestamp when the [`net`](https://nodejs.org/api/net.html#net_event_connect) module's `connect` event fires. This happens when the server acknowledges the TCP connection.
     - `response`: Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_response) module's `response` event fires. This happens when the first bytes are received from the server.
     - `end`: Relative timestamp when the last bytes of the response are received.
   - `timingPhases` Contains the durations of each request phase. If there were redirects, the properties reflect the timings of the final request in the redirect chain:

--- a/README.md
+++ b/README.md
@@ -812,17 +812,23 @@ default in Linux can be anywhere from 20-120 seconds][linux-timeout]).
 
 ---
 
-- `time` - If `true`, the request-response cycle (including all redirects) is timed at millisecond resolution, and the result provided on the response's `elapsedTime` property. The `responseStartTime` property is also available to indicate the timestamp when the response begins. In addition, there is a `.timings` object available with the following properties:
-  - `start`: Timestamp when `request()` was initialized
-  - `socket` Timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_socket) module's `socket` event fires. This happens when the socket is assigned to the request (after DNS has been resolved).
-  - `connect`: Timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_connect) module's `connect` event fires. This happens when the server acknowledges the TCP connection.
-  - `response`: Timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_response) module's `response` event fires. This happens when the first bytes are received from the server.
-  - `end`: Timestamp when the last bytes of the response are received.
-  - `dns`: Duration of DNS lookup (`timings.socket` - `timings.start`)
-  - `tcp`: Duration of TCP connection (`timings.connect` - `timings.socket`)
-  - `firstByte`: Duration of HTTP server response (`timings.response` - `timings.connect`)
-  - `download`: Duration of HTTP download (`timings.end` - `timings.response`)
-  - `total`: Duration entire HTTP round-trip (`timings.end` - `timings.start`)
+- `time` - If `true`, the request-response cycle (including all redirects) is timed at millisecond resolution. When set, the following properties are added to the response object:
+  - `elapsedTime` Duration of the entire request/response in milliseconds (*deprecated*).
+  - `responseStartTime` Timestamp when the response began (in Unix Epoch milliseconds) (*deprecated*).
+  - `timingStart` Timestamp of the start of the request (in Unix Epoch milliseconds).
+  - `timings` Contains event timestamps in millisecond resolution relative to `timingStart`. If there were redirects, the properties reflect the timings of the final request in the redirect chain:
+    - `socket` Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_socket) module's `socket` event fires. This happens when the socket is assigned to the request.
+    - `lookup` Relative timestamp when the [`net`](https://nodejs.org/api/net.html#net_event_lookup) module's `lookup` event fires. This happens when the DNS has been resolved.
+    - `connect`: Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_connect) module's `connect` event fires. This happens when the server acknowledges the TCP connection.
+    - `response`: Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_response) module's `response` event fires. This happens when the first bytes are received from the server.
+    - `end`: Relative timestamp when the last bytes of the response are received.
+  - `timingPhases` Contains the durations of each request phase. If there were redirects, the properties reflect the timings of the final request in the redirect chain:
+    - `wait`: Duration of socket initialization (`timings.socket`)
+    - `dns`: Duration of DNS lookup (`timings.lookup` - `timings.socket`)
+    - `tcp`: Duration of TCP connection (`timings.connect` - `timings.socket`)
+    - `firstByte`: Duration of HTTP server response (`timings.response` - `timings.connect`)
+    - `download`: Duration of HTTP download (`timings.end` - `timings.response`)
+    - `total`: Duration entire HTTP round-trip (`timings.end`)
 
 - `har` - A [HAR 1.2 Request Object](http://www.softwareishard.com/blog/har-12-spec/#request), will be processed from HAR format into options overwriting matching values *(see the [HAR 1.2 section](#support-for-har-1.2) for details)*
 - `callback` - alternatively pass the request's callback in the options object

--- a/request.js
+++ b/request.js
@@ -717,7 +717,13 @@ Request.prototype.start = function () {
   var self = this
 
   if (self.timing) {
-    var startTime = now()
+    // All timings will be relative to this request's startTime.  In order to do this,
+    // we need to capture the wall-clock start time (via Date), immediately followed
+    // by the high-resolution timer (via now()).  While these two won't be set
+    // at the _exact_ same time, they should be close enough to be able to calculate
+    // high-resolution, monotonically non-decreasing timestamps relative to startTime.
+    var startTime = new Date().getTime()
+    var startTimeNow = now()
   }
 
   if (self._aborted) {
@@ -755,10 +761,12 @@ Request.prototype.start = function () {
   }
 
   if (self.timing) {
-    self.startTime = new Date().getTime()
-    self.timings = {
-      start: startTime
-    }
+    self.startTime = startTime
+    self.startTimeNow = startTimeNow
+
+    // Timing values will all be relative to startTime (by comparing to startTimeNow
+    // so we have an accurate clock)
+    self.timings = {}
   }
 
   var timeout
@@ -777,9 +785,12 @@ Request.prototype.start = function () {
   })
   self.req.on('socket', function(socket) {
     if (self.timing) {
-      self.timings.socket = now()
+      self.timings.socket = now() - self.startTimeNow
+      socket.on('lookup', function() {
+        self.timings.lookup = now() - self.startTimeNow
+      })
       socket.on('connect', function() {
-        self.timings.connect = now()
+        self.timings.connect = now() - self.startTimeNow
       })
     }
 
@@ -866,30 +877,50 @@ Request.prototype.onRequestResponse = function (response) {
   var self = this
 
   if (self.timing) {
-    self.timings.response = now()
+    self.timings.response = now() - self.startTimeNow
   }
 
   debug('onRequestResponse', self.uri.href, response.statusCode, response.headers)
   response.on('end', function() {
     if (self.timing) {
-      self.timings.end = now()
+      self.timings.end = now() - self.startTimeNow
+      response.timingStart = self.startTime
 
-      self.timings.dns = self.timings.socket - self.timings.start
-      self.timings.tcp = self.timings.connect - self.timings.socket
-      self.timings.firstByte = self.timings.response - self.timings.connect
-      self.timings.download = self.timings.end - self.timings.response
-      self.timings.total = self.timings.end - self.timings.start
+      // fill in the blanks for any periods that didn't trigger, such as
+      // no lookup or connect due to keep alive
+      if (!self.timings.socket) {
+        self.timings.socket = 0
+      }
+      if (!self.timings.lookup) {
+        self.timings.lookup = self.timings.socket
+      }
+      if (!self.timings.connect) {
+        self.timings.connect = self.timings.lookup
+      }
+      if (!self.timings.response) {
+        self.timings.response = self.timings.connect
+      }
 
-      debug('elapsed time', self.timings.total)
+      debug('elapsed time', self.timings.end)
 
       // elapsedTime includes all redirects
-      self.elapsedTime += Math.round(self.timings.total)
+      self.elapsedTime += Math.round(self.timings.end)
 
       // NOTE: elapsedTime is deprecated in favor of .timings
       response.elapsedTime = self.elapsedTime
 
       // timings is just for the final fetch
       response.timings = self.timings
+
+      // pre-calculate phase timings as well
+      response.timingPhases = {
+        wait: self.timings.socket,
+        dns: self.timings.lookup - self.timings.socket,
+        tcp: self.timings.connect - self.timings.lookup,
+        firstByte: self.timings.response - self.timings.connect,
+        download: self.timings.end - self.timings.response,
+        total: self.timings.end
+      }
     }
     debug('response end', self.uri.href, response.statusCode, response.headers)
   })


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: Addresses some feedback from https://github.com/request/request/pull/2452

## PR Description
Feedback from @mcorb in https://github.com/request/request/pull/2452 found a few items with the new `.timings` object.

Changes:

1. The [`net` `'lookup'`](https://nodejs.org/api/net.html#net_event_lookup) event is now tracked, which is the correct event to track DNS lookup time.
2. There is a new `.timingStart` property that is based on `Date.now()`.
3. The `.timings.*` timestamps are relative to `.timingStart` (using `now()`).
4. The `.timings` object now only contains `socket`, `lookup`, `connect`, `response` and `end` (moving the durations to `.timingPhases`)
5. `.timings.start` is no longer needed, since it will always in effect be `0`.
6. The other durations such as `wait`, `dns`, `tcp`, etc were moved to `.timingPhases`.
7. A new `.timingPhases.wait` delta is added, which tracks the time from `start->socket`
8. The `.timingPhases.dns` calculation is changed from `start->socket` to `socket->lookup`.
9. Documentation was updated to be clearer about the handling of HTTP redirects and for all of the new properties above.
10. For cases of connection re-use, the timings would have resulted in `NaN`s or negative numbers.  This is resolved by assuming any events (such as `lookup`) that did not happen (due to re-use) are "filled in" using the timestamp of the previous phase (such as `socket`), resulting in a `0` ms delta.
11. Fixes https://github.com/request/request/issues/2575 by not re-adding event listeners to Keep-Alive sockets (resulting in EventEmitter leak)

Here is an example of the current properties:

```
{ 
  elapsedTime: 143,                 // deprecated
  responseStartTime: 1488424737161, // deprecated
  timingStart: 1488424737018,       // Unix Epoch ms
  timings: {                        // relative to timingStart
     socket: 6.410719000000002,
     lookup: 7.299280000000001,
     connect: 46.287758000000004,
     response: 105.45501300000001,
     end: 142.975414 
  },
  timingPhases: {                   // durations
     wait: 6.410719000000002,
     dns: 0.8885609999999993,
     tcp: 38.988478,
     firstByte: 59.167255000000004,
     download: 37.52040099999999,
     total: 142.975414
  } 
}
```

Tests have been added.