### PR TITLE
Support a runImmediate flag to avoid processing delays

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,9 +4,15 @@ var jsonSafeStringify = require('json-stringify-safe')
 var crypto = require('crypto')
 var Buffer = require('safe-buffer').Buffer
 
-var defer = typeof setImmediate === 'undefined'
-  ? process.nextTick
-  : setImmediate
+function defer (f, runImmediate) {
+  if (runImmediate) {
+    f()
+  } else if (typeof setImmediate === 'undefined') {
+    process.nextTick(f)
+  } else {
+    setImmediate(f)
+  }
+}
 
 function paramsHaveRequestBody (params) {
   return (

--- a/request.js
+++ b/request.js
@@ -579,7 +579,7 @@ Request.prototype.init = function (options) {
     }
 
     self.ntick = true
-  })
+  }, self.runImmediate)
 }
 
 Request.prototype.getNewAgent = function () {

--- a/tests/browser/test.js
+++ b/tests/browser/test.js
@@ -32,3 +32,15 @@ tape('succeeds on valid URLs (with https and CORS)', function (t) {
     t.end()
   })
 })
+
+tape('supports runImmediate', function (t) {
+  t.plan(1)
+  request({
+    uri: __karma__.config.requestTestUrl, // eslint-disable-line no-undef
+    withCredentials: false,
+    runImmediate: true
+  }, function (_, response) {
+    t.equal(response.statusCode, 200)
+    t.end()
+  })
+})


### PR DESCRIPTION
## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
This is particularly useful in web environments where setImmediate() may be temporarily paused by the browser. When a high resource usage tab is put in the background, browsers often pause timer usage until the app is foregrounded again. For some web applications, performing background network requests even when backgrounded itself is useful and may wish to avoid use of setImmediate, understanding the risk in potentially doing so.
