### PR TITLE
Fix `timingPhases.tcp` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ default in Linux can be anywhere from 20-120 seconds][linux-timeout]).
   - `timingPhases` Contains the durations of each request phase. If there were redirects, the properties reflect the timings of the final request in the redirect chain:
     - `wait`: Duration of socket initialization (`timings.socket`)
     - `dns`: Duration of DNS lookup (`timings.lookup` - `timings.socket`)
-    - `tcp`: Duration of TCP connection (`timings.connect` - `timings.socket`)
+    - `tcp`: Duration of TCP connection (`timings.connect` - `timings.lookup`)
     - `firstByte`: Duration of HTTP server response (`timings.response` - `timings.connect`)
     - `download`: Duration of HTTP download (`timings.end` - `timings.response`)
     - `total`: Duration entire HTTP round-trip (`timings.end`)


### PR DESCRIPTION
## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description

There is a difference between the README and the code about `timingPhases` when the `time` option is enabled.

In the [README](https://github.com/request/request#requestoptions-callback):
```
tcp: Duration of TCP connection (timings.connect - timings.socket)
```

In the [code](https://github.com/request/request/blob/a92e138d897d78ce19dd70bd1ad271c7f9c6a23d/request.js#L927):
```
tcp: self.timings.connect - self.timings.lookup,
```

I believe the truth is in the code (and it makes more sense) so I updated the README.

Note: there is already one issue open about it https://github.com/request/request/issues/2930