### PR TITLE
Handshake failure error when using agentOptions (Fix #2528)

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -67,6 +67,8 @@ function constructProxyHeaderWhiteList (headers, proxyHeaderWhiteList) {
 function constructTunnelOptions (request, proxyHeaders) {
   var proxy = request.proxy
 
+  var agentOptions = request.agentOptions || {}
+
   var tunnelOptions = {
     proxy: {
       host: proxy.hostname,
@@ -75,11 +77,11 @@ function constructTunnelOptions (request, proxyHeaders) {
       headers: proxyHeaders
     },
     headers: request.headers,
-    ca: request.ca,
-    cert: request.cert,
-    key: request.key,
-    passphrase: request.passphrase,
-    pfx: request.pfx,
+    ca: request.ca || agentOptions.ca,
+    cert: request.cert || agentOptions.cert,
+    key: request.key || agentOptions.key,
+    passphrase: request.passphrase || agentOptions.passphrase,
+    pfx: request.pfx || agentOptions.pfx,
     ciphers: request.ciphers,
     rejectUnauthorized: request.rejectUnauthorized,
     secureOptions: request.secureOptions,

--- a/tests/test-tunnel.js
+++ b/tests/test-tunnel.js
@@ -443,6 +443,20 @@ function addTests () {
     'https response',
     '200 https ok'
   ])
+
+  runTest('mutual https over http using agentOptions, tunnel=default', {
+    url: ss2.url,
+    proxy: s.url,
+    agentOptions: {
+      cert: clientCert,
+      key: clientKey,
+      passphrase: clientPassword
+    }
+  }, [
+    'http connect to localhost:' + ss2.port,
+    'https response',
+    '200 https ok'
+  ])
 }
 
 tape('setup', function (t) {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #2528

## PR Description
Fix a bug caused by the fact that tunneling agent certificate options are ignored when using agentOptions. 