### PR TITLE
Add badge to display install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Coverage](https://img.shields.io/coveralls/request/request.svg?style=flat-square)](https://coveralls.io/r/request/request)
 [![Dependency Status](https://img.shields.io/david/request/request.svg?style=flat-square)](https://david-dm.org/request/request)
 [![Known Vulnerabilities](https://snyk.io/test/npm/request/badge.svg?style=flat-square)](https://snyk.io/test/npm/request)
-[![Install Size](https://flat.badgen.net/packagephobia/install/request)](https://packagephobia.now.sh/result?p=request)
+[![Install Size](https://flat.badgen.net/packagephobia/install/request)](https://packagephobia.com/result?p=request)
 [![Gitter](https://img.shields.io/badge/gitter-join_chat-blue.svg?style=flat-square)](https://gitter.im/request/request?utm_source=badge)
 
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Coverage](https://img.shields.io/coveralls/request/request.svg?style=flat-square)](https://coveralls.io/r/request/request)
 [![Dependency Status](https://img.shields.io/david/request/request.svg?style=flat-square)](https://david-dm.org/request/request)
 [![Known Vulnerabilities](https://snyk.io/test/npm/request/badge.svg?style=flat-square)](https://snyk.io/test/npm/request)
+[![Install Size](https://flat.badgen.net/packagephobia/install/request)](https://packagephobia.now.sh/result?p=request)
 [![Gitter](https://img.shields.io/badge/gitter-join_chat-blue.svg?style=flat-square)](https://gitter.im/request/request?utm_source=badge)
 
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.


## PR Description
This adds a badge to the readme to display the npm install size.

## Screenshot 
![image](https://user-images.githubusercontent.com/229881/64123946-b39f3780-cd73-11e9-8da9-f85e639cd9f6.png)
