### PR TITLE
Bump http-signature to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "forever-agent": "~0.6.1",
     "form-data": "~2.3.2",
     "har-validator": "~5.1.3",
-    "http-signature": "~1.2.0",
+    "http-signature": "~1.3.1",
     "is-typedarray": "~1.0.0",
     "isstream": "~0.1.2",
     "json-stringify-safe": "~5.0.1",


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description
A new version of [Http Signature](https://github.com/joyent/node-http-signature) has been released to support  `Signature` headers in addition to `Authorization` headers ([See issue](https://github.com/joyent/node-http-signature/issues/77)).


