### PR TITLE
Allow options to be passed to getCookieString and getCookie

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -24,13 +24,13 @@ RequestJar.prototype.setCookie = function (cookieOrStr, uri, options) {
   var self = this
   return self._jar.setCookieSync(cookieOrStr, uri, options || {})
 }
-RequestJar.prototype.getCookieString = function (uri) {
+RequestJar.prototype.getCookieString = function (uri, options) {
   var self = this
-  return self._jar.getCookieStringSync(uri)
+  return self._jar.getCookieStringSync(uri, options)
 }
-RequestJar.prototype.getCookies = function (uri) {
+RequestJar.prototype.getCookies = function (uri, options) {
   var self = this
-  return self._jar.getCookiesSync(uri)
+  return self._jar.getCookiesSync(uri, options)
 }
 
 exports.jar = function (store) {


### PR DESCRIPTION
## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
In the current master, you cannot pass any options to getCookies. I don't believe this to cause any issues were it to be added.
