### PR TITLE
Allow to set main content-type header with form/formData

### DIFF
--- a/request.js
+++ b/request.js
@@ -570,7 +570,7 @@ Request.prototype.init = function (options) {
 
     if (self._form && !self.hasHeader('content-length')) {
       // Before ending the request, we had to compute the length of the whole form, asyncly
-      self.setHeader(self._form.getHeaders(), true)
+      self.setHeader(self._form.getHeaders(self.headers), true)
       self._form.getLength(function (err, length) {
         if (!err && !isNaN(length)) {
           self.setHeader('content-length', length)

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -203,6 +203,23 @@ tape('catch invalid characters error - POST', function(t) {
   })
 })
 
+tape('allow custom content type on form data - POST', function(t) {
+  request({
+    url: s.url + '/headers.json',
+    headers: {
+      'content-type': 'custom'
+    },
+    formData: {
+      'field': 'fieldContent'
+    },
+    json: true
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(body['content-type'], 'custom')
+    t.end()
+  })
+})
+
 tape('IPv6 Host header', function(t) {
   // Horrible hack to observe the raw data coming to the server
   var rawData = ''


### PR DESCRIPTION
Request headers are passed to the `form-data` `getHeaders()` method, so it is possible to override the default header for `content-type`, generated by `form-data`.
For detailed description, see issue [Allow to set main content-type header with form/formData](https://github.com/request/request/issues/2582)