### PR TITLE
Documented response.caseless.get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,17 @@ Function that creates a new cookie jar.
 request.jar()
 ```
 
+### response.caseless.get('header-name')
+
+Function that returns the specified response header field using a [case-insensitive match](https://tools.ietf.org/html/rfc7230#section-3.2)
+
+```js
+request('http://www.google.com', function (error, response, body) {
+  // print the Content-Type header even if the server returned it as 'content-type' (lowercase)
+  console.log('Content-Type is:', response.caseless.get('Content-Type')); 
+});
+```
+
 [back to top](#table-of-contents)
 
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

`response.caseless.get()` is an undocumented convenience method exposed by `request`. 

I spent some time looking for a RFC compliant way to retrieve response headers and I've found this in the project sources.

For example, without an explicit reference to it, a request user probably will use:

    assert(res.headers['x-request-id']);

When the right, and error-free, way to retrieve it is via caseless:

    assert(res.caseless.get('x-request-id'));

