### PR TITLE
Lazy loading tough-cookie

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,10 +1,5 @@
 'use strict'
 
-var tough = require('tough-cookie')
-
-var Cookie = tough.Cookie
-var CookieJar = tough.CookieJar
-
 exports.parse = function (str) {
   if (str && str.uri) {
     str = str.uri
@@ -12,12 +7,13 @@ exports.parse = function (str) {
   if (typeof str !== 'string') {
     throw new Error('The cookie function only accepts STRING as param')
   }
-  return Cookie.parse(str, {loose: true})
+  return require('tough-cookie').Cookie.parse(str, {loose: true})
 }
 
 // Adapt the sometimes-Async api of tough.CookieJar to our requirements
 function RequestJar (store) {
   var self = this
+  var CookieJar = require('tough-cookie').CookieJar
   self._jar = new CookieJar(store, {looseMode: true})
 }
 RequestJar.prototype.setCookie = function (cookieOrStr, uri, options) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.

## PR Description
I'm currently working on a device with low memory and while going through heapdumps, one of Request's deps, [tough-cookie](https://www.npmjs.com/package/tough-cookie), uses a lot of memory by [loading a large array](https://github.com/salesforce/tough-cookie/blob/master/lib/pubsuffix.js) of domain name suffices when using `require`. This PR lazy loads the `tough-cookies` module and components for handling cookies. Now modules using Request that do not use cookies will not load `tough-cookies` into memory.