### PR TITLE
Drop support for Node.js v4 (Fix #2917)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
   - 10
   - 8
   - 6
-  - 4
 
 after_script:
   - npm run test-cov

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "main": "index.js",
   "files": [


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #2917 (wasn't really discussed but people seem to support it)
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Node.js v4 reached its EOL a few months ago. Updated package.json and travis.yml to use Node.js v6 and later. One thing to note, I ran `npm test` and I did get failing tests, however they fail on master as well.