### PR TITLE
Support proxy basic auth in URL without password

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -66,12 +66,17 @@ function constructProxyHeaderWhiteList (headers, proxyHeaderWhiteList) {
 
 function constructTunnelOptions (request, proxyHeaders) {
   var proxy = request.proxy
+  var proxyAuth = proxy.auth
+
+  if (proxyAuth && proxyAuth.indexOf(':') === -1) {
+    proxyAuth += ':'
+  }
 
   var tunnelOptions = {
     proxy: {
       host: proxy.hostname,
       port: +proxy.port,
-      proxyAuth: proxy.auth,
+      proxyAuth: proxyAuth,
       headers: proxyHeaders
     },
     headers: request.headers,

--- a/request.js
+++ b/request.js
@@ -391,6 +391,7 @@ Request.prototype.init = function (options) {
 
   if (!self.tunnel && self.proxy && self.proxy.auth && !self.hasHeader('proxy-authorization')) {
     var proxyAuthPieces = self.proxy.auth.split(':').map(function (item) { return self._qs.unescape(item) })
+    if (proxyAuthPieces.length === 1) proxyAuthPieces.push('')
     var authHeader = 'Basic ' + toBase64(proxyAuthPieces.join(':'))
     self.setHeader('proxy-authorization', authHeader)
   }

--- a/tests/test-basic-auth.js
+++ b/tests/test-basic-auth.js
@@ -105,6 +105,19 @@ tape('credentials in url', function (t) {
   })
 })
 
+tape('credentials in url without pass', function (t) {
+  var r = request({
+    'method': 'GET',
+    'uri': basicServer.url.replace(/:\/\//, '$&user@') + '/test2/'
+  }, function (error, res, body) {
+    t.error(error)
+    t.equal(r._auth.user, 'user')
+    t.equal(res.statusCode, 200)
+    t.equal(numBasicRequests, 5)
+    t.end()
+  })
+})
+
 tape('POST request', function (t) {
   var r = request({
     'method': 'POST',
@@ -119,7 +132,7 @@ tape('POST request', function (t) {
     t.error(error)
     t.equal(r._auth.user, 'user')
     t.equal(res.statusCode, 200)
-    t.equal(numBasicRequests, 6)
+    t.equal(numBasicRequests, 7)
     t.end()
   })
 })
@@ -138,7 +151,7 @@ tape('user - empty string', function (t) {
       t.error(error)
       t.equal(r._auth.user, '')
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 8)
+      t.equal(numBasicRequests, 9)
       t.end()
     })
   })
@@ -158,7 +171,7 @@ tape('pass - undefined', function (t) {
       t.error(error)
       t.equal(r._auth.user, 'user')
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 10)
+      t.equal(numBasicRequests, 11)
       t.end()
     })
   })
@@ -179,7 +192,7 @@ tape('pass - utf8', function (t) {
       t.equal(r._auth.user, 'user')
       t.equal(r._auth.pass, 'pâss')
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 12)
+      t.equal(numBasicRequests, 13)
       t.end()
     })
   })
@@ -192,7 +205,7 @@ tape('auth method', function (t) {
     .on('response', function (res) {
       t.equal(r._auth.user, 'user')
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 14)
+      t.equal(numBasicRequests, 15)
       t.end()
     })
 })
@@ -209,7 +222,7 @@ tape('get method', function (t) {
       t.equal(r._auth.user, 'user')
       t.equal(err, null)
       t.equal(res.statusCode, 200)
-      t.equal(numBasicRequests, 16)
+      t.equal(numBasicRequests, 17)
       t.end()
     })
 })

--- a/tests/test-proxy.js
+++ b/tests/test-proxy.js
@@ -111,6 +111,12 @@ function addTests () {
       t.equal(req.headers['proxy-authorization'], 'Basic dXNlcjpwYXNz')
     })
 
+    runTest('proxy auth without pass', {
+      proxy: 'http://user@localhost:' + s.port
+    }, function (t, req, res) {
+      t.equal(req.headers['proxy-authorization'], 'Basic dXNlcjo=')
+    })
+
     // http: urls and basic proxy settings
 
     runTest('HTTP_PROXY environment variable and http: url', {


### PR DESCRIPTION
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.

According to [RFC 2617](https://tools.ietf.org/html/rfc2617#section-2), Basic authentication must have a `:` between the username and password, and according to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2.1), the `userinfo` component doesn't require the `:` character to be present.

The usual interpretation of that is that if an URI defines authentication with just an username, e.g. `http://user@host`, when this is translated to Basic authentication, the password is considered empty and `user:` is sent (sending just `user` would be invalid).

This is currently supported for the main request URI (but it's not tested for, maybe it's a side effect of the way the code is written), but not supported for proxy with authentication in the URL.

This PR:

1. Adds test for the main request URI to make sure it supports the username being defined in the URI without a `:` and a password, and that it translates to a valid Basic authentication.
2. Adds test for both proxy and proxy connect to ensure this behaviour.
3. Fix the proxy authentication code to ensure the `:` is present in the Basic authorization header.
4. Fix the proxy connect code to support this case. I'm unsure if this should be fixed here in directly in tunnel-agent but I'm assuming the latter is more low-level and maybe shouldn't care about that.

**Note:** tests pass locally, not sure why it does not on CI but seems unrelated.