### PR TITLE
Include SSL negotiation timings in timings and timingPhases objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ The first argument can be either a `url` or an `options` object. The only requir
     - `wait`: Duration of socket initialization (`timings.socket`)
     - `dns`: Duration of DNS lookup (`timings.lookup` - `timings.socket`)
     - `tcp`: Duration of TCP connection (`timings.connect` - `timings.socket`)
+    - `ssl`: Durcation of SSL negotiation (`timings.secureConnect` - `timings.connect`)
     - `firstByte`: Duration of HTTP server response (`timings.response` - `timings.connect`)
     - `download`: Duration of HTTP download (`timings.end` - `timings.response`)
     - `total`: Duration entire HTTP round-trip (`timings.end`)

--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ The first argument can be either a `url` or an `options` object. The only requir
     - `socket` Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_socket) module's `socket` event fires. This happens when the socket is assigned to the request.
     - `lookup` Relative timestamp when the [`net`](https://nodejs.org/api/net.html#net_event_lookup) module's `lookup` event fires. This happens when the DNS has been resolved.
     - `connect`: Relative timestamp when the [`net`](https://nodejs.org/api/net.html#net_event_connect) module's `connect` event fires. This happens when the server acknowledges the TCP connection.
+    - `secureConnect`: Relative timestamp when the [`net`](https://nodejs.org/api/tls.html#tls_event_secureconnect) module's `secureConnect` event fires. This happens when the SSL processing for the connection has finished (only available for https, timing is there whether the ssl negotiation is successful or not).
     - `response`: Relative timestamp when the [`http`](https://nodejs.org/api/http.html#http_event_response) module's `response` event fires. This happens when the first bytes are received from the server.
     - `end`: Relative timestamp when the last bytes of the response are received.
   - `timingPhases` Contains the durations of each request phase. If there were redirects, the properties reflect the timings of the final request in the redirect chain:

--- a/request.js
+++ b/request.js
@@ -936,6 +936,7 @@ Request.prototype.onRequestResponse = function (response) {
       }
       if (self.httpModule === https) {
         response.timingPhases.ssl = self.timings.secureConnect - self.timings.connect
+        response.timingPhases.firstByte = self.timings.response - self.timings.secureConnect
       }
     }
     debug('response end', self.uri.href, response.statusCode, response.headers)

--- a/tests/test-timing-tls.js
+++ b/tests/test-timing-tls.js
@@ -1,0 +1,137 @@
+'use strict'
+
+var server = require('./server')
+var request = require('../index')
+var tape = require('tape')
+var https = require('https')
+
+var tlsServer = server.createSSLServer()
+var redirectMockTime = 10
+
+tape('setup', function (t) {
+  tlsServer.listen(55079, function () {
+    tlsServer.on('/', function (req, res) {
+      res.writeHead(200)
+      res.end('https')
+    })
+    tlsServer.on('/redir', function (req, res) {
+      // fake redirect delay to ensure strong signal for rollup check
+      setTimeout(function () {
+        res.writeHead(301, { 'location': 'https://localhost:' + tlsServer.port + '/' })
+        res.end()
+      }, redirectMockTime)
+    })
+
+    t.end()
+  })
+})
+
+tape('non-redirected request is timed', function (t) {
+  var options = {time: true, strictSSL: false}
+
+  var start = new Date().getTime()
+  var r = request('https://localhost:' + tlsServer.port + '/', options, function (err, res, body) {
+    var end = new Date().getTime()
+
+    t.equal(err, null)
+    t.equal(typeof res.elapsedTime, 'number')
+    t.equal(typeof res.responseStartTime, 'number')
+    t.equal(typeof res.timingStart, 'number')
+    t.equal((res.timingStart >= start), true)
+    t.equal(typeof res.timings, 'object')
+    t.equal((res.elapsedTime > 0), true)
+    t.equal((res.elapsedTime <= (end - start)), true)
+    t.equal((res.responseStartTime > r.startTime), true)
+    t.equal((res.timings.socket >= 0), true)
+    t.equal((res.timings.lookup >= res.timings.socket), true)
+    t.equal((res.timings.connect >= res.timings.lookup), true)
+    t.equal((res.timings.secureConnect >= res.timings.connect), true)
+    t.equal((res.timings.response >= res.timings.secureConnect), true)
+    t.equal((res.timings.end >= res.timings.response), true)
+    t.equal(typeof res.timingPhases, 'object')
+    t.equal((res.timingPhases.wait >= 0), true)
+    t.equal((res.timingPhases.dns >= 0), true)
+    t.equal((res.timingPhases.tcp >= 0), true)
+    t.equal((res.timingPhases.ssl > 0), true)
+    t.equal((res.timingPhases.firstByte > 0), true)
+    t.equal((res.timingPhases.download > 0), true)
+    t.equal((res.timingPhases.total > 0), true)
+    t.equal((res.timingPhases.total <= (end - start)), true)
+
+    // validate there are no unexpected properties
+    var propNames = []
+    for (var propName in res.timings) {
+      if (res.timings.hasOwnProperty(propName)) {
+        propNames.push(propName)
+      }
+    }
+    t.deepEqual(propNames, ['socket', 'lookup', 'connect', 'secureConnect', 'response', 'end'])
+
+    propNames = []
+    for (propName in res.timingPhases) {
+      if (res.timingPhases.hasOwnProperty(propName)) {
+        propNames.push(propName)
+      }
+    }
+    t.deepEqual(propNames, ['wait', 'dns', 'tcp', 'firstByte', 'download', 'total', 'ssl'])
+
+    t.end()
+  })
+})
+
+tape('keepAlive is timed', function (t) {
+  var agent = new https.Agent({ keepAlive: true })
+  var options = { time: true, agent: agent, strictSSL: false }
+  var start1 = new Date().getTime()
+
+  request('https://localhost:' + tlsServer.port + '/', options, function (err1, res1, body1) {
+    var end1 = new Date().getTime()
+
+    // ensure the first request's timestamps look ok
+    t.equal((res1.timingStart >= start1), true)
+    t.equal((start1 <= end1), true)
+
+    t.equal((res1.timings.socket >= 0), true)
+    t.equal((res1.timings.lookup >= res1.timings.socket), true)
+    t.equal((res1.timings.connect >= res1.timings.lookup), true)
+    t.equal((res1.timings.secureConnect >= res1.timings.connect), true)
+    t.equal((res1.timings.response >= res1.timings.connect), true)
+
+    // open a second request with the same agent so we re-use the same connection
+    var start2 = new Date().getTime()
+    request('https://localhost:' + tlsServer.port + '/', options, function (err2, res2, body2) {
+      var end2 = new Date().getTime()
+
+      // ensure the second request's timestamps look ok
+      t.equal((res2.timingStart >= start2), true)
+      t.equal((start2 <= end2), true)
+
+      // ensure socket==lookup==connect for the second request
+      t.equal((res2.timings.socket >= 0), true)
+      t.equal((res2.timings.lookup === res2.timings.socket), true)
+      t.equal((res2.timings.connect === res2.timings.lookup), true)
+      t.equal((res2.timings.secureConnect === res2.timings.connect), true)
+      t.equal((res2.timings.response >= res2.timings.connect), true)
+
+      // explicitly shut down the agent
+      if (typeof agent.destroy === 'function') {
+        agent.destroy()
+      } else {
+        // node < 0.12
+        Object.keys(agent.sockets).forEach(function (name) {
+          agent.sockets[name].forEach(function (socket) {
+            socket.end()
+          })
+        })
+      }
+
+      t.end()
+    })
+  })
+})
+
+tape('cleanup', function (t) {
+  tlsServer.close(function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
## PR Checklist:
- [X ] I have run `npm test` locally and all tests are passing.
- [X ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [X ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [https://github.com/request/request/issues/3127]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
This adds `secureConnect` to the `timings` object and `ssl` to the `timingPhases` object when you specify `time: true` in the request options.