### PR TITLE
Make 'uri is a required argument' error consistent

### DIFF
--- a/request.js
+++ b/request.js
@@ -197,7 +197,7 @@ Request.prototype.init = function (options) {
 
   // If there's a baseUrl, then use it as the base URL (i.e. uri must be
   // specified as a relative path and is appended to baseUrl).
-  if (self.baseUrl) {
+  if (self.baseUrl && (self.uri || self.uri === '')) {
     if (typeof self.baseUrl !== 'string') {
       return self.emit('error', new Error('options.baseUrl must be a string'))
     }

--- a/tests/test-errors.js
+++ b/tests/test-errors.js
@@ -12,6 +12,13 @@ tape('without uri', function (t) {
   t.end()
 })
 
+tape('without uri but with baseUrl', function (t) {
+  t.throws(function () {
+    request({ baseUrl: 'https://github.com' })
+  }, /^Error: options\.uri is a required argument$/)
+  t.end()
+})
+
 tape('invalid uri 1', function (t) {
   t.throws(function () {
     request({


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
There is an inconsistency in 'missing uri' errors.

1. Call `request` without `uri` and `baseUrl` (`request({ });`)
2. Call `request` without `uri` but with `baseUrl` (`request({ baseUrl: 'https://github.com' });`)

**Actual**:
The 1st call throws `options.uri is a required argument` error, the 2nd one throws `options.uri must be a string when using options.baseUrl` error

**Expected**:
Both call throw `options.uri is a required argument` error.

PR adds missing test and fixes the problem
