### PR TITLE
Ensure formData value is not undefined

### DIFF
--- a/request.js
+++ b/request.js
@@ -320,6 +320,10 @@ Request.prototype.init = function (options) {
     var formData = options.formData
     var requestForm = self.form()
     var appendFormValue = function (key, value) {
+      // cast undefined value to empty string otherwise form-data barks
+      if (typeof value === 'undefined') {
+        value = '';
+      }
       if (value && value.hasOwnProperty('value') && value.hasOwnProperty('options')) {
         requestForm.append(key, value.value, value.options)
       } else {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior. (there is a test for `null` exception, there was none for `undefined`)
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [ #3063 ]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
One must be careful that all formData values are not undefined

An undefined value in form-data append will cause a confusing error:
`TypeError: Cannot read property 'name' of undefined`

Simple fix here is casting to empty string when value is undefined

To repro:
```js
var formData = { woops: undefined };
var request = require('request');
request('https://github.com', { formData }, console.log)
```

Related PR to fix form-data https://github.com/form-data/form-data/pull/417