### PR TITLE
Describe casing for method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 
 - `uri` || `url` - fully qualified uri or a parsed url object from `url.parse()`
 - `baseUrl` - fully qualified uri string used as the base url. Most useful with `request.defaults`, for example when you want to do many requests to the same domain. If `baseUrl` is `https://example.com/api/`, then requesting `/end/point?test=true` will fetch `https://example.com/api/end/point?test=true`. When `baseUrl` is given, `uri` must also be a string.
-- `method` - http method (default: `"GET"`)
+- `method` - http method in uppercase (default: `"GET"`)
 - `headers` - http headers (default: `{}`)
 
 ---


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [n/a] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [n/a] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
The code base is treating HTTP method casing inconsistently. For example, [request.js:1389](https://github.com/request/request/blob/master/request.js#L1389) converts the method to all uppercase, while [index.js:L49](https://github.com/request/request/blob/master/index.js#L49) is only checking against all upper case. In this specific case, if `` head `` is the method, it could still by pass all the checks. Thus IMO, the easiest way to solve this is to document the casing. Personally, I'd prefer to make HTTP method case-insensitive as a feature, however, due to lack of knowledge about the code base, I'm not able to create an PR for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/request/request/2827)
<!-- Reviewable:end -->
