### PR TITLE
Add host and port to timed out error properties

### DIFF
--- a/request.js
+++ b/request.js
@@ -813,6 +813,8 @@ Request.prototype.start = function () {
           var e = new Error('ESOCKETTIMEDOUT')
           e.code = 'ESOCKETTIMEDOUT'
           e.connect = false
+          e.host = self.host
+          e.port = self.port
           self.emit('error', e)
         }
       })
@@ -846,6 +848,8 @@ Request.prototype.start = function () {
           var e = new Error('ETIMEDOUT')
           e.code = 'ETIMEDOUT'
           e.connect = true
+          e.host = self.host
+          e.port = self.port
           self.emit('error', e)
         }, timeout)
       } else {

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -65,6 +65,20 @@ tape('should set connect to false', function (t) {
   })
 })
 
+tape('should set host and port', function (t) {
+  var shouldTimeout = {
+    url: s.url + '/timeout',
+    timeout: 100
+  }
+
+  request(shouldTimeout, function (err, res, body) {
+    checkErrCode(t, err)
+    t.ok(err.host === 'localhost', 'Read Timeout Error should set \'host\' property')
+    t.ok(err.port === String(s.port), 'Read Timeout Error should set \'port\' property')
+    t.end()
+  })
+})
+
 tape('should timeout with events', function (t) {
   t.plan(3)
 


### PR DESCRIPTION
Allows for easier debugging when a timeout occurs due to a timed out error. Based on #1747. Replaces https://github.com/request/request/pull/2551.