### PR TITLE
Make Authorization header propercase

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -136,7 +136,7 @@ Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
     authHeader = self.basic(user, pass, sendImmediately)
   }
   if (authHeader) {
-    request.setHeader('authorization', authHeader)
+    request.setHeader('Authorization', authHeader)
   }
 }
 


### PR DESCRIPTION
I know this shouldn't matter but I had a weird server that I had to call that needed this to be propercase.
Since it's described as Propercase in the related RFCs, I made this PR.

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
