### PR TITLE
Fix typo 'securityOptions' => 'secureOptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ const options = {
         // Or use `pfx` property replacing `cert` and `key` when using private key, certificate and CA certs in PFX or PKCS12 format:
         // pfx: fs.readFileSync(pfxFilePath),
         passphrase: 'password',
-        securityOptions: 'SSL_OP_NO_SSLv3'
+        secureOptions: 'SSL_OP_NO_SSLv3'
     }
 };
 


### PR DESCRIPTION
## PR Checklist:
(No code was changed; this was a minor typo in the README.)

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
I think this is a typo (https://github.com/nodejs/node-v0.x-archive/issues/8608 and elsewhere in the request codebase). Passing in as 'securityOptions' would probably be a no-op, at least from first glance.
