### PR TITLE
Replace querystring.unescape with decodeURI

### DIFF
--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -45,6 +45,4 @@ Querystring.prototype.rfc3986 = function (str) {
   })
 }
 
-Querystring.prototype.unescape = querystring.unescape
-
 exports.Querystring = Querystring

--- a/request.js
+++ b/request.js
@@ -388,12 +388,12 @@ Request.prototype.init = function (options) {
   }
 
   if (self.uri.auth && !self.hasHeader('authorization')) {
-    var uriAuthPieces = self.uri.auth.split(':').map(function (item) { return self._qs.unescape(item) })
+    var uriAuthPieces = self.uri.auth.split(':').map(function (item) { return decodeURI(item) })
     self.auth(uriAuthPieces[0], uriAuthPieces.slice(1).join(':'), true)
   }
 
   if (!self.tunnel && self.proxy && self.proxy.auth && !self.hasHeader('proxy-authorization')) {
-    var proxyAuthPieces = self.proxy.auth.split(':').map(function (item) { return self._qs.unescape(item) })
+    var proxyAuthPieces = self.proxy.auth.split(':').map(function (item) { return decodeURI(item) })
     var authHeader = 'Basic ' + toBase64(proxyAuthPieces.join(':'))
     self.setHeader('proxy-authorization', authHeader)
   }


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
This addresses (closed) issues #1627 and  #1619 which we also hit recently.

Our initial attempts to use `couchdb-nano` uncovered in this issue, where a URI with basic authorization in it was throwing the error `self._qs.unescape is not a function`. 
This may be due to webpack in our Vue.js environment.
```
var nano = require('nano')('http://user:password@localhost:5984');
(using nano after this results in request throwing the error
```

To fix it on our end, I've simply replaced `self._qs.unescape`  with the `decodeURI`  standard javascript call. This now functions correctly in our environment. The issues above mention this issue in Electron builds, which are likely similar to our standard Vue.js (webpack) configuration. As mentioned by @stevage in #1627, I hope this is a benign and fairly straightforward change.

This querystring.unescape call was referenced here: 

[#475](https://github.com/request/request/pull/475) Use `unescape` from `querystring` (@shimaore)

Thanks!

