### PR TITLE
New option forceReadResponseBody which always read the response body e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 - `json` - sets `body` to JSON representation of value and adds `Content-type: application/json` header. Additionally, parses the response body as JSON.
 - `jsonReviver` - a [reviver function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) that will be passed to `JSON.parse()` when parsing a JSON response body.
 - `jsonReplacer` - a [replacer function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) that will be passed to `JSON.stringify()` when stringifying a JSON request body.
+- `forceReadResponseBody` - if no callback is provided, the response body is not processed; with this option set to true, the response body will be processed as it would with a callback; response body is passed to the `complete` event as the second parameter.
 
 ---
 

--- a/request.js
+++ b/request.js
@@ -1095,7 +1095,7 @@ Request.prototype.onRequestResponse = function (response) {
     })
     responseContent.on('close', function () {self.emit('close')})
 
-    if (self.callback) {
+    if (self.callback || self.forceReadResponseBody) {
       self.readResponseBody(response)
     }
     //if no callback

--- a/tests/test-forceReadResponseBody.js
+++ b/tests/test-forceReadResponseBody.js
@@ -1,0 +1,82 @@
+
+var http = require('http')
+var tape = require('tape')
+var request = require('../')
+var server
+
+
+tape('before', function (t) {
+  server = http.createServer()
+  server.on('request', function (req, res) {
+    res.writeHead(200, {
+      'content-type': req.headers['content-type']
+    })
+    req.pipe(res)
+  })
+  server.listen(0, function() {
+    server.url = 'http://localhost:' + this.address().port
+    t.end()
+  })
+})
+
+tape('forceReadResponseBody option', function (t) {
+  var testData = 'test request data'
+    , stream
+  
+  stream = request.post({
+    uri: server.url,
+    body: testData,
+    forceReadResponseBody: true
+  })
+
+  stream.on('complete', function(res, body) {
+    t.equal(res.statusCode, 200)
+    t.equal(body, testData)
+    t.end()
+  })
+})
+
+tape('without forceReadResponseBody option', function (t) {
+  var testData = 'test request data'
+    , stream
+  
+  stream = request.post({
+    uri: server.url,
+    body: testData
+  })
+
+  stream.on('complete', function(res, body) {
+    t.equal(res.statusCode, 200)
+    t.equal(body, undefined)
+    t.end()
+  })
+})
+
+tape('forceReadResponseBody and json option', function (t) {
+  var testData
+    , stream
+
+  testData = {
+    test: {
+      payload: 'test'
+    }
+  }
+  
+  stream = request.post({
+    uri: server.url,
+    body: testData,
+    json: true,
+    forceReadResponseBody: true
+  })
+
+  stream.on('complete', function(res, body) {
+    t.equal(res.statusCode, 200)
+    t.equal(typeof body, 'object')
+    t.deepEqual(body, testData)
+    t.end()
+  })
+})
+
+tape('after', function (t) {
+  server.close(t.end)
+})


### PR DESCRIPTION
…ven without callback

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->


## PR Description
<!-- Describe Your PR Here! -->
