### PR TITLE
Failure to set proxy during redirects

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -122,6 +122,7 @@ Redirect.prototype.onResponse = function (response) {
   delete request.src
   delete request.req
   delete request._started
+  delete request.proxy
   if (response.statusCode !== 401 && response.statusCode !== 307) {
     // Remove parameters from the previous response, unless this is the second request
     // for a server that requires digest authentication.

--- a/request.js
+++ b/request.js
@@ -274,7 +274,7 @@ Request.prototype.init = function (options) {
     return self.emit('error', new Error(message))
   }
 
-  if (!self.hasOwnProperty('proxy')) {
+  if (!self.hasOwnProperty('proxy') || self.proxy == null) {
     self.proxy = getProxyFromURI(self.uri)
   }
 

--- a/request.js
+++ b/request.js
@@ -274,7 +274,7 @@ Request.prototype.init = function (options) {
     return self.emit('error', new Error(message))
   }
 
-  if (!self.hasOwnProperty('proxy') || self.proxy == null) {
+  if (!self.hasOwnProperty('proxy')) {
     self.proxy = getProxyFromURI(self.uri)
   }
 

--- a/tests/test-redirect.js
+++ b/tests/test-redirect.js
@@ -404,6 +404,22 @@ tape('should preserve referer header set in the initial request when removeRefer
   })
 })
 
+tape('should have proxy deleted when following redirect', function (t) {
+  request.get({
+    uri: s.url + '/temp',
+    jar: jar,
+    headers: { cookie: 'foo=bar' },
+    proxy: null
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.end()
+  })
+  .on('redirect', function () {
+    t.ok(typeof this.proxy === "undefined")
+  })
+})
+
 tape('should use same agent class on redirect', function (t) {
   var agent
   var calls = 0


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [] If this is a significant change, an issue has already been created where the problem / solution was discussed: [#2683]

## PR Description
This change makes sure that the proxy setting is re-evaluated according to the redirect url
