### PR TITLE
chore(dependencies): har-validator to 5.x [removes babel dep]

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extend": "~3.0.0",
     "forever-agent": "~0.6.1",
     "form-data": "~2.1.1",
-    "har-validator": "~4.2.1",
+    "har-validator": "~5.0.0",
     "hawk": "~3.1.3",
     "http-signature": "~1.1.0",
     "is-typedarray": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extend": "~3.0.0",
     "forever-agent": "~0.6.1",
     "form-data": "~2.1.1",
-    "har-validator": "~5.0.1",
+    "har-validator": "~5.0.2",
     "hawk": "~3.1.3",
     "http-signature": "~1.1.0",
     "is-typedarray": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extend": "~3.0.0",
     "forever-agent": "~0.6.1",
     "form-data": "~2.1.1",
-    "har-validator": "~5.0.0",
+    "har-validator": "~5.0.1",
     "hawk": "~3.1.3",
     "http-signature": "~1.1.0",
     "is-typedarray": "~1.0.0",


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.

## PR Description
a simple `npm install request` resulted in a `babel` install due to usage as a `devDependency` in `har-validator`, so `har-validator` is now refactored to remove that dependency entirely, making `request` lighter to install _(if only slightly)_ :)