### PR TITLE
Update README.md with regards to Digest Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,18 @@ request({url}, function (error, response, body) {
 Digest authentication is supported, but it only works with `sendImmediately`
 set to `false`; otherwise `request` will send basic authentication on the
 initial request, which will probably cause the request to fail.
+You will also need to set `withCredentials` to `true`.
+
+```js
+request.get('http://some.server.com/', {
+  'auth': {
+    'user': 'username',
+    'pass': 'password',
+    'sendImmediately': false
+  },
+  'withCredentials': true
+});
+```
 
 Bearer authentication is supported, and is activated when the `bearer` value is
 available. The value may be either a `String` or a `Function` returning a


### PR DESCRIPTION
Update README with details related to Digest authentication

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
Could only ever get Digest authentication to work by setting `withCredentials` to `true`.
Update README to reflect this.