### PR TITLE
Follow url persist auth

### DIFF
--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -40,7 +40,7 @@ Redirect.prototype.onRequest = function (options) {
   if (options.followOriginalHttpMethod !== undefined) {
     self.followOriginalHttpMethod = options.followOriginalHttpMethod
   }
-  if (options.followLocationTrusted !== undefined ){
+  if (options.followLocationTrusted !== undefined) {
     self.followLocationTrusted = options.followLocationTrusted
   }
 }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -40,6 +40,9 @@ Redirect.prototype.onRequest = function (options) {
   if (options.followOriginalHttpMethod !== undefined) {
     self.followOriginalHttpMethod = options.followOriginalHttpMethod
   }
+  if (options.followLocationTrusted !== undefined ){
+    self.followLocationTrusted = options.followLocationTrusted
+  }
 }
 
 Redirect.prototype.redirectTo = function (response) {
@@ -131,7 +134,7 @@ Redirect.prototype.onResponse = function (response) {
       request.removeHeader('host')
       request.removeHeader('content-type')
       request.removeHeader('content-length')
-      if (request.uri.hostname !== request.originalHost.split(':')[0]) {
+      if (request.uri.hostname !== request.originalHost.split(':')[0] && !self.followLocationTrusted) {
         // Remove authorization if changing hostnames (but not if just
         // changing ports or protocols).  This matches the behavior of curl:
         // https://github.com/bagder/curl/blob/6beb0eee/lib/http.c#L710


### PR DESCRIPTION
Added option "followLocationTrusted" to support --location-trusted flag in curl.
In curl, when you pass flag '--location-trusted', auth(-u) will be persisted to all the forwarded hosts.
In request, when set followLocationTrusted, it persists auth in header and send it to all forwarded hosts

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->