### PR TITLE
Allow zero-length request bodies

### DIFF
--- a/request.js
+++ b/request.js
@@ -431,7 +431,7 @@ Request.prototype.init = function (options) {
         length = self.body.length
       }
 
-      if (length) {
+      if (typeof length === 'number') {
         self.setHeader('content-length', length)
       } else {
         self.emit('error', new Error('Argument error, options.body.'))


### PR DESCRIPTION
If you provide a `body` which is not a stream, it will fail if the body has zero length.

I noticed this when some code that had been successfully sending protocol buffer messages as POST bodies started failing. The cause was that we eventually had a message whose fields were all the default value, which means they're omitted from the serialization, producing a zero-length message.

The bug is caused by a line that seems to be using `if (body.length)` to check for the presence of a length property, which is getting tripped-up by the falsiness of zero.

## Example (tested with request@2.88.0 on Node v8.9.4)

```javascript
const request = require('request');

async function main() {
    const nonEmpty = new Uint8Array([0x00]);
    request({
        url: 'http://google.com/',
        method: 'POST',
        body: nonEmpty,
    }, error => {
        console.log(`error for nonEmpty: ${error}`); // no error
    });

    const empty = new Uint8Array([]);
    request({
        url: 'http://google.com/',
        method: 'POST',
        body: empty,
    }, error => {
        console.log(`error for empty: ${error}`); // Error: Argument error, options.body.
    });
}

main();
```