### PR TITLE
Signing request with uppercase method.

### DIFF
--- a/request.js
+++ b/request.js
@@ -1363,7 +1363,7 @@ Request.prototype.aws = function (opts, now) {
     var options = {
       host: self.uri.host,
       path: self.uri.path,
-      method: self.method,
+      method: self.method.toUpperCase(),
       headers: {
         'content-type': self.getHeader('content-type') || ''
       },


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->

Not sure how to go about adding tests for that / if it's necessary. The aws signature test seems pretty shallow. I guess we could spy on what is passed to `aws4.sign`. Would that be good enough?

## PR Description
 According to the [aws4 doc](https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html), the method name in the canonical request should be in upper case. This is also implicitly documented in [the aws4 library doc](https://github.com/mhart/aws4#more-options). I guess we could argue that aws4 should do the upper-casing but this also resolves the problem.
