### PR TITLE
if obj is string type, don't need "JSON.stringify"

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,6 +18,8 @@ function paramsHaveRequestBody (params) {
 }
 
 function safeStringify (obj, replacer) {
+  // if obj is string type, don't need run
+  if (typeof obj === 'string') return obj
   var ret
   try {
     ret = JSON.stringify(obj, replacer)


### PR DESCRIPTION
if "content-type" is 'text/plain', there will be more a pair of semicolons.
send: 'Hello world!'
changed: "'Hello world!'"

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
