### PR TITLE
(fix) update documentation for cert/key usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,12 +645,12 @@ const fs = require('fs')
 
 const options = {
     url: 'https://api.some-server.com/',
+    cert: fs.readFileSync(certFile),
+    key: fs.readFileSync(keyFile),
+    // Or use `pfx` property replacing `cert` and `key` when using private key, certificate and CA certs in PFX or PKCS12 format:
+    // pfx: fs.readFileSync(pfxFilePath),
+    passphrase: 'password',
     agentOptions: {
-        cert: fs.readFileSync(certFile),
-        key: fs.readFileSync(keyFile),
-        // Or use `pfx` property replacing `cert` and `key` when using private key, certificate and CA certs in PFX or PKCS12 format:
-        // pfx: fs.readFileSync(pfxFilePath),
-        passphrase: 'password',
         securityOptions: 'SSL_OP_NO_SSLv3'
     }
 };
@@ -671,15 +671,13 @@ request.get({
 
 It is possible to accept other certificates than those signed by generally allowed Certificate Authorities (CAs).
 This can be useful, for example,  when using self-signed certificates.
-To require a different root certificate, you can specify the signing CA by adding the contents of the CA's certificate file to the `agentOptions`.
+To require a different root certificate, you can specify the signing CA by adding the contents of the CA's certificate file to the `options`.
 The certificate the domain presents must be signed by the root certificate specified:
 
 ```js
 request.get({
     url: 'https://api.some-server.com/',
-    agentOptions: {
-        ca: fs.readFileSync('ca.cert.pem')
-    }
+    ca: fs.readFileSync('ca.cert.pem')
 });
 ```
 
@@ -693,12 +691,10 @@ you can configure your request as follows:
 ```js
 request.get({
     url: 'https://api.some-server.com/',
-    agentOptions: {
-        ca: [
+    ca: [
           fs.readFileSync('Corp Issuing Server.pem'),
           fs.readFileSync('Corp Root CA.pem')
         ]
-    }
 });
 ```
 


### PR DESCRIPTION
## PR Checklist:
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
       <!-- Request is a complex project, there are VERY FEW exceptions
               where a new test is not required for new behavior. -->
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change to request,
               please create an issue to discuss those changes and gather
               feedback BEFORE submitting your PR. -->


## PR Description
Follow up to https://github.com/request/request/pull/1585 and https://github.com/request/request/pull/1289 for fixing documentation.

As new relic user their scripted api documentation brought me to this library as I was required to implement some two-way ssl monitors.  Using the example with `agentOptions` I wasted some good time trying to get it to work until I found these issues.

I did not find usage for `agentOptions` useful except for protocol/ciphers specifications.
