### PR TITLE
self.encoding ignore both undefined and null

### DIFF
--- a/request.js
+++ b/request.js
@@ -1124,7 +1124,8 @@ Request.prototype.readResponseBody = function (response) {
     if (bufferLength) {
       debug('has body', self.uri.href, bufferLength)
       response.body = Buffer.concat(buffers, bufferLength)
-      if (self.encoding !== null) {
+      //This can ignore both undefined and null  
+      if (self.encoding != null) {
         response.body = response.body.toString(self.encoding)
       }
       // `buffer` is defined in the parent scope and used in a closure it exists for the life of the Request.


### PR DESCRIPTION
when using with pbjs , original value of self.encoding is undefined,we wish to keep response.body Buffer style

## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
when using with pbjs , original value of self.encoding is undefined,we wish to keep response.body Buffer style
