### PR TITLE
Always use URI host in the Host header (fix #3274)

### DIFF
--- a/request.js
+++ b/request.js
@@ -288,13 +288,6 @@ Request.prototype.init = function (options) {
   if (!self.hasHeader('host')) {
     var hostHeaderName = self.originalHostHeaderName || 'host'
     self.setHeader(hostHeaderName, self.uri.host)
-    // Drop :port suffix from Host header if known protocol.
-    if (self.uri.port) {
-      if ((self.uri.port === '80' && self.uri.protocol === 'http:') ||
-          (self.uri.port === '443' && self.uri.protocol === 'https:')) {
-        self.setHeader(hostHeaderName, self.uri.hostname)
-      }
-    }
     self.setHost = true
   }
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/request/request/issues/3274


## PR Description
This PR ensure the Host header is always set to the URI host
