### PR TITLE
keep track of previously excluded proxy headers

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -158,9 +158,18 @@ Tunnel.prototype.setup = function (options) {
   // Setup Proxy Headers and Proxy Headers Host
   // Only send the Proxy White Listed Header names
   var proxyHeaders = constructProxyHeaderWhiteList(request.headers, proxyHeaderWhiteList)
+  // Append previously excluded proxy exclusive headers
+  proxyHeaders = Object.assign(request.exclusiveHeaders || {}, proxyHeaders)
+
   proxyHeaders.host = constructProxyHost(request.uri)
 
-  proxyHeaderExclusiveList.forEach(request.removeHeader, request)
+  request.exclusiveHeaders = {}
+  proxyHeaderExclusiveList.forEach(function (exclusiveHeader) {
+    if (request.headers[exclusiveHeader] !== undefined) {
+      request.exclusiveHeaders[exclusiveHeader] = request.headers[exclusiveHeader]
+    }
+    request.removeHeader(exclusiveHeader)
+  }, request)
 
   // Set Agent from Tunnel Data
   var tunnelFn = getTunnelFn(request)

--- a/tests/test-proxy-connect.js
+++ b/tests/test-proxy-connect.js
@@ -2,33 +2,56 @@
 
 var request = require('../index')
 var tape = require('tape')
-
+var proxySocket
+var proxyData = []
 var called = false
-var proxiedHost = 'google.com'
-var data = ''
+var redirect = false
 
-var s = require('net').createServer(function (sock) {
-  called = true
-  sock.once('data', function (c) {
-    data += c
-
-    sock.write('HTTP/1.1 200 OK\r\n\r\n')
-
-    sock.once('data', function (c) {
-      data += c
-
-      sock.write('HTTP/1.1 200 OK\r\n')
-      sock.write('content-type: text/plain\r\n')
-      sock.write('content-length: 5\r\n')
-      sock.write('\r\n')
-      sock.end('derp\n')
+var proxyServer = require('net').createServer(function (sock) {
+  proxySocket = sock
+  if (redirect) {
+    redirect = false
+    return waitForData(['HTTP/1.1 200 OK\r\n\r\n'], function (data) {
+      proxyData.push(data)
+      waitForData([
+        'HTTP/1.1 301 Moved Permanently\r\n',
+        'Location: http://google.com/redirect\r\n',
+        'content-length: 59\r\n',
+        '\r\n'
+      ], function (data) {
+        proxyData.push(data)
+        proxySocket.end('derp\n')
+      })
+    })
+  }
+  waitForData(['HTTP/1.1 200 OK\r\n\r\n'], function (data) {
+    called = true
+    proxyData.push(data)
+    waitForData([
+      'HTTP/1.1 200 OK\r\n',
+      'content-type: text/plain\r\n',
+      'content-length: 5\r\n',
+      '\r\n'
+    ], function (data) {
+      proxyData.push(data)
+      proxySocket.end('derp\n')
     })
   })
 })
 
+function waitForData (reply, callback) {
+  reply = reply || []
+  proxySocket.once('data', function (buffer) {
+    reply.forEach(function (r) {
+      proxySocket.write(r)
+    })
+    callback(buffer.toString())
+  })
+}
+
 tape('setup', function (t) {
-  s.listen(0, function () {
-    s.url = 'http://localhost:' + this.address().port
+  proxyServer.listen(0, function () {
+    proxyServer.url = 'http://localhost:' + this.address().port
     t.end()
   })
 })
@@ -36,8 +59,8 @@ tape('setup', function (t) {
 tape('proxy', function (t) {
   request({
     tunnel: true,
-    url: 'http://' + proxiedHost,
-    proxy: s.url,
+    url: 'http://google.com',
+    proxy: proxyServer.url,
     headers: {
       'Proxy-Authorization': 'Basic dXNlcjpwYXNz',
       'authorization': 'Token deadbeef',
@@ -46,7 +69,7 @@ tape('proxy', function (t) {
       'accept': 'yo',
       'user-agent': 'just another foobar'
     },
-    proxyHeaderExclusiveList: ['Dont-send-to-dest']
+    proxyHeaderExclusiveList: ['dont-send-to-dest']
   }, function (err, res, body) {
     t.equal(err, null)
     t.equal(res.statusCode, 200)
@@ -67,14 +90,45 @@ tape('proxy', function (t) {
       'user-agent: just another foobar',
       'host: google.com'
     ].join('\r\n'))
-    t.equal(true, re.test(data))
+    t.equal(true, re.test(proxyData.join('')))
+    t.equal(called, true, 'the request must be made to the proxy server')
+    t.end()
+  })
+})
+
+tape('proxy with redirect', function (t) {
+  proxyData = []
+  redirect = true
+  called = false
+  request({
+    tunnel: true,
+    url: 'http://google.com',
+    proxy: proxyServer.url,
+    headers: {
+      'Proxy-Authorization': 'Basic dXNlcjpwYXNz',
+      'authorization': 'Token deadbeef',
+      'dont-send-to-proxy': 'ok',
+      'dont-send-to-dest': 'ok',
+      'accept': 'yo',
+      'user-agent': 'just another foobar'
+    },
+    proxyHeaderExclusiveList: ['dont-send-to-dest']
+  }, function (err, res, body) {
+    t.equal(err, null)
+    t.equal(res.statusCode, 200)
+    t.equal(body, 'derp\n')
+    t.equal(4, proxyData.length)
+    t.equal(true, proxyData[0].includes('dont-send-to-dest'), 'exclusive headers should be sent to proxy server')
+    t.equal(false, proxyData[1].includes('dont-send-to-dest'), 'destination should\'t receive exclusive headers')
+    t.equal(true, proxyData[2].includes('dont-send-to-dest'), 'exclusive headers should be sent to proxy server')
+    t.equal(false, proxyData[3].includes('dont-send-to-dest'), 'destination should\'t receive exclusive headers')
     t.equal(called, true, 'the request must be made to the proxy server')
     t.end()
   })
 })
 
 tape('cleanup', function (t) {
-  s.close(function () {
+  proxyServer.close(function () {
     t.end()
   })
 })


### PR DESCRIPTION
## PR Checklist:
- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/request/request/issues/3246


## PR Description
All proxy exclusive headers are excluded after a request is made, but if a redirect occurs, the proxy still expects to receive headers like `proxy-authorization` or custom ones.

### Simplest Example to Reproduce

```js
request({
  method: 'GET',
  url: 'https://httpbin.org/relative-redirect/1',
  headers: {
      'Exclusive-Header': '123',
  }.
  proxy: 'http://localhost:8080',
  proxyHeaderExclusiveList: [
      "Exclusive-Header"
  ],
},
```