### PR TITLE
Handle servers that send empty value for realm.

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -110,11 +110,11 @@ Auth.prototype.digest = function (method, path, authHeader) {
 
   authHeader = []
   for (var k in authValues) {
-    if (authValues[k]) {
+    if (authValues[k] || k === 'realm') {
       if (k === 'qop' || k === 'nc' || k === 'algorithm') {
         authHeader.push(k + '=' + authValues[k])
       } else {
-        authHeader.push(k + '="' + authValues[k] + '"')
+        authHeader.push(k + '="' + (authValues[k] || '') + '"')
       }
     }
   }

--- a/tests/test-digest-auth.js
+++ b/tests/test-digest-auth.js
@@ -18,9 +18,9 @@ function md5 (str) {
 }
 
 var digestServer = http.createServer(function (req, res) {
-  var ok,
-    testHeader,
-    realm = 'Private'
+  var ok
+  var testHeader
+  var realm = 'Private'
 
   if (req.url === '/test/' || req.url === '/test/no-realm') {
     if (req.url === '/test/no-realm') {


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description
I'm dealing with a public API where the server is using Digest Auth, but is not sending any value for `realm` in direct violation with [RFC 7616](https://tools.ietf.org/html/rfc7616). 

I have added a minimal change to not break on missing values for `realm`.

_I realize this is not a standard case and that as such you might not really want to add this to the project. No hard feelings! :)_
