### PR TITLE
Correctly format the Host header for IPv6 addresses

### DIFF
--- a/request.js
+++ b/request.js
@@ -289,13 +289,10 @@ Request.prototype.init = function (options) {
   self.setHost = false
   if (!self.hasHeader('host')) {
     var hostHeaderName = self.originalHostHeaderName || 'host'
-    self.setHeader(hostHeaderName, self.uri.hostname)
-    if (self.uri.port) {
-      if ( !(self.uri.port === 80 && self.uri.protocol === 'http:') &&
-           !(self.uri.port === 443 && self.uri.protocol === 'https:') ) {
-        self.setHeader(hostHeaderName, self.getHeader('host') + (':' + self.uri.port) )
-      }
-    }
+    // When used with an IPv6 address, `host` will provide
+    // the correct bracketed format, unlike using `hostname` and
+    // optionally adding the `port` when necessary.
+    self.setHeader(hostHeaderName, self.uri.host)
     self.setHost = true
   }
 


### PR DESCRIPTION
Fixes #2292

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [**N/A**, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description

When using IPv6 addresses in URLs, the address must be enclosed in brackets, e.g.`https://[::1]:3000/headers.json`

Likewise, when using IPv6 addresses in `Host` header values, the address again must be enclosed in brackets, e.g. `Host: [::1]:3000`

When the **request** module adds the `Host` header value, it does so using the `hostname` and `port` (if needed) parts of the parsed URL.  However, this approach does not correctly format IPv6 addresses with the necessary enclosing brackets as `hostname` does not include them.

If you were instead to utilize the `host` portion of the parsed URL instead, you would automatically get the correctly bracketed value, potentially plus the port.  My testing has not shown any case where the port was unnecessarily included in the `host` value so I have also avoided adding extra code to remove the port if deemed unnecessary by **request**, though I'd be happy to add such if anyone can prove it is needed.