### PR TITLE
Use relative uri path to fix digest authentication

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -3,6 +3,7 @@
 var caseless = require('caseless')
 var uuid = require('uuid/v4')
 var helpers = require('./helpers')
+var url = require('url')
 
 var md5 = helpers.md5
 var toBase64 = helpers.toBase64
@@ -160,7 +161,8 @@ Auth.prototype.onResponse = function (response) {
       return self.bearer(self.bearerToken, true)
 
     case 'digest':
-      return self.digest(request.method, request.path, authHeader)
+      var path = url.parse(request.path).path // Ensure path is relative
+      return self.digest(request.method, path, authHeader)
   }
 }
 


### PR DESCRIPTION
Fix issue with absolute URL instead of relative URL passed to digest authentication.
Issue: #3093 
