### PR TITLE
Added promises library

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,10 @@ You can still use intermediate proxies, the requests will still follow HTTP forw
 `request` supports both streaming and callback interfaces natively. If you'd like `request` to return a Promise instead, you can use an alternative interface wrapper for `request`. These wrappers can be useful if you prefer to work with Promises, or if you'd like to use `async`/`await` in ES2017.
 
 Several alternative interfaces are provided by the request team, including:
-- [`request-promise`](https://github.com/request/request-promise) (uses [Bluebird](https://github.com/petkaantonov/bluebird) Promises)
-- [`request-promise-native`](https://github.com/request/request-promise-native) (uses native Promises)
-- [`request-promise-any`](https://github.com/request/request-promise-any) (uses [any-promise](https://www.npmjs.com/package/any-promise) Promises)
+- [`request-promises`](https://github.com/franciscop/request-promises/): uses native promises and follows request's interface of passing `response` to the promise like `request(...).then(res => { ... });`.
+- [`request-promise`](https://github.com/request/request-promise): uses [Bluebird](https://github.com/petkaantonov/bluebird) Promises and `then()` receives the `body` like `request(...).then(body => { ... });`.
+- [`request-promise-native`](https://github.com/request/request-promise-native): uses native Promises and `.then()` receives the `body` like `request(...).then(body => { ... }); .
+- [`request-promise-any`](https://github.com/request/request-promise-any) uses [any-promise](https://www.npmjs.com/package/any-promise) Promises and passes `body`  like `request(...).then(body => { ... });`.
 
 
 [back to top](#table-of-contents)


### PR DESCRIPTION
## PR Checklist:

Simple doc change

## PR Description

Added a tiny promises library I made to follow the official `request` API (as per Node.js convention). Because passing `resolveWithFullResponse: true` to every single of the tests I had in my project didn't make sense (nor making a small library only for my project).

With my library you can do:

```js
const request = require('request-promises');

request(...).then(res => {
  // ...
});
```

I made it to be able to natively retrieve the `response` as per the official `request` interface. Node.js unwritten? (I couldn't find a reference) convention is that the first parameter in callbacks is the error and will be `.catch()`, and the second parameter is the value and will be passed to `.then()`. So passing the third parameter to `.then()` IMHO doesn't follow what we are used to.

By using this library, the tests become much simpler:

```js
const request = require('request-promises');

it('works', async () => {
  const res = await request('http://localhost:3000/');
  expect(res.statusCode).toBe(200);
  expect(res.body).toBe('Hello 世界');
});
```

And of course with ES7 you aren't really bothered if what you want is the body, just add a small destruct:

```js
const request = require('request-promises');

it('works', async () => {
  const { body } = await request('http://localhost:3000/');
  expect(res.statusCode).toBe(200);
  expect(res.body).toBe('Hello 世界');
});
```