### PR TITLE
fixes for redirect not preserving body with followOriginalHttpMethod #2608

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -125,12 +125,16 @@ Redirect.prototype.onResponse = function (response) {
   if (response.statusCode !== 401 && response.statusCode !== 307) {
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.
-    delete request.body
-    delete request._form
+    if (!self.followOriginalHttpMethod) {
+      delete request.body
+      delete request._form
+    }
     if (request.headers) {
       request.removeHeader('host')
-      request.removeHeader('content-type')
-      request.removeHeader('content-length')
+      if (!self.followOriginalHttpMethod) {
+        request.removeHeader('content-type')
+        request.removeHeader('content-length')
+      }
       if (request.uri.hostname !== request.originalHost.split(':')[0]) {
         // Remove authorization if changing hostnames (but not if just
         // changing ports or protocols).  This matches the behavior of curl:


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #2608 
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
I modified redirect logic to preserve body, content type, and content length when `followOriginalHttpMethod` is set to `true`.