### PR TITLE
Calculate the boundary once.

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -5,7 +5,7 @@ var CombinedStream = require('combined-stream')
 var isstream = require('isstream')
 var Buffer = require('safe-buffer').Buffer
 
-const boundary = uuid()
+var boundary = uuid()
 
 function Multipart (request) {
   this.request = request

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -5,9 +5,11 @@ var CombinedStream = require('combined-stream')
 var isstream = require('isstream')
 var Buffer = require('safe-buffer').Buffer
 
+const boundary = uuid()
+
 function Multipart (request) {
   this.request = request
-  this.boundary = uuid()
+  this.boundary = boundary
   this.chunked = false
   this.body = null
 }


### PR DESCRIPTION
## PR Checklist:

- [ ] I have run `npm test` locally and all tests are passing.

No, https tests are failing with cert expired.

- [ ] I have added/updated tests for any new behavior.

No, the uuid is random and AFAICT was not stubbed/faked out in the tests.

## PR Description

When using `node --trace-sync-io` on our app, it showed up the each outgoing request we make that the `Request` function calls the `Multipart` function and it always created a uuid for a form boundary.

We don't need the uuid, and also it looks like other http client its kosher to cache this value instead of constantly making a new one:

https://github.com/dlvovsky/commons-httpclient-3.1/blob/master/src/java/org/apache/commons/httpclient/methods/multipart/MultipartRequestEntity.java#L137


