### PR TITLE
NO_PROXY : allow wildcard subdomains 

### DIFF
--- a/lib/getProxyFromURI.js
+++ b/lib/getProxyFromURI.js
@@ -13,7 +13,13 @@ function parseNoProxyZone (zone) {
   var zonePort = zoneParts[1]
   var hasPort = zone.indexOf(':') > -1
 
-  return {hostname: zoneHost, port: zonePort, hasPort: hasPort}
+  var hostRegExp = null
+  if ((/^\*\.[a-z]/).test(zone)) {
+    let hostRegExpPrefix = /.*\./
+    hostRegExp = new RegExp(hostRegExpPrefix.source + zoneParts[0].substr(2))
+  }
+
+  return {hostname: zoneHost, port: zonePort, hasPort: hasPort, hostRegExp}
 }
 
 function uriInNoProxy (uri, noProxy) {
@@ -23,11 +29,16 @@ function uriInNoProxy (uri, noProxy) {
 
   // iterate through the noProxyList until it finds a match.
   return noProxyList.map(parseNoProxyZone).some(function (noProxyZone) {
-    var isMatchedAt = hostname.indexOf(noProxyZone.hostname)
-    var hostnameMatched = (
-      isMatchedAt > -1 &&
+    var isMatchedAt, hostnameMatched
+    if (noProxyZone.hostRegExp) {
+      hostnameMatched = isMatchedAt = (noProxyZone.hostRegExp.test(hostname)) ? 1 : 0
+    } else {
+      isMatchedAt = hostname.indexOf(noProxyZone.hostname)
+      hostnameMatched = (
+        isMatchedAt > -1 &&
         (isMatchedAt === hostname.length - noProxyZone.hostname.length)
-    )
+      )
+    }
 
     if (noProxyZone.hasPort) {
       return (port === noProxyZone.port) && hostnameMatched

--- a/tests/test-proxy.js
+++ b/tests/test-proxy.js
@@ -114,44 +114,44 @@ function addTests () {
     // http: urls and basic proxy settings
 
     runTest('HTTP_PROXY environment variable and http: url', {
-      env: { HTTP_PROXY: s.url }
+      env: {HTTP_PROXY: s.url}
     }, true)
 
     runTest('http_proxy environment variable and http: url', {
-      env: { http_proxy: s.url }
+      env: {http_proxy: s.url}
     }, true)
 
     runTest('HTTPS_PROXY environment variable and http: url', {
-      env: { HTTPS_PROXY: s.url }
+      env: {HTTPS_PROXY: s.url}
     }, false)
 
     runTest('https_proxy environment variable and http: url', {
-      env: { https_proxy: s.url }
+      env: {https_proxy: s.url}
     }, false)
 
     // https: urls and basic proxy settings
 
     runTest('HTTP_PROXY environment variable and https: url', {
-      env: { HTTP_PROXY: s.url },
+      env: {HTTP_PROXY: s.url},
       url: 'https://google.com',
       tunnel: false,
       pool: false
     }, true)
 
     runTest('http_proxy environment variable and https: url', {
-      env: { http_proxy: s.url },
+      env: {http_proxy: s.url},
       url: 'https://google.com',
       tunnel: false
     }, true)
 
     runTest('HTTPS_PROXY environment variable and https: url', {
-      env: { HTTPS_PROXY: s.url },
+      env: {HTTPS_PROXY: s.url},
       url: 'https://google.com',
       tunnel: false
     }, true)
 
     runTest('https_proxy environment variable and https: url', {
-      env: { https_proxy: s.url },
+      env: {https_proxy: s.url},
       url: 'https://google.com',
       tunnel: false
     }, true)
@@ -167,16 +167,16 @@ function addTests () {
 
     // no_proxy logic
 
-    runTest('NO_PROXY hostnames are case insensitive', {
+    runTest('NO_PROXY hostnames are case insensitive 2', {
       env: {
-        HTTP_PROXY: s.url,
+        http_proxy: s.url,
         NO_PROXY: 'GOOGLE.COM'
       }
     }, false)
 
-    runTest('NO_PROXY hostnames are case insensitive 2', {
+    runTest('NO_PROXY hostnames are case insensitive', {
       env: {
-        http_proxy: s.url,
+        HTTP_PROXY: s.url,
         NO_PROXY: 'GOOGLE.COM'
       }
     }, false)
@@ -189,7 +189,7 @@ function addTests () {
     }, false)
 
     runTest('NO_PROXY ignored with explicit proxy passed', {
-      env: { NO_PROXY: '*' },
+      env: {NO_PROXY: '*'},
       proxy: s.url
     }, true)
 
@@ -247,7 +247,7 @@ function addTests () {
         HTTP_PROXY: s.url,
         NO_PROXY: 'google.com'
       },
-      headers: { host: 'www.google.com' }
+      headers: {host: 'www.google.com'}
     }, false)
 
     runTest('NO_PROXY should not override HTTP_PROXY for partial domain matches', {
@@ -264,6 +264,34 @@ function addTests () {
       }
     }, true)
 
+    runTest('NO_PROXY hostnames support wildcards', {
+      env: {
+        HTTP_PROXY: s.url,
+        NO_PROXY: '*.com'
+      }
+    }, false)
+
+    runTest('NO_PROXY hostnames support wildcards 2', {
+      env: {
+        HTTP_PROXY: s.url,
+        NO_PROXY: '*.GOOGLE.COM'
+      }
+    }, false)
+
+    runTest('NO_PROXY hostnames support wildcards 3', {
+      env: {
+        HTTP_PROXY: s.url,
+        NO_PROXY: '*.subdomain.google.com'
+      }
+    }, true)
+
+    runTest('NO_PROXY hostnames support wildcards 4', {
+      env: {
+        HTTP_PROXY: s.url,
+        NO_PROXY: '*'
+      }
+    }, false)
+
     // misc
 
     // this fails if the check 'isMatchedAt > -1' in lib/getProxyFromURI.js is
@@ -276,7 +304,7 @@ function addTests () {
     }, true)
 
     runTest('proxy: null should override HTTP_PROXY', {
-      env: { HTTP_PROXY: s.url },
+      env: {HTTP_PROXY: s.url},
       proxy: null,
       timeout: 500
     }, false)


### PR DESCRIPTION
## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A
## PR Description
RequestJS does not respect the NO_PROXY format https://www.gnu.org/software/emacs/manual/html_node/url/Proxies.html
For example, asterix * as subdomains were totally ignored
This PR makes request handle such cases