### PR TITLE
Adds link directly to issue listing alternatives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 As of Feb 11th 2020, request is fully deprecated. No new changes are expected to land. In fact, none have landed for some time.
 
-For more information about why request is deprecated and possible alternatives refer to
-[this issue](https://github.com/request/request/issues/3142).
+For more information about why request is deprecated see [this issue](https://github.com/request/request/issues/3142) and possible alternatives refer to [this issue](https://github.com/request/request/issues/3143).
 
 # Request - Simplified HTTP client
 


### PR DESCRIPTION
Title says it all. Updates the `README.md` with a link to both the issue describing why it's been deprecated and also linking directly to the issue that lists alternatives to help reduce confusion and reduce the comments on #3142 to the effect of "where is the list of alternatives" (I totally didn't do this and am not guilty; stop looking at me like that)