### PR TITLE
Ignore ECONNRESET errors from a destroyed socket

### DIFF
--- a/request.js
+++ b/request.js
@@ -875,6 +875,16 @@ Request.prototype.onRequestError = function (error) {
     clearTimeout(self.timeoutTimer)
     self.timeoutTimer = null
   }
+
+  // This is a workaround for a race condition caused by the way that lib/redirect.js
+  // calls Request.init() when processing an HTTP redirect:
+  // https://github.com/request/request/issues/2807
+  // Somehow we end up with an ECONNRESET error from a socket that has already
+  // been destroyed and returned to the pool.
+  if (self.req && self.req.socket && self.req.socket.destroyed) {
+    return
+  }
+
   self.emit('error', error)
 }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: Issue #2807 
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
This is the workaround proposed in issue #2807.