### PR TITLE
Ignore null and undefined values on processing formData

### DIFF
--- a/request.js
+++ b/request.js
@@ -322,7 +322,7 @@ Request.prototype.init = function (options) {
     var appendFormValue = function (key, value) {
       if (value && value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
         requestForm.append(key, value.value, value.options)
-      } else {
+      } else if (value !== null && value !== undefined) {
         requestForm.append(key, value)
       }
     }

--- a/tests/test-form-data-error.js
+++ b/tests/test-form-data-error.js
@@ -64,20 +64,6 @@ tape('omit content-length header if the value is set to NaN', function (t) {
   })
 })
 
-// TODO: remove this test after form-data@2.0 starts stringifying null values
-tape('form-data should throw on null value', function (t) {
-  t.throws(function () {
-    request({
-      method: 'POST',
-      url: s.url,
-      formData: {
-        key: null
-      }
-    })
-  }, TypeError)
-  t.end()
-})
-
 tape('cleanup', function (t) {
   s.close(function () {
     t.end()

--- a/tests/test-form-data.js
+++ b/tests/test-form-data.js
@@ -71,6 +71,10 @@ function runTest (t, options) {
       t.ok(data.indexOf('form-data; name="batch"') !== -1)
       t.ok(data.match(/form-data; name="batch"/g).length === 2)
 
+      // my_undefined and my_null should have been removed
+      t.ok(data.indexOf('form-data; name="my_undefined"') === -1)
+      t.ok(data.indexOf('form-data; name="my_null"') === -1)
+
       // check for http://localhost:nnnn/file traces
       t.ok(data.indexOf('Photoshop ICC') !== -1)
       t.ok(data.indexOf('Content-Type: ' + mime.lookup(remoteFile)) !== -1)
@@ -98,6 +102,8 @@ function runTest (t, options) {
       fs.createReadStream(localFile),
       fs.createReadStream(localFile)
     ]
+    multipartFormData.my_undefined = undefined
+    multipartFormData.my_null = null
 
     var reqOptions = {
       url: url + '/upload',


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #2948
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Do not append `undefined` and `null` values from `options.formData` to `requestForm`. Avoids crashing with cryptic error message from `form-data` package. Rationale see #2948
