### PR TITLE
Use nyc instead of istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 .idea
 npm-debug.log
 package-lock.json
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-ci && npm run test-browser",
     "test-ci": "taper tests/test-*.js",
-    "test-cov": "istanbul cover tape tests/test-*.js",
+    "test-cov": "nyc tape tests/test-*.js",
     "test-browser": "node tests/browser/start.js",
     "lint": "standard"
   },
@@ -63,13 +63,13 @@
     "codecov": "^3.0.4",
     "coveralls": "^3.0.2",
     "function-bind": "^1.0.2",
-    "istanbul": "^0.4.0",
     "karma": "^3.0.0",
     "karma-browserify": "^5.0.1",
     "karma-cli": "^1.0.0",
     "karma-coverage": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-tap": "^3.0.1",
+    "nyc": "^14.1.1",
     "phantomjs-prebuilt": "^2.1.3",
     "rimraf": "^2.2.8",
     "server-destroy": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-ci && npm run test-browser",
     "test-ci": "taper tests/test-*.js",
-    "test-cov": "nyc tape tests/test-*.js",
+    "test-cov": "nyc --reporter=lcov tape tests/test-*.js",
     "test-browser": "node tests/browser/start.js",
     "lint": "standard"
   },


### PR DESCRIPTION
istanbul package is not longer maintained

## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #3168

## PR Description
- Removed `istanbul` package and replaced it with `nyc` package.
- Modified the test coverage script so it uses the new package.
- Added the coverage output folder to the list of files ignored by git.
