### PR TITLE
Mitigate prototype pollution when filtering options

### DIFF
--- a/lib/filterForNonReserved.js
+++ b/lib/filterForNonReserved.js
@@ -1,0 +1,15 @@
+function filterForNonReserved (reserved, options) {
+  // Filter out properties that are not reserved.
+  // Reserved values are passed in at call site.
+
+  var object = Object.create(null)
+  for (var i in options) {
+    var notReserved = (reserved.indexOf(i) === -1)
+    if (notReserved) {
+      object[i] = options[i]
+    }
+  }
+  return object
+}
+
+module.exports = filterForNonReserved

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -56,6 +56,21 @@ function version () {
   }
 }
 
+function filterForNonReserved (reserved, options) {
+  // Filter out properties that are not reserved.
+  // Reserved values are passed in at call site.
+
+  var object = Object.create(null)
+  for (var i in options) {
+    var notReserved = (reserved.indexOf(i) === -1)
+    if (notReserved) {
+      object[i] = options[i]
+    }
+  }
+  return object
+}
+
+exports.filterForNonReserved = filterForNonReserved
 exports.paramsHaveRequestBody = paramsHaveRequestBody
 exports.safeStringify = safeStringify
 exports.md5 = md5

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -56,21 +56,6 @@ function version () {
   }
 }
 
-function filterForNonReserved (reserved, options) {
-  // Filter out properties that are not reserved.
-  // Reserved values are passed in at call site.
-
-  var object = Object.create(null)
-  for (var i in options) {
-    var notReserved = (reserved.indexOf(i) === -1)
-    if (notReserved) {
-      object[i] = options[i]
-    }
-  }
-  return object
-}
-
-exports.filterForNonReserved = filterForNonReserved
 exports.paramsHaveRequestBody = paramsHaveRequestBody
 exports.safeStringify = safeStringify
 exports.md5 = md5

--- a/request.js
+++ b/request.js
@@ -18,6 +18,7 @@ var isstream = require('isstream')
 var isTypedArray = require('is-typedarray').strict
 var helpers = require('./lib/helpers')
 var cookies = require('./lib/cookies')
+var filterForNonReserved = require('./lib/filterForNonReserved')
 var getProxyFromURI = require('./lib/getProxyFromURI')
 var Querystring = require('./lib/querystring').Querystring
 var Har = require('./lib/har').Har
@@ -30,7 +31,6 @@ var Tunnel = require('./lib/tunnel').Tunnel
 var now = require('performance-now')
 var Buffer = require('safe-buffer').Buffer
 
-var filterForNonReserved = helpers.filterForNonReserved
 var safeStringify = helpers.safeStringify
 var isReadStream = helpers.isReadStream
 var toBase64 = helpers.toBase64

--- a/request.js
+++ b/request.js
@@ -30,6 +30,7 @@ var Tunnel = require('./lib/tunnel').Tunnel
 var now = require('performance-now')
 var Buffer = require('safe-buffer').Buffer
 
+var filterForNonReserved = helpers.filterForNonReserved
 var safeStringify = helpers.safeStringify
 var isReadStream = helpers.isReadStream
 var toBase64 = helpers.toBase64
@@ -39,20 +40,6 @@ var version = helpers.version
 var globalCookieJar = cookies.jar()
 
 var globalPool = {}
-
-function filterForNonReserved (reserved, options) {
-  // Filter out properties that are not reserved.
-  // Reserved values are passed in at call site.
-
-  var object = {}
-  for (var i in options) {
-    var notReserved = (reserved.indexOf(i) === -1)
-    if (notReserved) {
-      object[i] = options[i]
-    }
-  }
-  return object
-}
 
 function filterOutReservedFunctions (reserved, options) {
   // Filter out properties that are functions and are reserved.

--- a/tests/test-filterForNonReserved.js
+++ b/tests/test-filterForNonReserved.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var assert = require('assert')
-var filterForNonReserved = require('../lib/helpers').filterForNonReserved
+var filterForNonReserved = require('../lib/filterForNonReserved')
 var tape = require('tape')
 
 tape('setup', function (t) {

--- a/tests/test-filterForNonReserved.js
+++ b/tests/test-filterForNonReserved.js
@@ -1,0 +1,27 @@
+'use strict'
+
+var assert = require('assert')
+var filterForNonReserved = require('../lib/helpers').filterForNonReserved
+var tape = require('tape')
+
+tape('setup', function (t) {
+  var obj = {}
+  obj.__proto__.hostname = 'evil.com' // eslint-disable-line no-proto
+  t.end()
+})
+
+tape('do not create a polluted object when filtering reserved options', function (t) {
+  var options = Object.create(null)
+  assert.equal(options.hostname, undefined)
+
+  var filtered = filterForNonReserved([], options)
+  assert.equal(filtered.hostname, undefined)
+
+  t.end()
+})
+
+tape('cleanup', function (t) {
+  var obj = {}
+  obj.__proto__.hostname = undefined // eslint-disable-line no-proto
+  t.end()
+})


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing. ( `test-localAddress.js` fails in my branch, but also on `master` so I assume something with my env differs from the ci-build where it may pass )
- [x] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description
In an ideal world, prototype pollution wouldn't be an issue and we could prevent vectors that ourselves or our colleagues may open.

Unfortunately, this is impossible to guarantee.  While we can do our best to mitigate the risk of prototype pollution by passing a clean `options` object to `request`, the method `filterForNonReserved` creates a new object with the possibly polluted `object` prototype rather than either the clean object we have provided or filtering the object in place.

This PR is very subtle - the only change is from

```js
var object = {}
```

to

```js
var object = Object.create(null)
```

Though for those of us that pass in a clean object, we won't get a polluted object out.  If someone is using a polluted prototype intentionally, those options will be passed since we're not filtering the `for ... in` loop with `Object.hasOwnProperty`.

Practically speaking, if our node process's Object's prototype has a polluted value for `host` we will have `request` make requests to potentially malicious hosts.

Current attack vector:
```js
// Contrived example, but this could come from very sneaky places
var obj = {}
obj.__proto__.hostname = 'yahoo.com'

// Create a clean object, not affected by previous prototype pollution
var options = Object.create(null);
options.uri = 'http://localhost'
console.log(options.hostname) // undefined

// This will _still_ hit our polluted hostname!
request(options, (err, res, body) => console.log(body))
```