### PR TITLE
Added a maxResponseSize option that limits the maximum buffered response size

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ The first argument can be either a `url` or an `options` object. The only requir
 - `removeRefererHeader` - removes the referer header when a redirect happens (default: `false`). **Note:** if true, referer header set in the initial request is preserved during redirect chain.
 
 ---
-
+<a id="request-encoding-section"></a>
 - `encoding` - encoding to be used on `setEncoding` of response data. If `null`, the `body` is returned as a `Buffer`. Anything else **(including the default value of `undefined`)** will be passed as the [encoding](http://nodejs.org/api/buffer.html#buffer_buffer) parameter to `toString()` (meaning this is effectively `utf8` by default). (**Note:** if you expect binary data, you should set `encoding: null`.)
 - `gzip` - if `true`, add an `Accept-Encoding` header to request compressed content encodings from the server (if not already present) and decode supported content encodings in the response. **Note:** Automatic decoding of the response content is performed on the body data returned through `request` (both through the `request` stream and passed to the callback function) but is not performed on the `response` stream (available from the `response` event) which is the unmodified `http.IncomingMessage` object which may contain compressed data. See example below.
 - `jar` - if `true`, remember cookies for future use (or define your custom cookie jar; see examples section)
@@ -828,7 +828,15 @@ The first argument can be either a `url` or an `options` object. The only requir
   - **Connection timeout**: Sets the socket to timeout after `timeout` milliseconds of inactivity. Note that increasing the timeout beyond the OS-wide TCP connection timeout will not have any effect ([the default in Linux can be anywhere from 20-120 seconds][linux-timeout])
 
 [linux-timeout]: http://www.sekuda.com/overriding_the_default_linux_kernel_20_second_tcp_socket_connect_timeout
-
+- `maxResponseSize` - The maximum response size that can be buffered. If you use any `encoding`, the callback will convert incoming chunks to strings, so this will be counted in UTF characters, otherwise if you use raw buffers(binary data), this will be counted in bytes. See `Buffer.length` and `String.length`. If this response size is exceeded, the request will be aborted and an error will be emitted.
+  - **Notes**
+    - **For more information on encoding:** See https://nodejs.org/api/stream.html `setEncoding` and also [documentation above](#request-encoding-section)
+    - **Usage:** This is only used when using a callback and not `on()`, ie. when you want to buffer the response and not process it as a stream.
+    - **Compression:** This is applied after the response chunks are decompressed, meaning that it's possible to receive a smaller compressed 
+    message and still emit an error if when decompressed it exceeds the `maxResponseSize`.
+    This can protect you from some kinds of decompression bombs.
+    - **Default behaviour:** For backwards compatibility, not specifying a maxResponseSize will mean that there is no enforced limit.
+    - **Example error message**: `Response size is too big. Max allowed is  1234`
 ---
 
 - `localAddress` - local interface to bind for network connections.

--- a/tests/test-max-response-size.js
+++ b/tests/test-max-response-size.js
@@ -1,0 +1,216 @@
+'use strict'
+var http = require('http')
+var tape = require('tape')
+var request = require('../index')
+var zlib = require('zlib')
+
+/**
+ *
+ * ugly shim for node 6
+ */
+var promisify = function (fn) {
+  return function () {
+    var args = [].slice.apply(arguments)
+    return new Promise(function (resolve, reject) {
+      fn.apply(null, args.concat([
+        function () {
+          var results = [].slice.apply(arguments)
+          results.length === 1 ? reject(results[0]) : resolve(results[1])
+        }]))
+    })
+  }
+}
+
+/**
+ * A way to compress with a promise instead of a callback
+ */
+var zlibPromisified = promisify(zlib.gzip)
+/**
+ * The mock HTTP server configured in the tape('setup')
+ */
+var server
+/**
+ * Arrays initialized by setupCases()
+ */
+var testCases, testCasesRaw, testCasesGzip, testCasesBadLimits
+
+/**
+ * Create the HTTP server without doing listen()
+ */
+function createHttpServer (testContent, testContentGzip) {
+  return http.createServer(function (req, res) {
+    res.statusCode = 200
+
+    if (req.url === '/testContent') {
+      res.setHeader('Content-Type', 'text/plain')
+      res.end(testContent)
+    } else if (req.url === '/testContentGzip') {
+      res.setHeader('Content-Type', 'text/plain')
+      res.setHeader('Content-Encoding', 'deflate')
+      res.end(testContentGzip)
+    } else if (req.url === '/testContentRaw') {
+      res.setHeader('Content-Type', 'application/octet-stream')
+      res.end(testContentGzip)
+    }
+  })
+}
+
+/**
+ * Set-up the cases in testCases, testCasesRaw, testCasesGzip
+ */
+function setupCases (testContent, testContentGzip) {
+  testCases = [
+    {
+      name: 'try request for small data with max response size bigger than data size should be okay',
+      path: '/testContent',
+      maxResponseSize: testContent.length + 1,
+      shouldError: false
+    },
+    {
+      name: 'try request for small data with max response size same as data size should be okay',
+      path: '/testContent',
+      maxResponseSize: testContent.length,
+      shouldError: false
+    },
+    {
+      name: 'request for data with max response size lesser than data size should give error',
+      path: '/testContent',
+      maxResponseSize: testContent.length - 1,
+      shouldError: true
+    }
+  ]
+  testCasesGzip = [
+    {
+      name: 'gzip: request for small data with max response size bigger than data size should be okay',
+      path: '/testContent',
+      maxResponseSize: testContent.length + 1,
+      shouldError: false,
+      gzip: true
+    },
+    {
+      name: 'gzip: request for small data with max response size same as data size should be okay',
+      path: '/testContent',
+      maxResponseSize: testContent.length,
+      shouldError: false,
+      gzip: true
+    },
+    {
+      name: 'gzip: request for data with max response size lesser than data size should give error',
+      path: '/testContent',
+      maxResponseSize: testContent.length - 1,
+      shouldError: true,
+      gzip: true
+    }
+  ]
+  testCasesRaw = [
+    {
+      name: 'raw: request for small data with max response size bigger than data size should be okay',
+      path: '/testContentRaw',
+      maxResponseSize: testContentGzip.length + 1,
+      shouldError: false,
+      gzip: false,
+      encoding: null
+    },
+    {
+      name: 'raw: request for small data with max response size same as data size should be okay',
+      path: '/testContentRaw',
+      maxResponseSize: testContentGzip.length,
+      shouldError: false,
+      gzip: false,
+      encoding: null
+    },
+    {
+      name: 'raw: request for data with max response size lesser than data size should give error',
+      path: '/testContentRaw',
+      maxResponseSize: testContentGzip.length - 1,
+      shouldError: true,
+      gzip: false,
+      encoding: null
+    }
+  ]
+  testCasesBadLimits = [
+    {
+      name: 'bad limit: 0 is not a valid maxResponseSize',
+      path: '/testContent',
+      maxResponseSize: 0,
+      shouldError: false,
+      shouldThrow: true
+    }, {
+      name: 'bad limit: -1 is not a valid maxResponseSize',
+      path: '/testContent',
+      maxResponseSize: -1,
+      shouldError: false,
+      shouldThrow: true
+    }, {
+      name: 'bad limit: \'abc\' is not a valid maxResponseSize',
+      path: '/testContent',
+      maxResponseSize: 'abc',
+      shouldError: false,
+      shouldThrow: true
+    }
+  ]
+}
+
+/**
+ * Executes a subtest, it receives the the subtest as t and ends it when done
+ */
+function doCase (t, currCase) {
+  var options = { maxResponseSize: currCase.maxResponseSize }
+  if (typeof currCase.encoding !== 'undefined') options.encoding = currCase.encoding
+  if (currCase.gzip) options.gzip = true
+  var doRequest = function () {
+    request.get(server.url + currCase.path, options, (err, res, body) => {
+      currCase.shouldError ? t.notEqual(err, null) : t.equal(err, null)
+      t.end()
+    })
+  }
+  if (currCase.shouldThrow) {
+    t.throws(doRequest)
+    t.end()
+  } else {
+    doRequest()
+  }
+}
+
+/**
+ * Generates a Gzipped instance of data
+ * Set-ups the test cases by putting the content length of the testContent
+ * and testGzippedContent
+ * This also configures an HTTP server in
+ * the global server var
+ */
+tape('setup', function (t) {
+  var testContent = 'Stuff response bytes\r\n'
+  zlibPromisified(testContent).then(function (testGzippedContent) {
+    setupCases(testContent, testGzippedContent)
+    server = createHttpServer(testContent, testGzippedContent)
+    server.listen(0, function () {
+      server.url = 'http://localhost:' + this.address().port
+      t.end()
+    })
+  })
+})
+
+/**
+ * Loops through the test cases create by setupCases()
+ * and creates a subtest for each case
+ */
+tape('subtests', function (t) {
+  var allCases = [testCases, testCasesRaw, testCasesGzip, testCasesBadLimits]
+  allCases.forEach(caseArr => caseArr.forEach(function (aCase) {
+    t.test(aCase.name, function (t) {
+      doCase(t, aCase)
+    })
+  }))
+
+  t.end()
+})
+
+/**
+ * Closes the HTTP server
+ */
+tape('cleanup', function (t) {
+  server.close(function () {
+    t.end()
+  })
+})

--- a/tests/test-timeout.js
+++ b/tests/test-timeout.js
@@ -3,7 +3,7 @@
 function checkErrCode (t, err) {
   t.notEqual(err, null)
   t.ok(err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT',
-    'Error ETIMEDOUT or ESOCKETTIMEDOUT')
+  'Error ETIMEDOUT or ESOCKETTIMEDOUT')
 }
 
 function checkEventHandlers (t, socket) {
@@ -168,7 +168,7 @@ tape('connect timeout', function tryConnect (t) {
   var socket
   request(shouldConnectTimeout, function (err) {
     t.notEqual(err, null)
-    if (err.code === 'ENETUNREACH' && nrIndex < nonRoutable.length) {
+    if ((err.code === 'ENETUNREACH' || err.code === 'EHOSTUNREACH') && nrIndex < nonRoutable.length) {
       // With some network configurations, some addresses will be reported as
       // unreachable immediately (before the timeout occurs). In those cases,
       // try other non-routable addresses before giving up.


### PR DESCRIPTION
Added maxResponseSize option, checks for invalid values, backward compatibility and relevant tests plus fix to the test-timeout.js so all the tests pass

## PR Checklist:
- [Y] I have run `npm test` locally and all tests are passing.
- [Y] I have added/updated tests for any new behavior.
- [Y] Relevant documentation

- [Y] Full backward compatibility is ensured


## PR Description
When using a callback, the response is being buffered either in Buffer or string array.
The size of this buffer however is not regulated and there is no way to explicitly limit it.
The same also applied when the response is compressed, after decompression it can become much bigger leading to out-of-memory problems.

This feature adds an optional limit(maxResponseSize) that can protect you from such issues. 
Please see the updated Doc for more information.
