### PR TITLE
At safeStringify, if param is string type

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,6 +20,7 @@ function paramsHaveRequestBody (params) {
 function safeStringify (obj, replacer) {
   var ret
   try {
+    if (typeof obj === 'string') return obj
     ret = JSON.stringify(obj, replacer)
   } catch (e) {
     ret = jsonSafeStringify(obj, replacer)


### PR DESCRIPTION
if param is string type, don't JSON.stringify it

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
