### PR TITLE
At safeStringify, if param is string type

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,6 +18,7 @@ function paramsHaveRequestBody (params) {
 }
 
 function safeStringify (obj, replacer) {
+  if (typeof obj === 'string') return obj;
   var ret
   try {
     ret = JSON.stringify(obj, replacer)


### PR DESCRIPTION
if param is string type, don't JSON.stringify it
