### PR TITLE
fix: #2327, Host header is not required in UNIX Domain Sockets

### DIFF
--- a/request.js
+++ b/request.js
@@ -285,7 +285,7 @@ Request.prototype.init = function (options) {
   self._redirect.onRequest(options)
 
   self.setHost = false
-  if (!self.hasHeader('host')) {
+  if (!self.hasHeader('host') && !self.uri.isUnix) {
     var hostHeaderName = self.originalHostHeaderName || 'host'
     self.setHeader(hostHeaderName, self.uri.host)
     // Drop :port suffix from Host header if known protocol.

--- a/tests/server.js
+++ b/tests/server.js
@@ -71,6 +71,19 @@ exports.createSSLServer = function (opts) {
   return s
 }
 
+exports.createUnixSockServer = function (unixSockPath) {
+  var s = http.createServer(function (req, resp) {
+    s.emit(req.url, req, resp)
+  })
+  if (fs.existsSync(unixSockPath)) {
+    s.on('close', function () {
+      fs.unlinkSync(unixSockPath)
+    })
+  }
+  s.listen(unixSockPath)
+  return s
+}
+
 exports.createPostStream = function (text) {
   var postStream = new stream.Stream()
   postStream.writeable = true

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -263,6 +263,31 @@ tape('catch invalid characters error - POST', function (t) {
   })
 })
 
+tape('Host header is not required when use UNIX Domain Sockets', function (t) {
+  if (os.platform() === 'win32') {
+    t.end()
+  }
+  var sockPath = '/tmp/request.sock'
+  var sockServer = server.createUnixSockServer(sockPath)
+  sockServer.on('/', function (req, res) {
+    res.writeHead(200, {
+      'Content-Type': 'application/json'
+    })
+    res.end(JSON.stringify(req.headers))
+  })
+
+  request({
+    method: 'GET',
+    url: 'http://unix:' + sockPath + ':/',
+    json: true
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(typeof body['host'], 'undefined')
+    sockServer.close()
+    t.end()
+  })
+})
+
 if (hasIPv6interface) {
   tape('IPv6 Host header', function (t) {
     // Horrible hack to observe the raw data coming to the server


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [#2327]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
If add Host header to request through UNIX Domain Sockets, some server(Docker Engine API Server) may reject it, it is also mentioned in #2327.
Host header must be sent in HTTP/1.1, but if we use UNIX Domain Sockets, it is not required to automatically add it to the request headers. 