### PR TITLE
Alterations for failing CI tests

### DIFF
--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -5,6 +5,15 @@ var request = require('../index')
 var util = require('util')
 var tape = require('tape')
 var url = require('url')
+var os = require('os')
+
+var interfaces = os.networkInterfaces()
+var loopbackKeyTest = exports.isWindows ? /Loopback Pseudo-Interface/ : /lo/
+var hasIPv6interface = Object.keys(interfaces).some(function (name) {
+  return loopbackKeyTest.test(name) && interfaces[name].some(function (info) {
+    return info.family === 'IPv6'
+  })
+})
 
 var s = server.createServer()
 
@@ -171,6 +180,11 @@ tape('undefined headers', function (t) {
   })
 })
 
+var isExpectedHeaderCharacterError = function (headerName, err) {
+  return err.message === 'The header content contains invalid characters' ||
+    err.message === ('Invalid character in header content ["' + headerName + '"]')
+}
+
 tape('catch invalid characters error - GET', function (t) {
   request({
     url: s.url + '/headers.json',
@@ -178,10 +192,10 @@ tape('catch invalid characters error - GET', function (t) {
       'test': 'אבגד'
     }
   }, function (err, res, body) {
-    t.equal(err.message, 'The header content contains invalid characters')
+    t.true(isExpectedHeaderCharacterError('test', err))
   })
   .on('error', function (err) {
-    t.equal(err.message, 'The header content contains invalid characters')
+    t.true(isExpectedHeaderCharacterError('test', err))
     t.end()
   })
 })
@@ -195,49 +209,51 @@ tape('catch invalid characters error - POST', function (t) {
     },
     body: 'beep'
   }, function (err, res, body) {
-    t.equal(err.message, 'The header content contains invalid characters')
+    t.true(isExpectedHeaderCharacterError('test', err))
   })
   .on('error', function (err) {
-    t.equal(err.message, 'The header content contains invalid characters')
+    t.true(isExpectedHeaderCharacterError('test', err))
     t.end()
   })
 })
 
-tape('IPv6 Host header', function (t) {
-  // Horrible hack to observe the raw data coming to the server
-  var rawData = ''
+if (hasIPv6interface) {
+  tape('IPv6 Host header', function (t) {
+    // Horrible hack to observe the raw data coming to the server
+    var rawData = ''
 
-  s.on('connection', function (socket) {
-    if (socket.ondata) {
-      var ondata = socket.ondata
-    }
-    function handledata (d, start, end) {
-      if (ondata) {
-        rawData += d.slice(start, end).toString()
-        return ondata.apply(this, arguments)
-      } else {
-        rawData += d
+    s.on('connection', function (socket) {
+      if (socket.ondata) {
+        var ondata = socket.ondata
       }
+      function handledata (d, start, end) {
+        if (ondata) {
+          rawData += d.slice(start, end).toString()
+          return ondata.apply(this, arguments)
+        } else {
+          rawData += d
+        }
+      }
+      socket.on('data', handledata)
+      socket.ondata = handledata
+    })
+
+    function checkHostHeader (host) {
+      t.ok(
+        new RegExp('^Host: ' + host + '$', 'im').test(rawData),
+        util.format(
+          'Expected "Host: %s" in data "%s"',
+          host, rawData.trim().replace(/\r?\n/g, '\\n')))
+      rawData = ''
     }
-    socket.on('data', handledata)
-    socket.ondata = handledata
-  })
 
-  function checkHostHeader (host) {
-    t.ok(
-      new RegExp('^Host: ' + host + '$', 'im').test(rawData),
-      util.format(
-        'Expected "Host: %s" in data "%s"',
-        host, rawData.trim().replace(/\r?\n/g, '\\n')))
-    rawData = ''
-  }
-
-  request({
-    url: s.url.replace(url.parse(s.url).hostname, '[::1]') + '/headers.json'
-  }, function (err, res, body) {
-    t.equal(err, null)
-    t.equal(res.statusCode, 200)
-    checkHostHeader('\\[::1\\]:' + s.port)
-    t.end()
+    request({
+      url: s.url.replace(url.parse(s.url).hostname, '[::1]') + '/headers.json'
+    }, function (err, res, body) {
+      t.equal(err, null)
+      t.equal(res.statusCode, 200)
+      checkHostHeader('\\[::1\\]:' + s.port)
+      t.end()
+    })
   })
-})
+}

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -8,7 +8,7 @@ var url = require('url')
 var os = require('os')
 
 var interfaces = os.networkInterfaces()
-var loopbackKeyTest = exports.isWindows ? /Loopback Pseudo-Interface/ : /lo/
+var loopbackKeyTest = os.platform() === 'win32' ? /Loopback Pseudo-Interface/ : /lo/
 var hasIPv6interface = Object.keys(interfaces).some(function (name) {
   return loopbackKeyTest.test(name) && interfaces[name].some(function (info) {
     return info.family === 'IPv6'


### PR DESCRIPTION
## PR Checklist:
- [Y] I have run `npm test` locally and all tests are passing.
- [Y] I have added/updated tests for any new behavior.
- [Y] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/request/request/issues/2877

## PR Description
This is a suggestion of alterations to test-headers.js to unblock CI again, given there are a number of consistently failing tests there for some months now.
I've changed the invalid header characters test, so that it passes with _either_ the old or new message returned by node.
I've altered the IPv6 header test, so that if the underlying OS doesn't support IPv6 the test doesn't run.
