### PR TITLE
Update http-signature to major version 1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "forever-agent": "~0.6.1",
     "form-data": "~2.3.2",
     "har-validator": "~5.1.3",
-    "http-signature": "~1.2.0",
+    "http-signature": "~1.3.6",
     "is-typedarray": "~1.0.0",
     "isstream": "~0.1.2",
     "json-stringify-safe": "~5.0.1",


### PR DESCRIPTION
All versions of http-signature major version 1.2 eventually rely on an outdated and proven flawed version of json-schema. Major version 1.3 fixes this.
