### PR TITLE
keep track of previously excluded proxy headers after redirect

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -158,9 +158,16 @@ Tunnel.prototype.setup = function (options) {
   // Setup Proxy Headers and Proxy Headers Host
   // Only send the Proxy White Listed Header names
   var proxyHeaders = constructProxyHeaderWhiteList(request.headers, proxyHeaderWhiteList)
+  // Append previously excluded proxy exclusive headers
+  proxyHeaders = Object.assign(request.exclusiveHeaders || {}, proxyHeaders)
+
   proxyHeaders.host = constructProxyHost(request.uri)
 
-  proxyHeaderExclusiveList.forEach(request.removeHeader, request)
+  request.exclusiveHeaders = {}
+  proxyHeaderExclusiveList.forEach(function (exclusiveHeader) {
+    request.exclusiveHeaders[exclusiveHeader] = request.headers[exclusiveHeader]
+    request.removeHeader(exclusiveHeader)
+  }, request)
 
   // Set Agent from Tunnel Data
   var tunnelFn = getTunnelFn(request)


### PR DESCRIPTION
## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
All proxy exclusive headers are excluded after a request is made, but if a redirect occurs, the proxy still expects to receive headers like proxy-authorization or custom ones.