### PR TITLE
Updated the Change Log for v2.88.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Change Log
 
+### v2.88.0 (2018/08/10)
+- [#2996](https://github.com/request/request/pull/2996) fix(uuid): import versioned uuid (@kwonoj)
+- [#2994](https://github.com/request/request/pull/2994) Update to oauth-sign 0.9.0 (@dlecocq)
+- [#2993](https://github.com/request/request/pull/2993) Fix header tests (@simov)
+- [#2904](https://github.com/request/request/pull/2904) #515, #2894 Strip port suffix from Host header if the protocol is known. (#2904) (@paambaati)
+- [#2791](https://github.com/request/request/pull/2791) Improve AWS SigV4 support. (#2791) (@vikhyat)
+- [#2977](https://github.com/request/request/pull/2977) Update test certificates (@simov)
+
 ### v2.87.0 (2018/05/21)
 - [#2943](https://github.com/request/request/pull/2943) Replace hawk dependency with a local implemenation (#2943) (@hueniverse)
 


### PR DESCRIPTION
## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->

I want to need the CHANGELOG.md about the latest version 2.88.0.
Now I'll update the `request` module to latest version on our projects but I cannot see the "Change Log" on CHANGELOG.md.

Please review this pull request when you have a time.
Thanks!

### for reviewers

Used the following command:

```
github-changes -o request -r request -b master --date-format '(YYYY/MM/DD)' --only-pulls --use-commit-body --auth
```

