### PR TITLE
Add promise support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ request('http://www.google.com', function (error, response, body) {
 ## Table of contents
 
 - [Streaming](#streaming)
+- [Promises & Async/Await](#promises--asyncawait)
 - [Forms](#forms)
 - [HTTP Authentication](#http-authentication)
 - [Custom HTTP Headers](#custom-http-headers)
@@ -135,6 +136,22 @@ http.createServer(function (req, resp) {
 ```
 
 You can still use intermediate proxies, the requests will still follow HTTP forwards, etc.
+
+[back to top](#table-of-contents)
+
+
+---
+
+
+## Promises & Async/Await
+
+`request` supports both streaming and callback interfaces natively. If you'd like `request` to return a Promise instead, you can use an alternative interface wrapper for `request`. These wrappers can be useful if you prefer to work with Promises, or if you'd like to use `async`/`await` in ES2017.
+
+Several alternative interfaces are provided by the request team, including:
+- [`request-promise`](https://github.com/request/request-promise) (uses [Bluebird](https://github.com/petkaantonov/bluebird) Promises)
+- [`request-promise-native`](https://github.com/request/request-promise-native) (uses native Promises)
+- [`request-promise-any`](https://github.com/request/request-promise-any) (uses [any-promise](https://www.npmjs.com/package/any-promise) Promises)
+
 
 [back to top](#table-of-contents)
 


### PR DESCRIPTION
## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/request/request/issues/1935
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Should counter the opinion that request "doesn't support promises" and help users find these helper libraries. Promises will only get more and more popular as async/await gains support.

/cc @mikeal 