### PR TITLE
Clear timeout on `#abort()`

### DIFF
--- a/request.js
+++ b/request.js
@@ -828,8 +828,7 @@ Request.prototype.start = function () {
       if (isConnecting) {
         var onReqSockConnect = function () {
           socket.removeListener('connect', onReqSockConnect)
-          clearTimeout(self.timeoutTimer)
-          self.timeoutTimer = null
+          self.clearTimeout()
           setReqTimeout()
         }
 
@@ -1527,6 +1526,7 @@ Request.prototype.resume = function () {
 }
 Request.prototype.destroy = function () {
   var self = this
+  this.clearTimeout()
   if (!self._ended) {
     self.end()
   } else if (self.response) {
@@ -1535,7 +1535,7 @@ Request.prototype.destroy = function () {
 }
 
 Request.prototype.clearTimeout = function () {
-  if (this.timeout && this.timeoutTimer) {
+  if (this.timeoutTimer) {
     clearTimeout(this.timeoutTimer)
     this.timeoutTimer = null
   }

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -244,6 +244,15 @@ tape('request timeout with keep-alive connection', function (t) {
   })
 })
 
+tape('calling abort clears the timeout', function (t) {
+  const req = request({ url: s.url + '/timeout', timeout: 2500 })
+  setTimeout(function () {
+    req.abort()
+    t.equal(req.timeoutTimer, null)
+    t.end()
+  }, 5)
+})
+
 tape('cleanup', function (t) {
   s.close(function () {
     t.end()


### PR DESCRIPTION
This is a rebased version of #2410 with review notes addressed and an additional `clearTimeout` that either didn't exist or was missed in the original pr.

From @elmigranto's #2410

> Calling `#abort()` does not clear timeout, process hangs until timer is triggered. There are couple of places this is done correctly, `#abort()` happens not to be one of them. There are couple of relevant issues and PRs from **years ago**.
> 
> Sample script to reproduce:
> 
> ``` js
> 'use strict';
> const request = require('request');
> const started = Date.now();
> const printTime = label => () => console.log('%d ms\t%s', Date.now() - started, label);
> 
> const req = request({
>   uri: 'http://example.com',
>   timeout: 2500
> }, printTime('callback'));
> 
> setTimeout(() => {
>   req.abort();
>   printTime('aborted')();
> }, 10);
> 
> process.on('exit', printTime('exit'));
> 
> // 27 ms    aborted
> // 2519 ms  callback
> // 2521 ms  exit
> ```
> 
> Let's close this one finally. Can any of you guys help, please? @mikeal @simov
> 

closes @2410