### PR TITLE
Bump har-validator version to 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extend": "~3.0.2",
     "forever-agent": "~0.6.1",
     "form-data": "~2.3.2",
-    "har-validator": "~5.1.0",
+    "har-validator": "~5.1.3",
     "http-signature": "~1.2.0",
     "is-typedarray": "~1.0.0",
     "isstream": "~0.1.2",


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.

## PR Description
<!-- Describe Your PR Here! -->

It seems that a new version of har-validator (5.1.2) may have been published, and then deleted. This PR explicitly sets the version to the latest patch, 5.1.3.

Closes #3054 