### PR TITLE
Fixed #2614. Content length of the body of the Post request is calcul…

### DIFF
--- a/request.js
+++ b/request.js
@@ -435,14 +435,15 @@ Request.prototype.init = function (options) {
       }
     }
   }
-  if (self.body && !isstream(self.body)) {
-    setContentLength()
-  }
 
   if (options.oauth) {
     self.oauth(options.oauth)
   } else if (self._oauth.params && self.hasHeader('authorization')) {
     self.oauth(self._oauth.params)
+  }
+
+  if (self.body && !isstream(self.body)) {
+    setContentLength()
   }
 
   var protocol = self.proxy && !self.tunnel ? self.proxy.protocol : self.uri.protocol

--- a/tests/test-oauth.js
+++ b/tests/test-oauth.js
@@ -535,6 +535,7 @@ tape('body transport_method + form option + url params', function (t) {
         oauth_token: 'kkk9d7dh3k39sjv7',
         oauth_version: '1.0',
         oauth_signature: 'OB33pYjWAnf+xtOHN4Gmbdil168=' })
+    t.equal(parseInt(r.headers['content-length'], 10), r.body.length)
     r.abort()
     t.end()
   })


### PR DESCRIPTION
…ated properly when using OAuth 1.0 and 'form' object and transport_method=body

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.

## PR Description
Fixes https://github.com/request/request/issues/2614 and possibly https://github.com/request/request/issues/2599
<!-- Describe Your PR Here! -->
Content-length of the body is calculated after OAuth because OAuth can update body if transport_method=body.