### PR TITLE
Add neverstale label to stalebot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - "Up for consideration"
   - greenkeeper
+  - neverstale
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
This will help me mark issues that should stick around but don't fit into the previously two listed categories.