### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,8 +677,8 @@ request.get({
 
 The `ca` value can be an array of certificates, in the event you have a private or internal corporate public-key infrastructure hierarchy. For example, if you want to connect to https://api.some-server.com which presents a key chain consisting of:
 1. its own public key, which is signed by:
-2. an intermediate **some-server Corp Issuing Server 01**, that is in turn signed by: 
-3. a root CA **some-server Corp Root CA**;
+2. an intermediate "Corp Issuing Server", that is in turn signed by: 
+3. a root CA "Corp Root CA";
 
 you can configure your request as follows:
 
@@ -686,7 +686,10 @@ you can configure your request as follows:
 request.get({
     url: 'https://api.some-server.com/',
     agentOptions: {
-        ca: [fs.readFileSync('issuing-server-01.pem'), fs.readFileSync('root-ca.pem')]
+        ca: [
+          fs.readFileSync('Corp Issuing Server.pem'),
+          fs.readFileSync('Corp Root CA.pem')
+        ]
     }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -675,6 +675,22 @@ request.get({
 });
 ```
 
+The `ca` value can be an array of certificates, in the event you have a private or internal corporate public-key infrastructure hierarchy. For example, if you want to connect to https://api.some-server.com which presents a key chain consisting of:
+1. its own public key, which is signed by:
+2. an intermediate **some-server Corp Issuing Server 01**, that is in turn signed by: 
+3. a root CA **some-server Corp Root CA**;
+
+you can configure your request as follows:
+
+```js
+request.get({
+    url: 'https://api.some-server.com/',
+    agentOptions: {
+        ca: [fs.readFileSync('issuing-server-01.pem'), fs.readFileSync('root-ca.pem')]
+    }
+});
+```
+
 [back to top](#table-of-contents)
 
 


### PR DESCRIPTION
## PR Checklist:
- [N/A] I have run `npm test` locally and all tests are passing.
- [N/A] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Added a paragraph of text to the TLS section, on the use of the `ca` option, explicitly detailing how to get SSL certificates that consist of more than one issuer to successfully verify. It was not made clear that `ca` can be an array, and that in fact this is necessary (AFAICT) when you want to accept a certificate that has been signed by multiple issuers, common in internal environments.
