### PR TITLE
fix logic

### DIFF
--- a/request.js
+++ b/request.js
@@ -169,7 +169,7 @@ Request.prototype.init = function (options) {
   self._qs.init(options)
 
   debug(options)
-  if (!self.pool && self.pool !== false) {
+  if (self.pool !== undefined) {
     self.pool = globalPool
   }
   self.dests = self.dests || []

--- a/request.js
+++ b/request.js
@@ -169,7 +169,7 @@ Request.prototype.init = function (options) {
   self._qs.init(options)
 
   debug(options)
-  if (self.pool !== undefined) {
+  if (self.pool === undefined) {
     self.pool = globalPool
   }
   self.dests = self.dests || []


### PR DESCRIPTION
old code: !self.pool && self.pool !== false
+ self is always defined, so self.pool has 2 values: undefined or defined
+ self.pool === undefined: undefined type is different with boolean so statement 2 will TRUE
+ self.pool === false: self.pool !== false will make the test fail, again
+ self.pool === something_else: !self.pool will make test fail
====
I think at this line it should compare self.pool with undefined

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
