### PR TITLE
request can encodeURIComponent all the url

### DIFF
--- a/request.js
+++ b/request.js
@@ -735,6 +735,11 @@ Request.prototype.start = function () {
   // auth option.  If we don't remove it, we're gonna have a bad time.
   var reqOptions = copy(self)
   delete reqOptions.auth
+  
+  // if encodeURI is false, don't encodeURIComponent
+  if (self.encodeURI != null && !self.encodeURI) {
+    reqOptions.path = decodeURIComponent(reqOptions.path);
+  }
 
   debug('make request', self.uri.href)
 


### PR DESCRIPTION
request can encodeURIComponent all the url, but sometimes I don't need it
if i set encodeURI is false, like this "request({ url: url, encodeURI: false });",

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
