### PR TITLE
optimize:do unnecessary processing when changing options to null

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function initParams (uri, options, callback) {
   }
 
   var params = {}
-  if (typeof options === 'object') {
+  if (options !== null && typeof options === 'object') {
     extend(params, options, {uri: uri})
   } else if (typeof uri === 'string') {
     extend(params, {uri: uri})


### PR DESCRIPTION
## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
When `options=null`, `extend(params, options, {uri: uri})` is not entered, but `extend(params, uris)`
