### PR TITLE
Stop wrapping cookie method in request.defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ request.defaults = function (options, requester) {
     defaults[verb] = wrapRequestMethod(self[verb], options, requester, verb)
   })
 
-  defaults.cookie = wrapRequestMethod(self.cookie, options, requester)
+  defaults.cookie = self.cookie
   defaults.jar = self.jar
   defaults.defaults = self.defaults
   return defaults


### PR DESCRIPTION
For some odd reason when [cookie support](https://github.com/request/request/pull/102) was first added in 2011, the `request.cookie` method was treated like a request method. All it does is parse a cookie string. Everybody has been wrapping it since then... lmao

I'd guess the reason why this has gone undiscovered is because nobody has ever tried to do the following.
```js
const request = require('request').defaults({});
// This will make a request!!!
request.cookie('some cookie string');
```

Anyway, this PR fixes that.