### PR TITLE
Capitalize Authorization header

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -136,7 +136,7 @@ Auth.prototype.onRequest = function (user, pass, sendImmediately, bearer) {
     authHeader = self.basic(user, pass, sendImmediately)
   }
   if (authHeader) {
-    request.setHeader('authorization', authHeader)
+    request.setHeader('Authorization', authHeader)
   }
 }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior. (Nothing worth testing here, beyond the existing suite.)

## PR Description
This is a dumb change! Although HTTP headers are supposed to be case-insensitive, not all servers behave that way in practice—I found a random API that wouldn't behave unless `Authorization` is capitalized when using HTTP basic auth.