### PR TITLE
fix: error on Querystring.prototype.rfc3986 when the 'str' parameter is not a string

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -40,6 +40,7 @@ Querystring.prototype.parse = function (str) {
 }
 
 Querystring.prototype.rfc3986 = function (str) {
+  if (typeof str !== 'string') str = JSON.stringify(str)
   return str.replace(/[!'()*]/g, function (c) {
     return '%' + c.charCodeAt(0).toString(16).toUpperCase()
   })


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.

   Yes, I've run it but some test were not passing even before I made any edits, please check it.

- [x] I have added/updated tests for any new behavior.

   I don't think any test should be added/updated, again, please check.

- [x] If this is a significant change, an issue has already been created where the problem/solution was discussed: https://github.com/request/request-promise/issues/134

## PR Description
I was using request-promise (https://www.npmjs.com/package/request-promise) when I got the error that says: 'str.replace is not a function' then I changed the code in the node_modules (just like what I did in this PR) and I no longer get the error. I'm a newbie developer so please do check my code, it's just one line but I'll be really happy to contribute what I can and if it turns out that my code is not working as you expected, please do tell me about it. Thank you very much, have a nice day!