### PR TITLE
update form-data to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "combined-stream": "~1.0.6",
     "extend": "~3.0.2",
     "forever-agent": "~0.6.1",
-    "form-data": "~2.3.2",
+    "form-data": "~2.5.0",
     "har-validator": "~5.1.3",
     "http-signature": "~1.2.0",
     "is-typedarray": "~1.0.0",


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
```
total ......................... 1587/1587

ok
```

- [NA] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [NA] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
`form-data` 2.4.0 adds the `getBuffer()` function which is very helpful to `request-debug`
Ref: https://github.com/request/request-debug/pull/26

Going to form-data 2.5.0 should also be fine because the changes are mostly non-functional, like adding TypeScript typings.
