### PR TITLE
Adds logger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ The first argument can be either a `url` or an `options` object. The only requir
     - `firstByte`: Duration of HTTP server response (`timings.response` - `timings.connect`)
     - `download`: Duration of HTTP download (`timings.end` - `timings.response`)
     - `total`: Duration entire HTTP round-trip (`timings.end`)
+- `logger` - All requests made from the server will be logget at `info` level, that supports the standard loggin API (like `console` or [Winston](https://github.com/winstonjs/winston))
 
 - `har` - a [HAR 1.2 Request Object](http://www.softwareishard.com/blog/har-12-spec/#request), will be processed from HAR format into options overwriting matching values *(see the [HAR 1.2 section](#support-for-har-12) for details)*
 - `callback` - alternatively pass the request's callback in the options object
@@ -898,9 +899,10 @@ instead, it **returns a wrapper** that has your default settings applied to it.
 
 For example:
 ```js
-//requests using baseRequest() will set the 'x-token' header
+//requests using baseRequest() will set the 'x-token' header and log its requests on console
 const baseRequest = request.defaults({
-  headers: {'x-token': 'my-token'}
+  headers: {'x-token': 'my-token'},
+  logger: console
 })
 
 //requests using specialRequest() will include the 'x-token' header set in

--- a/request.js
+++ b/request.js
@@ -710,6 +710,10 @@ Request.prototype.start = function () {
   // this is usually called on the first write(), end() or on nextTick()
   var self = this
 
+  if (self.logger) {
+    self.timing = true
+  }
+
   if (self.timing) {
     // All timings will be relative to this request's startTime.  In order to do this,
     // we need to capture the wall-clock start time (via Date), immediately followed
@@ -915,6 +919,10 @@ Request.prototype.onRequestResponse = function (response) {
 
       // timings is just for the final fetch
       response.timings = self.timings
+
+      if (self.logger) {
+        self.logger.info(`----> ${response.request.method} ${response.request.href} - ${response.statusCode} - ${response.timings.response.toFixed(2)}ms`)
+      }
 
       // pre-calculate phase timings as well
       response.timingPhases = {

--- a/tests/test-logger.js
+++ b/tests/test-logger.js
@@ -1,0 +1,52 @@
+var fs = require('fs')
+var path = require('path')
+var http = require('http')
+var tape = require('tape')
+var request = require('../')
+var server
+
+tape('before', function (t) {
+  server = http.createServer()
+  server.on('request', function (req, res) {
+    req.pipe(res)
+  })
+  server.listen(0, function () {
+    server.url = 'http://localhost:' + this.address().port
+    t.end()
+  })
+})
+
+tape('request with logger option', function (t) {
+  var fpath = path.join(__dirname, 'unicycle.jpg')
+  var input = fs.createReadStream(fpath, {highWaterMark: 1000})
+  request({
+    uri: server.url,
+    method: 'POST',
+    body: input,
+    encoding: null,
+    logger: console
+  }, function (err, res, body) {
+    t.error(err)
+    t.equal(body.length, fs.statSync(fpath).size)
+    t.end()
+  })
+})
+
+tape('request without logger option', function (t) {
+  var fpath = path.join(__dirname, 'unicycle.jpg')
+  var input = fs.createReadStream(fpath, {highWaterMark: 1000})
+  request({
+    uri: server.url,
+    method: 'POST',
+    body: input,
+    encoding: null
+  }, function (err, res, body) {
+    t.error(err)
+    t.equal(body.length, fs.statSync(fpath).size)
+    t.end()
+  })
+})
+
+tape('after', function (t) {
+  server.close(t.end)
+})


### PR DESCRIPTION
## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]


## PR Description
Adds a `logger` option so that all requests are logged at `info` level. 
It supports the standard logging API (like `console` or Winston).

### How it's done:
- If `logger` option is provided, `self.timings` is set to `true` so it can use `self.logger.info` using a few variables so its output is like below:
`----> POST http://localhost:50240/ - 200 - 22.95ms` (retrieved from test).
- The arrow is to separate the logs that the server did from logs that the server received, so it don't get confusing. (Maybe there is another way to do this? Yeah, of course there is, but that's what I was able to think).

### Reason for this PR
- `options.time` works, but you have to manipulate the timings to log the requests you made.
- I've asked myself "why not to make this a built-in feature of the package?". Seems reasonable to me :smiley:.

