### PR TITLE
Support for multiple www-authenticate headers

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -151,8 +151,8 @@ Auth.prototype.onResponse = function (response) {
   var regSplit = /, (?=[A-Z])/
   var authHeader = c.get('www-authenticate')
   var authMethods = authHeader && authHeader.split(regSplit)
-  if (!authMethods) return;
-  for (var i=0; i<authMethods.length; i++) {
+  if (!authMethods) return
+  for (var i = 0; i < authMethods.length; i++) {
     var authVerb = authMethods[i].split(' ')[0].toLowerCase()
     request.debug('reauth', authVerb)
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -148,19 +148,22 @@ Auth.prototype.onResponse = function (response) {
 
   var c = caseless(response.headers)
 
+  var regSplit = /, (?=[A-Z])/
   var authHeader = c.get('www-authenticate')
-  var authVerb = authHeader && authHeader.split(' ')[0].toLowerCase()
-  request.debug('reauth', authVerb)
+  var authMethods = authHeader && authHeader.split(regSplit)
+  if (!authMethods) return;
+  for (var i=0; i<authMethods.length; i++) {
+    var authVerb = authMethods[i].split(' ')[0].toLowerCase()
+    request.debug('reauth', authVerb)
 
-  switch (authVerb) {
-    case 'basic':
-      return self.basic(self.user, self.pass, true)
-
-    case 'bearer':
-      return self.bearer(self.bearerToken, true)
-
-    case 'digest':
-      return self.digest(request.method, request.path, authHeader)
+    switch (authVerb) {
+      case 'basic':
+        return self.basic(self.user, self.pass, true)
+      case 'bearer':
+        return self.bearer(self.bearerToken, true)
+      case 'digest':
+        return self.digest(request.method, request.path, authMethods[i])
+    }
   }
 }
 


### PR DESCRIPTION
https://github.com/request/request/issues/2999

## PR Description
Adding support for multiple `www-authenticate` headers. Parsing of `www-authenticate` from `response.headers` requires some care, as multiple headers are joined using `,` which is also used inside the `Digest` header. So we use a regex to split the string, looking for a capital letter following the comma.
