### PR TITLE
AWS region option to use sigv4 not only with us-east-1

### DIFF
--- a/request.js
+++ b/request.js
@@ -1362,6 +1362,9 @@ Request.prototype.aws = function (opts, now) {
     if (opts.service) {
       options.service = opts.service
     }
+    if (opts.region) {
+      options.region = opts.region
+    }
     var signRes = aws4.sign(options, {
       accessKeyId: opts.key,
       secretAccessKey: opts.secret,


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
In order to do sigv4 calls to AWS we need to be able to set the region, as not everyone is operating in `us-east-1` region, which is the default value here: https://github.com/mhart/aws4/blob/master/aws4.js#L38. This PR should provide capability to forward this parameter to aws4 via option as already done with e.g. service name.