### PR TITLE
Handled '"toString()" failed' uncaught error.

### DIFF
--- a/request.js
+++ b/request.js
@@ -1137,6 +1137,7 @@ Request.prototype.readResponseBody = function (response) {
         try {
           response.body = response.body.toString(self.encoding)
         } catch (e) {
+          e.code = 'NODE_RESPONSE_SIZE_LIMIT_REACHED'
           return self.emit('error', e)
         }
       }

--- a/request.js
+++ b/request.js
@@ -1134,7 +1134,11 @@ Request.prototype.readResponseBody = function (response) {
       debug('has body', self.uri.href, bufferLength)
       response.body = Buffer.concat(buffers, bufferLength)
       if (self.encoding !== null) {
-        response.body = response.body.toString(self.encoding)
+        try {
+          response.body = response.body.toString(self.encoding)
+        } catch (e) {
+          return self.emit('error', e)
+        }
       }
       // `buffer` is defined in the parent scope and used in a closure it exists for the life of the Request.
       // This can lead to leaky behavior if the user retains a reference to the request object.

--- a/tests/test-largeData.js
+++ b/tests/test-largeData.js
@@ -1,0 +1,63 @@
+'use strict'
+
+var server = require('./server')
+var request = require('../index')
+var tape = require('tape')
+
+var s = server.createServer()
+
+function checkErrCode (t, err) {
+  t.notEqual(err, null)
+  t.ok(err.code === 'NODE_RESPONSE_SIZE_LIMIT_REACHED')
+}
+
+function writeLargeResponseInChunks (resSizeInMb1, req, res) {
+  var resSizeInMb = 256
+
+  let str1mb = 'a'
+  // generate 1mb string
+  for (let j = 0; j < 20; j++) {
+    str1mb += str1mb
+  }
+
+  let i = 0
+  res.writeHead(200, {'content-type': 'text/plain'})
+  function partialWrite () {
+    if (i < resSizeInMb) {
+      res.write(str1mb)
+      i++
+      // process.stdout.write('Wrote ' + i + 'mb\r')
+      setImmediate(partialWrite)
+    } else {
+      res.end()
+    }
+  }
+  partialWrite()
+}
+
+tape('setup', function (t) {
+  s.listen(0, function () {
+    t.end()
+  })
+})
+
+tape('should send error in callback for response >=256mb', function (t) {
+  s.on('/256mbdata', function (req, res) {
+    writeLargeResponseInChunks(256, req, res)
+  })
+
+  var options = {
+    url: s.url + '/256mbdata'
+  }
+
+  request(options, function (err, res, body) {
+    checkErrCode(t, err)
+    t.end()
+  })
+})
+
+tape('cleanup', function (t) {
+  s.close(function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
Fix for the issue - https://github.com/request/request/issues/2067

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
      test case was not added because, huge files (>256mb) should be used for testing. attaching this file to the project will drastically increases the repo size.


## PR Description
For response size >256mb, buffer.toString throws an error (https://github.com/nodejs/node/issues/3175). Since this was thrown in end event handler, there is no way for the developers to catch these exceptions, so it is resulting in uncaught Errors/Exceptions. 

So we have to gracefully handle those scenarios by catching those errors and then emitting error event.
