### PR TITLE
Remove request.prototype.getHeader().

### DIFF
--- a/request.js
+++ b/request.js
@@ -1311,24 +1311,6 @@ Request.prototype.json = function (val) {
 
   return self
 }
-Request.prototype.getHeader = function (name, headers) {
-  var self = this
-  var result, re, match
-  if (!headers) {
-    headers = self.headers
-  }
-  Object.keys(headers).forEach(function (key) {
-    if (key.length !== name.length) {
-      return
-    }
-    re = new RegExp(name, 'i')
-    match = key.match(re)
-    if (match) {
-      result = headers[key]
-    }
-  })
-  return result
-}
 Request.prototype.enableUnixSocket = function () {
   // Get the socket & request paths from the URL
   var unixParts = this.uri.path.split(':')
@@ -1342,7 +1324,6 @@ Request.prototype.enableUnixSocket = function () {
   this.uri.hostname = host
   this.uri.isUnix = true
 }
-
 Request.prototype.auth = function (user, pass, sendImmediately, bearer) {
   var self = this
 
@@ -1412,7 +1393,7 @@ Request.prototype.httpSignature = function (opts) {
   var self = this
   httpSignature.signRequest({
     getHeader: function (header) {
-      return self.getHeader(header, self.headers)
+      return self.getHeader(header)
     },
     setHeader: function (header, value) {
       self.setHeader(header, value)


### PR DESCRIPTION
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
With the addition of `caseless` in v2.41.0, #1006, `getHeader` is now set on a request instance inside `caseless.httpify`.
https://github.com/request/request/blob/253c5e507ddb95dd88622087b6387655bd0ff935/request.js#L160

https://github.com/request/caseless/blob/a3edd69b68c014a1599bd095ca19a944a355d013/index.js#L59-L61

It seems this definition was simply missed during the cleanup and left behind. A single instance of the legacy call signature, providing a second arg, was in `httpSignature` which is always called after `caseless.httpify` is run on the request.
