### PR TITLE
safe-buffer doesn't zero-fill by default, its just a polyfill.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -36,7 +36,7 @@ function isReadStream (rs) {
 }
 
 function toBase64 (str) {
-  return (new Buffer(str || '', 'utf8')).toString('base64')
+  return Buffer.from(str || '', 'utf8').toString('base64')
 }
 
 function copy (obj) {

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -72,7 +72,7 @@ Multipart.prototype.build = function (parts, chunked) {
     if (typeof part === 'number') {
       part = part.toString()
     }
-    return chunked ? body.append(part) : body.push(new Buffer(part))
+    return chunked ? body.append(part) : body.push(Buffer.from(part))
   }
 
   if (self.request.preambleCRLF) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -71,7 +71,7 @@ OAuth.prototype.buildBodyHash = function(_oauth, body) {
   shasum.update(body || '')
   var sha1 = shasum.digest('hex')
 
-  return new Buffer(sha1).toString('base64')
+  return Buffer.from(sha1).toString('base64')
 }
 
 OAuth.prototype.concatParams = function (oa, sep, wrap) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "safe-buffer": "^5.0.1",
     "stringstream": "~0.0.4",
     "tough-cookie": "~2.3.0",
-    "tunnel-agent": "^0.5.0",
+    "tunnel-agent": "^0.6.0",
     "uuid": "^3.0.0"
   },
   "scripts": {

--- a/request.js
+++ b/request.js
@@ -418,7 +418,7 @@ Request.prototype.init = function (options) {
 
   function setContentLength () {
     if (isTypedArray(self.body)) {
-      self.body = new Buffer(self.body)
+      self.body = Buffer.from(self.body)
     }
 
     if (!self.hasHeader('content-length')) {
@@ -1122,7 +1122,7 @@ Request.prototype.readResponseBody = function (response) {
     }
     debug('emitting complete', self.uri.href)
     if (typeof response.body === 'undefined' && !self._json) {
-      response.body = self.encoding === null ? new Buffer(0) : ''
+      response.body = self.encoding === null ? Buffer.alloc(0) : ''
     }
     self.emit('complete', response, response.body)
   })


### PR DESCRIPTION
The last PR for safe-buffer didn't actually migrate to the new APIs. I had assumed it would zero-fill by default but I was incorrect.