### PR TITLE
Allow content-length of 0 (#920)

### DIFF
--- a/request.js
+++ b/request.js
@@ -431,7 +431,7 @@ Request.prototype.init = function (options) {
         length = self.body.length
       }
 
-      if (length) {
+      if (length !== undefined) {
         self.setHeader('content-length', length)
       } else {
         self.emit('error', new Error('Argument error, options.body.'))

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -101,6 +101,20 @@ function addTests () {
     function (t, req, res) {
       t.equal(req.headers.cookie, undefined)
     })
+
+  runTest(
+    '#920: allow content-length of 0',
+    'headers.json',
+    {
+      json: false,
+      method: 'POST',
+      headers: { 'content-type': 'text/plain; charset=UTF-8' },
+      body: Buffer.alloc(0)
+    },
+    function (t, req, res) {
+      t.equal(req.headers['content-length'], '0')
+    }
+  )
 }
 
 tape('setup', function (t) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Change check for if length is set in order to allow passing a 0-length buffer as body. Previously this emited an error. This is to fix #920 