### PR TITLE
The content-length is wrong in some times.

### DIFF
--- a/request.js
+++ b/request.js
@@ -429,7 +429,7 @@ Request.prototype.init = function (options) {
     } else {
       length = self.body.length
     }
-    
+
     if (length) {
       self.setHeader('content-length', length)
     } else {

--- a/request.js
+++ b/request.js
@@ -421,20 +421,20 @@ Request.prototype.init = function (options) {
     // sometimes the urlencode method is different from the original's method, such as: chrome. The content length is wrong.
     // so we need to fix it.
     // if (!self.hasHeader('content-length')) {
-      var length
-      if (typeof self.body === 'string') {
-        length = Buffer.byteLength(self.body)
-      } else if (Array.isArray(self.body)) {
-        length = self.body.reduce(function (a, b) { return a + b.length }, 0)
-      } else {
-        length = self.body.length
-      }
-
-      if (length) {
-        self.setHeader('content-length', length)
-      } else {
-        self.emit('error', new Error('Argument error, options.body.'))
-      }
+    var length
+    if (typeof self.body === 'string') {
+      length = Buffer.byteLength(self.body)
+    } else if (Array.isArray(self.body)) {
+      length = self.body.reduce(function (a, b) { return a + b.length }, 0)
+    } else {
+      length = self.body.length
+    }
+    
+    if (length) {
+      self.setHeader('content-length', length)
+    } else {
+      self.emit('error', new Error('Argument error, options.body.'))
+    }
     // }
   }
   if (self.body && !isstream(self.body)) {

--- a/request.js
+++ b/request.js
@@ -418,7 +418,9 @@ Request.prototype.init = function (options) {
       self.body = Buffer.from(self.body)
     }
 
-    if (!self.hasHeader('content-length')) {
+    //sometimes the urlencode method is different from the original's method, such as: chrome. The content length is wrong.
+    //so we need to fix it.
+    //if (!self.hasHeader('content-length')) {
       var length
       if (typeof self.body === 'string') {
         length = Buffer.byteLength(self.body)
@@ -433,7 +435,7 @@ Request.prototype.init = function (options) {
       } else {
         self.emit('error', new Error('Argument error, options.body.'))
       }
-    }
+    //}
   }
   if (self.body && !isstream(self.body)) {
     setContentLength()

--- a/request.js
+++ b/request.js
@@ -418,9 +418,9 @@ Request.prototype.init = function (options) {
       self.body = Buffer.from(self.body)
     }
 
-    //sometimes the urlencode method is different from the original's method, such as: chrome. The content length is wrong.
-    //so we need to fix it.
-    //if (!self.hasHeader('content-length')) {
+    // sometimes the urlencode method is different from the original's method, such as: chrome. The content length is wrong.
+    // so we need to fix it.
+    // if (!self.hasHeader('content-length')) {
       var length
       if (typeof self.body === 'string') {
         length = Buffer.byteLength(self.body)
@@ -435,7 +435,7 @@ Request.prototype.init = function (options) {
       } else {
         self.emit('error', new Error('Argument error, options.body.'))
       }
-    //}
+    // }
   }
   if (self.body && !isstream(self.body)) {
     setContentLength()


### PR DESCRIPTION
sometimes the urlencode method is different from the original's method, such as: chrome. The content length is wrong.
For example:
```
POST http://kaosyslocal.acmcoder.com:14822/factory/runOnlineCodeTwo HTTP/1.1
Host: kaosyslocal.acmcoder.com:14822
Connection: keep-alive
Content-Length: 240
Accept: */*
Origin: http://kaosyslocal.acmcoder.com:14822
X-Requested-With: XMLHttpRequest
User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
Content-Type: application/x-www-form-urlencoded; charset=UTF-8
Referer: http://kaosyslocal.acmcoder.com:14822/ques
Accept-Encoding: gzip, deflate
Accept-Language: zh-CN,zh;q=0.8
Cookie: koa:sess=eyJkaWQiOiI1OTJmZDJkYThkOWVkZTUz; CNZZDATA1260870790=1276442953-1497420720-null%7C1498549765; Hm_lvt_6fb90b2f24d985857e64bfdea40ddf7e=1498190576,1498440148,1498441587,1498529691; Hm_lpvt_6fb90b2f24d985857e64bfdea40ddf7e=1498553382; JSESSIONID=7F233BA1A41787D9B825070603D2A65C

ques_id=59521b548d9ede51d82c5d64&language=0&language_name=0&code_content=%23include+%3Cstdio.h%3E%0A++++int+main()+%7B%0A++++%7D&testlist=331a697f705441db8e5674d5ab249ddf%2C7a5777df81d148d9922b7d5b2cc8275c%2C1b9256fd5f8f4a79a76f69e3e650ea0b
```

After use koa-proxy2, The post form string is:
ques_id=59521b548d9ede51d82c5d64&language=0&language_name=0&code_content=%23include%20%3Cstdio.h%3E%0A%20%20%20%20int%20main%28%29%20%7B%0A%20%20%20%20%7D&testlist=331a697f705441db8e5674d5ab249ddf%2C7a5777df81d148d9922b7d5b2cc8275c%2C1b9256fd5f8f4a79a76f69e3e650ea0b
The content length should be 266.

If the content length is not fixed, keep the original one 240, the testlist field in server script will lost 26 characters.

So, I think we should fix it.

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
