### PR TITLE
fix: defer for ie, setImmediate implementation is buggy

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,9 +4,12 @@ var jsonSafeStringify = require('json-stringify-safe')
 var crypto = require('crypto')
 var Buffer = require('safe-buffer').Buffer
 
-var defer = typeof setImmediate === 'undefined'
-  ? process.nextTick
-  : setImmediate
+var defer =
+  typeof setImmediate === 'undefined'
+    ? process.nextTick
+    : function (fn) {
+      return setImmediate(fn)
+    }
 
 function paramsHaveRequestBody (params) {
   return (


### PR DESCRIPTION
## PR Checklist:
- [Y] I have run `npm test` locally and all tests are passing.
at least not introducing any new fails
- [N] I have added/updated tests for any new behavior.
this is a browser specific error, I don't know how to test a browser bug.
- [N/A] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

There are already many issues of setImmediate function:

https://github.com/reflux/refluxjs/issues/374
https://github.com/digitalbazaar/forge/issues/385
https://github.com/babel/babel/issues/1414

I triggered this bug in my project, and the fix is also simple, check the diff